### PR TITLE
docs: clarify codegen environment rules for top-level const and fn bindings

### DIFF
--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -25,7 +25,7 @@ row_var       = ".." lower_ident
 ### 1.2 Keywords
 
 ```
-fn let const mut own ref type struct enum trait impl effect handle
+fn let const extern mut own ref type struct enum trait impl effect handle
 resume handler match if else while for return break continue in
 true false where total module use pub as unsafe assume transmute
 forget Nat Int Bool Float String Type Row
@@ -68,7 +68,7 @@ Special:     \ (row restriction)
 ```ebnf
 program     = [module_decl] {import_decl} {top_level}
 top_level   = fn_decl | type_decl | trait_decl | impl_block | effect_decl
-            | const_decl
+            | const_decl | extern_fn_decl | extern_type_decl
 ```
 
 ### 2.2 Type Declarations
@@ -210,6 +210,28 @@ Both function names and const names are registered in the same codegen name
 environment so that later top-level declarations may refer to either kind of
 binding by name. See §8 (*Codegen Module Environment*) for the encoding and
 the current single-pass population order.
+
+### 2.10 Extern Declarations
+
+```ebnf
+extern_fn_decl   = [visibility] "extern" "fn" LOWER_IDENT
+                   [type_params] "(" [param_list] ")"
+                   ["->" type_expr] ["/" effects] ";"
+extern_type_decl = [visibility] "extern" "type" UPPER_IDENT
+                   [type_params] ";"
+```
+
+`extern fn` declares a function whose implementation is supplied by the host
+environment at link time. The linear-memory WebAssembly backend lowers each
+`extern fn` to an `(import "env" "<name>" (func …))` entry; the import slot
+is registered in the codegen name environment so call sites resolve through
+`call k` exactly as for locally-defined functions (see §8).
+
+`extern type` declares an opaque, host-provided type. It carries no runtime
+representation and generates no Wasm artifact; the typechecker treats the
+name as a nominal opaque type whose internal structure is unknown.
+
+Both forms are terminated by `;` and carry no body.
 
 ## 3. Type System
 
@@ -569,11 +591,18 @@ single integer per name keeps the lookup uniform across both kinds of binding.
 
 **Population.** Top-level declarations are visited in source order by
 `gen_decl`, which is folded over `prog.prog_decls` from `generate_module`.
-The two relevant cases are:
+The relevant cases are:
 
-- `TopFn fd` — registers `(fd.fd_name.name, func_idx)` in `func_indices`
-  *before* generating the function body, so the body may recursively refer
-  to its own name.
+- `TopFn fd` with `fd.fd_body <> FnExtern` — picks the next Wasm function
+  index (`import_func_count ctx + List.length ctx.funcs`), registers
+  `(fd.fd_name.name, func_idx)` in `func_indices` *before* generating the
+  body so the body may recursively refer to its own name, then appends the
+  emitted function to `ctx.funcs`.
+- `TopFn fd` with `fd.fd_body = FnExtern` — emits a Wasm import (module
+  `"env"`, name `fd.fd_name.name`) and registers
+  `(fd.fd_name.name, import_func_idx)` in `func_indices`, where
+  `import_func_idx` is the number of imports before adding this one. No
+  function body is generated. See §8.2.
 - `TopConst tc` — generates the global initializer, appends the global to
   `ctx.globals`, then registers `(tc.tc_name.name, -(global_idx + 1))` in
   `func_indices`.
@@ -589,6 +618,27 @@ needed to make a bare `const` identifier usable inside another top-level
 declaration's body — is tracked as a known gap in issue #73. The encoding
 documented in this section is the data layout the fix relies on; the
 call-site decode path will land alongside that fix.
+
+### 8.2 Extern Bindings
+
+An `extern fn name(…) -> Ret;` declaration produces a `TopFn` with
+`fd_body = FnExtern`. Codegen lowers it to a Wasm import:
+
+```
+(import "env" "<name>" (func (param …) (result …)))
+```
+
+The resulting import function index is positive (it counts among the
+combined "imports + defined functions" view used by every other call
+site), so the name is registered in `func_indices` with `k ≥ 0` and call
+sites resolve through `call k` indistinguishably from a locally-defined
+function. The Wasm module name is currently hard-coded to `"env"`,
+matching the convention adopted by the Node-CJS host shim.
+
+An `extern type Name;` declaration produces a `TopType` with
+`td_body = TyExtern`. It generates no Wasm artifact — opaque types are
+purely a typechecker concern — and the codegen `TopType TyExtern` case
+returns the unchanged context.
 
 ## Appendix: Grammar Reference
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -25,7 +25,7 @@ row_var       = ".." lower_ident
 ### 1.2 Keywords
 
 ```
-fn let const extern mut own ref type struct enum trait impl effect handle
+fn let const mut own ref type struct enum trait impl effect handle
 resume handler match if else while for return break continue in
 true false where total module use pub as unsafe assume transmute
 forget Nat Int Bool Float String Type Row
@@ -68,7 +68,7 @@ Special:     \ (row restriction)
 ```ebnf
 program     = [module_decl] {import_decl} {top_level}
 top_level   = fn_decl | type_decl | trait_decl | impl_block | effect_decl
-            | const_decl | extern_type_decl | extern_fn_decl
+            | const_decl
 ```
 
 ### 2.2 Type Declarations
@@ -201,20 +201,15 @@ impl_block  = "impl" [type_params] [trait_ref "for"] type_expr
 const_decl  = [visibility] "const" LOWER_IDENT ":" type_expr "=" expr ";"
 ```
 
-Top-level `const` bindings are evaluated at compile time and emitted as
-immutable WebAssembly globals. Both function names and const names are
-registered in the codegen name environment (see §5.1).
+A top-level `const` binding compiles to an immutable WebAssembly global. The
+initializer expression must reduce to a Wasm constant expression (a literal
+or a constant arithmetic combination thereof); non-constant initializers are
+not yet supported by the linear-memory backend.
 
-### 2.10 Extern Declarations
-
-```ebnf
-extern_type_decl = "extern" "type" UPPER_IDENT ";"
-extern_fn_decl   = "extern" "fn" LOWER_IDENT "(" [param_list] ")" ["->" type_expr] ";"
-```
-
-`extern type` declares an opaque host-provided type. `extern fn` declares a
-function whose implementation is supplied by the host environment at link time
-(a WebAssembly import). Both are top-level only and carry no body.
+Both function names and const names are registered in the same codegen name
+environment so that later top-level declarations may refer to either kind of
+binding by name. See §8 (*Codegen Module Environment*) for the encoding and
+the current single-pass population order.
 
 ## 3. Type System
 
@@ -554,33 +549,46 @@ contributors; the language semantics are fully specified in §2–4.
 
 ### 8.1 Name Environment (`func_indices`)
 
-The codegen context maintains a single association list `func_indices :
-(string * int) list` that maps every top-level name visible at call sites to an
+The codegen context maintains a single association list
+
+```ocaml
+func_indices : (string * int) list
+```
+
+that maps every top-level name visible at later declaration sites to an
 integer key. Two distinct kinds of binding share this table:
 
 | Source declaration | Key value | Meaning |
 |--------------------|-----------|---------|
-| `fn f(…) { … }` | `k ≥ 0` | WebAssembly function index (import + defined functions combined) |
-| `const C: T = e` | `-(g+1)` where `g` is the global index | Negative sentinel; caller must emit `global.get g` not `call k` |
+| `fn f(…) { … }` | `k ≥ 0` | WebAssembly function index (imports + defined functions, combined) |
+| `const C: T = e` | `-(g + 1)`, where `g` is the global's index in the Wasm `globals` vector | Negative sentinel reserved for constants |
 
-The negative-index encoding lets call-site code distinguish constants from
-functions with a single sign test before emitting the appropriate instruction.
+Sign-based partitioning is deliberate: `k ≥ 0` decodes directly as a Wasm
+`funcidx`, and `k < 0` recovers the global index as `g = -(k + 1)`. A
+single integer per name keeps the lookup uniform across both kinds of binding.
 
-**Population order.** Both `TopFn` and `TopConst` are processed by `gen_decl`
-in declaration order (the single pass in `gen_program`). Each inserts its name
-into `func_indices` before any later declaration can reference it. Forward
-references to functions are therefore not supported in the current
-single-pass design.
+**Population.** Top-level declarations are visited in source order by
+`gen_decl`, which is folded over `prog.prog_decls` from `generate_module`.
+The two relevant cases are:
 
-### 8.2 Extern Bindings
+- `TopFn fd` — registers `(fd.fd_name.name, func_idx)` in `func_indices`
+  *before* generating the function body, so the body may recursively refer
+  to its own name.
+- `TopConst tc` — generates the global initializer, appends the global to
+  `ctx.globals`, then registers `(tc.tc_name.name, -(global_idx + 1))` in
+  `func_indices`.
 
-`TopExternFn` declarations are added to the WebAssembly import section and
-their names are registered in `func_indices` with the resulting import function
-index. `TopExternType` declarations register an opaque type name and generate
-no code.
+Because population is strictly single-pass and in declaration order,
+forward references (to either functions or constants declared later in the
+file) are not supported by the current backend.
 
-The WebAssembly module name for an `extern fn` import defaults to `"env"` unless
-overridden by a `@module("…")` pragma on the declaration (not yet implemented).
+**Call-site lookup.** The `ExprApp (ExprVar id, _)` branch of `gen_expr`
+consults `func_indices` to translate a direct call into a Wasm `call k`
+instruction. Decoding the negative sentinel back to a `global.get` —
+needed to make a bare `const` identifier usable inside another top-level
+declaration's body — is tracked as a known gap in issue #73. The encoding
+documented in this section is the data layout the fix relies on; the
+call-site decode path will land alongside that fix.
 
 ## Appendix: Grammar Reference
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -25,7 +25,7 @@ row_var       = ".." lower_ident
 ### 1.2 Keywords
 
 ```
-fn let mut own ref type struct enum trait impl effect handle
+fn let const extern mut own ref type struct enum trait impl effect handle
 resume handler match if else while for return break continue in
 true false where total module use pub as unsafe assume transmute
 forget Nat Int Bool Float String Type Row
@@ -68,6 +68,7 @@ Special:     \ (row restriction)
 ```ebnf
 program     = [module_decl] {import_decl} {top_level}
 top_level   = fn_decl | type_decl | trait_decl | impl_block | effect_decl
+            | const_decl | extern_type_decl | extern_fn_decl
 ```
 
 ### 2.2 Type Declarations
@@ -193,6 +194,27 @@ trait_item  = fn_sig ";" | fn_decl | assoc_type
 impl_block  = "impl" [type_params] [trait_ref "for"] type_expr
               [where_clause] "{" {impl_item} "}"
 ```
+
+### 2.9 Constant Declarations
+
+```ebnf
+const_decl  = [visibility] "const" LOWER_IDENT ":" type_expr "=" expr ";"
+```
+
+Top-level `const` bindings are evaluated at compile time and emitted as
+immutable WebAssembly globals. Both function names and const names are
+registered in the codegen name environment (see §5.1).
+
+### 2.10 Extern Declarations
+
+```ebnf
+extern_type_decl = "extern" "type" UPPER_IDENT ";"
+extern_fn_decl   = "extern" "fn" LOWER_IDENT "(" [param_list] ")" ["->" type_expr] ";"
+```
+
+`extern type` declares an opaque host-provided type. `extern fn` declares a
+function whose implementation is supplied by the host environment at link time
+(a WebAssembly import). Both are top-level only and carry no body.
 
 ## 3. Type System
 
@@ -523,6 +545,42 @@ Compiles to (ownership removed):
 (func $useFile (param $file (ref $File))
   (call $close (local.get $file)))
 ```
+
+## 8. Codegen Module Environment
+
+This section describes how the WebAssembly code generator (`lib/codegen.ml`)
+builds its name environment. It is implementation documentation aimed at
+contributors; the language semantics are fully specified in §2–4.
+
+### 8.1 Name Environment (`func_indices`)
+
+The codegen context maintains a single association list `func_indices :
+(string * int) list` that maps every top-level name visible at call sites to an
+integer key. Two distinct kinds of binding share this table:
+
+| Source declaration | Key value | Meaning |
+|--------------------|-----------|---------|
+| `fn f(…) { … }` | `k ≥ 0` | WebAssembly function index (import + defined functions combined) |
+| `const C: T = e` | `-(g+1)` where `g` is the global index | Negative sentinel; caller must emit `global.get g` not `call k` |
+
+The negative-index encoding lets call-site code distinguish constants from
+functions with a single sign test before emitting the appropriate instruction.
+
+**Population order.** Both `TopFn` and `TopConst` are processed by `gen_decl`
+in declaration order (the single pass in `gen_program`). Each inserts its name
+into `func_indices` before any later declaration can reference it. Forward
+references to functions are therefore not supported in the current
+single-pass design.
+
+### 8.2 Extern Bindings
+
+`TopExternFn` declarations are added to the WebAssembly import section and
+their names are registered in `func_indices` with the resulting import function
+index. `TopExternType` declarations register an opaque type name and generate
+no code.
+
+The WebAssembly module name for an `extern fn` import defaults to `"env"` unless
+overridden by a `@module("…")` pragma on the declaration (not yet implemented).
 
 ## Appendix: Grammar Reference
 

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -28,7 +28,11 @@ type context = {
   locals : (string * int) list;      (** local variable name to index map *)
   next_local : int;                  (** next available local index *)
   loop_depth : int;                  (** current loop nesting depth *)
-  func_indices : (string * int) list;  (** function name to index map *)
+  func_indices : (string * int) list;
+  (** Top-level name environment shared by functions and constants.
+      - [k >= 0]: Wasm function index (imports + defined functions).
+      - [k < 0]:  Constant (global): actual global index is [-(k+1)].
+      Both [TopFn] and [TopConst] insert into this table in declaration order. *)
   lambda_funcs : func list;          (** lifted lambda functions *)
   next_lambda_id : int;              (** next lambda function ID *)
   heap_ptr : int option;             (** global index for heap pointer, if initialized *)

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -31,8 +31,11 @@ type context = {
   func_indices : (string * int) list;
   (** Top-level name environment shared by functions and constants.
       - [k >= 0]: Wasm function index (imports + defined functions).
+                  Populated by both [TopFn] (defined function) and
+                  [TopFn _ with fd_body = FnExtern] (host-supplied import).
       - [k < 0]:  Constant (global): actual global index is [-(k+1)].
-      Both [TopFn] and [TopConst] insert into this table in declaration order. *)
+                  Populated by [TopConst].
+      Entries are inserted in source declaration order by [gen_decl]. *)
   lambda_funcs : func list;          (** lifted lambda functions *)
   next_lambda_id : int;              (** next lambda function ID *)
   heap_ptr : int option;             (** global index for heap pointer, if initialized *)


### PR DESCRIPTION
## Summary

- Grammar companion to PR #92 (extern lexer/parser/AST/codegen) and doc pointer for PR #94 (canonical `docs/specs/codegen-environment.adoc`)
- Adds `const_decl`, `extern_type_decl`, and `extern_fn_decl` to the `top_level` grammar in SPEC.md §2.1 (was missing `const` entirely)
- Adds §2.9 (Constant Declarations) and §2.10 (Extern Declarations) with full EBNF
- Adds §8 (Codegen Module Environment) — see PR #94's `codegen-environment.adoc` for the canonical narrative
- Updates the `func_indices` field comment in `lib/codegen.ml` to match

## Issue closure

Closes #89 *together with* PR #94. PR #94 is the canonical .adoc spec; this PR is the grammar/SPEC.md companion. Either PR alone is incomplete coverage of the issue.

## Depends on

- Depends on: #92 (extern type / extern fn parser+codegen) — §2.10 grammar and §8.2 extern bindings document features that land with #92.

## Test plan

- [ ] Read `docs/specs/SPEC.md` §2.1, §2.9, §2.10, §8 for accuracy against `lib/codegen.ml` `gen_decl`
- [ ] Confirm `TopConst` path uses `-(global_idx + 1)` encoding (codegen.ml line matches comment)
- [ ] Confirm `TopFn` path uses non-negative function index (matches §8.1 table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
