### PR TITLE
fix(ci): pass GITHUB_TOKEN to Hypatia scan step

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -55,6 +55,11 @@ jobs:
 
       - name: Run Hypatia scan
         id: scan
+        env:
+          # Hypatia uses Dependabot alerts as one of its signal sources.
+          # Without GITHUB_TOKEN it warns and exits 1. The default GITHUB_TOKEN
+          # has the security_events:read scope needed to query alerts.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Scanning repository: ${{ github.repository }}"
 


### PR DESCRIPTION
Round 4 of corrective work, single commit.

After the HYPATIA_DIR fix from PR #44 got the scanner past the directory error, the actual scan step is now running and exiting 1 because the scanner queries Dependabot alerts but GITHUB_TOKEN isn't passed to that step. Added `env: GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}` to the scan step.

Workflow's existing `permissions: read-all` already covers `security_events:read` so no additional permissions block is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)