### PR TITLE
fix: codegen const refs + CI fmt/antipattern blockers

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -436,7 +436,13 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
            UnboundVariable even though the parser accepts it. *)
         begin match List.assoc_opt id.name ctx.variant_tags with
           | Some tag -> Ok (ctx, [I32Const (Int32.of_int tag)])
-          | None -> Error (UnboundVariable id.name)
+          | None ->
+            (* Top-level const bindings are stored in func_indices with a
+               negative sentinel: actual global index = -(k+1). *)
+            begin match List.assoc_opt id.name ctx.func_indices with
+              | Some k when k < 0 -> Ok (ctx, [GlobalGet (-(k + 1))])
+              | _ -> Error (UnboundVariable id.name)
+            end
         end
     end
 


### PR DESCRIPTION
## Summary

Bundles three pre-existing blockers that were causing every PR to fail CI:

**1. fix(codegen): resolve top-level const refs in ExprVar — closes #73**
- `ExprVar` name lookup fell through to `UnboundVariable` after checking locals and variant_tags, never consulting `func_indices` where `TopConst` bindings live (negative sentinel: `global_idx = -(k+1)`)
- Adds a `GlobalGet` fallback — `check` already passed; `compile` now passes too
- 207/207 existing tests pass

**2. fix(ci): dune @fmt — root dune missing blank line**
- `dune` (root) was missing a blank line between the comment and `(dirs ...)` stanza, causing the `@fmt` check to fail on every PR

**3. fix(ci): rsr-antipattern.yml BUILTIN_GLOBS crash**
- A dead second Python block leaked into bash after the first `PYEOF` closed the heredoc; bash tried to execute `BUILTIN_GLOBS` as a command (exit 127) on every PR run
- Removed the orphaned 77-line block; the first block already performs the full check

## Test plan

- [x] Reproducer from #73 (`const inputSuffix` + `fn withInput`) compiles cleanly
- [x] 207/207 existing tests pass (`dune test`)
- [x] `dune build @fmt` diff is empty for the two dune files
- [ ] Smoke-test `migration/shared/PortNames.affine` from idaptik Wave 3 pilot

Generated with [Claude Code](https://claude.com/claude-code)