### PR TITLE
fix(build): track bin/dune (gitignore negation was a no-op)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,12 @@ __pycache__/
 # Ada/SPARK
 *.ali
 /obj/
-/bin/
+# `/bin/` excludes the directory itself, which makes git unable to re-include
+# files inside it (negations can't re-include children of an excluded dir).
+# `/bin/*` excludes the *contents* so `!bin/*.ml` and `!bin/dune` actually
+# re-include their targets. The previous `/bin/` form silently dropped
+# bin/dune from origin and broke CI's executable build.
+/bin/*
 !bin/*.ml
 !bin/dune
 

--- a/bin/dune
+++ b/bin/dune
@@ -1,0 +1,7 @@
+; SPDX-License-Identifier: MIT OR AGPL-3.0-or-later
+
+(executable
+ (name main)
+ (public_name affinescript)
+ (package affinescript)
+ (libraries affinescript cmdliner fmt fmt.tty))


### PR DESCRIPTION
Round 7. CI's codegen-tests step fails with `Program 'affinescript' not found!` because origin's bin/ has no dune file (the executable definition).

Root cause: `.gitignore` had `/bin/` (excludes dir) followed by `!bin/dune` — but git can't re-include a file whose parent directory is excluded. The negation was a silent no-op.

Fix: `/bin/` → `/bin/*` and force-add bin/dune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)