### PR TITLE
stdlib: add extern binding modules for Grammy, Sqlite, Network, Crypto, Ajv

### DIFF
--- a/stdlib/Ajv.affine
+++ b/stdlib/Ajv.affine
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Ajv.affine — extern bindings for AJV v8 JSON Schema Validator.
+// The Node-CJS shim instantiates ajv@8 with allErrors:true, strict:false
+// and ajv-formats@3 applied. All handles are opaque Int.
+
+module Ajv;
+
+pub extern type AjvInstance;
+pub extern type Validator;
+
+pub extern fn ajv_new() -> AjvInstance;
+pub extern fn ajv_compile(a: AjvInstance, schema_json: String) -> Validator;
+pub extern fn ajv_validate(v: Validator, value_json: String) -> Bool;
+pub extern fn ajv_errors_json(v: Validator) -> String;

--- a/stdlib/Crypto.affine
+++ b/stdlib/Crypto.affine
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Crypto.affine — extern bindings for crypto primitives and wall-clock time.
+// The Node-CJS shim wraps Node's built-in node:crypto and Date.now().
+
+module Crypto;
+
+pub extern fn random_string(n: Int) -> String;
+pub extern fn random_f64() -> Float;
+pub extern fn time_ms() -> Int;

--- a/stdlib/Grammy.affine
+++ b/stdlib/Grammy.affine
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Grammy.affine — extern bindings for the Grammy Telegram Bot framework.
+//
+// All Grammy host objects are opaque Int handles maintained by the Node-CJS
+// shim. Function names mirror the Grammy/Telegram API where possible, with
+// namespaces flattened (e.g. bot.api.sendMessage -> bot_send_message).
+//
+// API surface: the subset used by avow-protocol/telegram-bot in standards.
+
+module Grammy;
+
+pub extern type Bot;
+pub extern type Context;
+pub extern type BotInfo;
+
+pub extern fn bot_new(token: String) -> Bot;
+pub extern fn bot_command(b: Bot, command: String, handler: Int) -> Int;
+pub extern fn bot_catch(b: Bot, err_handler: Int) -> Int;
+pub extern fn bot_start(b: Bot, on_start_handler: Int) -> Int;
+pub extern fn bot_send_message(b: Bot, chat_id: Int, text: String, parse_mode: String) -> Int;
+
+pub extern fn ctx_from_id(ctx: Context) -> Option<Int>;
+pub extern fn ctx_from_username(ctx: Context) -> Option<String>;
+pub extern fn ctx_reply(ctx: Context, text: String, parse_mode: String) -> Int;
+
+pub extern fn botinfo_username(info: BotInfo) -> String;
+
+pub extern fn set_interval(handler: Int, interval_ms: Int) -> Int;

--- a/stdlib/Network.affine
+++ b/stdlib/Network.affine
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Network.affine — extern bindings for synchronous HTTP requests.
+// The Node-CJS shim wraps Node's built-in node:https via a sync adapter.
+
+module Network;
+
+pub extern fn http_get_status(url: String) -> Int;
+pub extern fn http_get_response_time_ms(url: String) -> Int;

--- a/stdlib/Sqlite.affine
+++ b/stdlib/Sqlite.affine
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Sqlite.affine — extern bindings for an SQLite backend.
+//
+// All database handles are opaque Int. Query parameters are JSON-encoded
+// strings; each result row is returned as a JSON-encoded string for
+// caller-side decoding. The Node-CJS shim wraps Deno sqlite or node:sqlite.
+
+module Sqlite;
+
+pub extern type Db;
+
+pub extern fn db_open(path: String) -> Db;
+pub extern fn db_close(d: Db) -> Int;
+pub extern fn db_execute(d: Db, sql: String) -> Int;
+pub extern fn db_query(d: Db, sql: String, params_json: String) -> String;
+pub extern fn db_query_one(d: Db, sql: String, params_json: String) -> String;
+pub extern fn db_query_int(d: Db, sql: String, params_json: String) -> Int;


### PR DESCRIPTION
## Summary

Adds five new \stdlib/*.affine\ extern-binding modules, completing acceptance criterion 3 of issue #65 (_port telegram bot + axel-protocol tests to .affine once #35 + #42 land_).

Both blockers are now closed:
- #35 (Node-CJS backend) — CLOSED
- #42 (\xtern type\ / \xtern fn\ parsing) — CLOSED

### Modules added

| File | Purpose |
|---|---|
| \stdlib/Grammy.affine\ | Grammy Telegram Bot framework bindings |
| \stdlib/Sqlite.affine\ | SQLite database bindings (Deno sqlite / node:sqlite) |
| \stdlib/Network.affine\ | Synchronous HTTP bindings |
| \stdlib/Crypto.affine\ | Cryptographic primitives + \	ime_ms()\ |
| \stdlib/Ajv.affine\ | AJV v8 JSON Schema Validator bindings |

All follow the pattern established by \stdlib/Vscode.affine\ (Phase 2 of #35): \pub extern type\ for opaque handles, \pub extern fn\ for host-provided operations. The Node-CJS shim populates the import table at runtime.

## Test plan

- [ ] All five files parse cleanly (\ffinescript check stdlib/*.affine\)
- [ ] Pattern matches \stdlib/Vscode.affine\ / \stdlib/VscodeLanguageClient.affine\ style
- [ ] Companion port PR against \hyperpolymath/standards\ (closes #65) merges after this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)