### PR TITLE
ci(antipattern): allowlist legit TS bridge/adapter paths

### DIFF
--- a/.github/workflows/rsr-antipattern.yml
+++ b/.github/workflows/rsr-antipattern.yml
@@ -26,34 +26,29 @@ jobs:
 
       - name: Check for TypeScript
         run: |
-          # Exclusions, in order of specificity. Each is "essential glue" —
-          # the platform requires TypeScript and a ReScript replacement is
-          # not viable.
-          #
-          # - bindings/deno/ : Deno FFI files using Deno.dlopen.
-          # - *.d.ts         : TypeScript declarations for ReScript FFI.
-          # - affinescript-deno-test/ : Deno-native test runner (Deno is
-          #   TS-native; the test driver imports Deno.test which has no
-          #   ReScript binding).
-          # - editors/vscode/ : VS Code extension. The extension API is
-          #   exclusively TypeScript; no ReScript path exists.
-          # - faces/         : vendored snapshots of upstream face
-          #   implementations; the antipattern policy applies to upstream,
-          #   not to a vendored copy in this repo.
+          # Allowlist (TS legitimate as a bridge/adapter to a non-ReScript ecosystem):
+          #   bindings/      - language bindings (Deno/TS/AssemblyScript FFI to ReScript core)
+          #   *.d.ts         - TypeScript type declarations for ReScript FFI
+          #   tests/, test/  - Deno test runners verifying ReScript output
+          #   scripts/       - Deno build scripts (bundle, dev-server, etc.)
+          #   mcp-adapter/   - MCP server adapters (MCP protocol is Deno/TS-typed by spec)
+          #   vscode/        - VSCode extensions (TS is the ecosystem default)
           TS_FILES=$(find . \( -name "*.ts" -o -name "*.tsx" \) \
             | grep -v node_modules \
-            | grep -v 'bindings/deno' \
+            | grep -v '/bindings/' \
             | grep -v '\.d\.ts$' \
-            | grep -v '^\./affinescript-deno-test/' \
-            | grep -v '^\./editors/vscode/' \
-            | grep -v '^\./faces/' \
+            | grep -v '/tests/' \
+            | grep -v '/test/' \
+            | grep -v '/scripts/' \
+            | grep -v '/mcp-adapter/' \
+            | grep -v '/vscode/' \
             || true)
           if [ -n "$TS_FILES" ]; then
             echo "❌ TypeScript files detected - use ReScript instead"
             echo "$TS_FILES"
             exit 1
           fi
-          echo "✅ No TypeScript files (essential-glue exclusions applied)"
+          echo "✅ No TypeScript files outside allowlisted bridge/adapter paths"
 
       - name: Check for Go
         run: |


### PR DESCRIPTION
Same fleet-wide patch as stapeln#24 / rsr-template-repo#30. Broadens TS exclusion list (bindings/, tests/, test/, scripts/, mcp-adapter/, vscode/).