### PR TITLE
fix(test): remove trailing semicolons in test_opt_if_fold if-branches

### DIFF
--- a/tests/codegen/test_opt_if_fold.affine
+++ b/tests/codegen/test_opt_if_fold.affine
@@ -1,7 +1,11 @@
 // Test if-expression constant folding
 
 fn main() -> Int {
-  let x = if true { 42; } else { 0; };   // Should fold to 42
-  let y = if false { 99; } else { 10; }; // Should fold to 10
+  // No trailing semicolons inside the if-branches: a trailing `;` makes
+  // the branch return Unit, so `let x = if ...` would fail with
+  // "Unification error: (Unify.TypeMismatch (Unit, Int))". The bare
+  // expression form returns Int.
+  let x = if true { 42 } else { 0 };   // Should fold to 42
+  let y = if false { 99 } else { 10 }; // Should fold to 10
   return x + y;  // 42 + 10 = 52
 }


### PR DESCRIPTION
Round 8. The codegen test `test_opt_if_fold.affine` had `if true { 42; } else { 0; }` — trailing `;` made the branches Unit-typed, conflicting with the `let x = if ...` Int target. Removed the semicolons; added a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)