### PR TITLE
docs(AI.a2ml): 4 patterns + 3 directives from idaptik Wave 3 (closes #45 #46 #47 #48 #49 #50 #52)

### DIFF
--- a/docs/guides/frontier-programming-practices/AI.a2ml
+++ b/docs/guides/frontier-programming-practices/AI.a2ml
@@ -138,6 +138,34 @@
       (composition "phantom + effect rows")
       (purpose "Mark values or functions as pure or impure in the type system for optimisation or testing.")
       (sketch "fn pure_compute(x: Int): Int  // no effect row = pure\nfn io_op(): String / {IO}  // effect row declares IO"))
+
+    (pattern
+      (name "per-element-error-extraction")
+      (composition "polymorphic-per-element + Validation")
+      (purpose "Accumulate errors from heterogeneously-typed Validation values without forcing them into a uniform list.")
+      (anti-pattern "List (Validation E a) when each element has a different `a` — non-starter type-theoretically; cannot unify a single `a` across heterogeneous components.")
+      (sketch "let allErrs = errsOf v1 ++ errsOf v2 ++ errsOf v3\n     where errsOf : Validation E a -> List E"))
+
+    (pattern
+      (name "fuel-based-total-recursion")
+      (composition "Nat parameter + structural decrease")
+      (purpose "Make recursive parsers / interpreters / search algorithms provably total without sized types.")
+      (anti-pattern "Depth tracking with `if depth > N then bail` — runtime guarantee, not provable. Totality checker cannot see incrementing parameters as well-founded.")
+      (sketch "fn parse(fuel: Nat, input: List Char) { match fuel { Z => Err(\"depth\"); S(f) => recurse(f, ...) } }"))
+
+    (pattern
+      (name "validation-chain-over-tuple-match")
+      (composition "Validation applicative + <*>")
+      (purpose "Accumulate errors across N independent extractions without N-tuple matches.")
+      (anti-pattern "case (a, b, c, d, e, f, g) of (Ok, Ok, Ok, ...) => ... — N>=5 tuple matches blow type inference / ambiguity-resolution budgets.")
+      (sketch "MkRecord <$> a <*> b <*> c <*> d <*> e <*> f <*> g"))
+
+    (pattern
+      (name "status-sum-vs-string-enum")
+      (composition "sum types")
+      (purpose "Distinguish status / kind values at compile time. Replaces stringly-typed dispatch (\"compromised\" / \"clean\" / etc.).")
+      (anti-pattern "dispatch(deviceId, \"compromised\") — typo \"compromied\" silently mis-matches at runtime.")
+      (sketch "type DeviceStatus = Compromised | Clean | Suspect | Unknown\nfn dispatch(d: DeviceId, s: DeviceStatus)"))
   )
 
   (agent-behavior
@@ -157,6 +185,12 @@
       (rule "Work that belongs in the Typed WASM project goes to the Typed WASM project. Never add it to AffineScript as a shortcut."))
     (honesty-in-documentation
       (rule "STATE.a2ml, README, and related docs must reflect what the code actually enforces, not what it aspires to. A 'dune build passing' is not a behavioural test and does not count as 'feature complete'."))
+    (stdlib-floor
+      (rule "Validation[E,A], Result[E,A], Option[A], and Either[E,A] are stdlib floor. Reject any project that re-implements them. Pointing migrators at canonical types prevents the heterogeneous-list-as-homogeneous antipattern."))
+    (eta-style
+      (rule "When a function has named pi-binders ((name : Type) -> ...), prefer eta-expanded definitions over point-free. Point-free is a parser-cascade trigger when the eta-rewrite's argument name disagrees with the declared signature's name."))
+    (no-side-effect-imports
+      (rule "AffineScript modules do not run code at load time. Migrating ReScript/JS code that uses `let _ = X.foo` for module-load side effects must be rewritten to call an explicit registration function. There is no implicit module-load-time side effect to hook in wasm."))
   )
 
   (relationship-with-typed-wasm-project


### PR DESCRIPTION
## Summary

Adds 4 new idiomatic patterns and 3 new directives to `AI.a2ml` based on the IDApTIK Wave 3 pilot exercise. Each entry closes one or more open issues.

## What's added

**Idiomatic patterns** (after `purity-tagging`):

| Pattern | Closes | Source observation |
|---|---|---|
| per-element-error-extraction | #46 | ProvenBridge.idr had 4 sites passing `[e1,e2,e3,e4] : List (Extracted a)` where each `a` was different. Type-theoretical non-starter; the polymorphic-per-element helper is the fix. |
| fuel-based-total-recursion | #47 | ProvenBridge's mutual JSON parser used incrementing `depth: Nat`; totality checker can't see that as well-founded. Fuel (decreasing Nat) is the canonical answer. |
| validation-chain-over-tuple-match | #49 | parseLevelJson's 7-tuple `case` match blew `%ambiguity_depth` even at 12. Splitting + Validation chain is the right shape. |
| status-sum-vs-string-enum | #52 | `dispatch(deviceId, "compromised")` typos silently mis-match. Sum type catches at compile time. |

**Directives** (added to `agent-behavior`):

| Directive | Closes | Why |
|---|---|---|
| stdlib-floor | #45 | Validation/Result/Option/Either as canonical stdlib types; reject re-implementations. |
| eta-style | #48 | Eta-expand named-pi-binder defs; point-free is a parser cascade trigger. |
| no-side-effect-imports | #50 | `let _ = X.foo` is a JS module-loading hack; rewrite to explicit registration. |

## Cross-reference

Source observations + concrete patch evidence: idaptik commit hyperpolymath/idaptik@98f110ce.
Full lesson catalogue: idaptik/migration/main/LESSONS.md.
Pilot translations: idaptik/migration/main/Main.affine, /shared/GameEvent.affine.

## Test plan

- [x] AI.a2ml's existing s-expression structure preserved
- [ ] Any tooling that lints AI.a2ml (if it exists) should still pass

This is a pure markdown / s-expr documentation patch; no code changes.