### PR TITLE
docs(readme): make build prereqs reproducible from a clean checkout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -387,9 +387,35 @@ Games are one place where the language’s properties are easy to demonstrate. T
 
 === Prerequisites
 
-- OCaml 5.1+
+- OCaml 4.14.2+ (dune-project lists `>= 5.1`, but the current tree also builds clean on 4.14.2; the constraint is stricter than the actual code requires)
 - Dune 3.14+
-- opam packages: `sedlex`, `menhir`, `ppx_deriving`, `cmdliner`, `yojson`
+- opam packages: `sedlex`, `menhir`, `ppx_deriving`, `ppx_sexp_conv`, `sexplib0`, `fmt`, `cmdliner`, `yojson`, `alcotest` (test), `ocamlformat` (test), `js_of_ocaml`, `js_of_ocaml-ppx`, `js_of_ocaml-compiler`
+
+[NOTE]
+====
+The top-level `dune build` compiles every target including `js/playground.bc.js`, so `js_of_ocaml*` are required for an out-of-the-box build. If you only need the CLI and tests, you can build the subtrees explicitly:
+
+[source,bash]
+----
+dune build lib/ bin/ test/
+----
+====
+
+=== One-shot opam setup
+
+[source,bash]
+----
+# Install the full dep set into the active switch
+opam install -y \
+  sedlex menhir ppx_deriving ppx_sexp_conv sexplib0 fmt cmdliner yojson \
+  alcotest ocamlformat \
+  js_of_ocaml js_of_ocaml-ppx js_of_ocaml-compiler
+
+# Make `dune`, `ocaml`, etc. visible to non-interactive shells
+eval "$(opam env --switch=default --set-switch)"
+----
+
+For login shells, persist the PATH wiring by appending the equivalent to `~/.profile` — opam's own `opam-init/init.sh` gates PATH-setup behind `[ -t 0 ]`, so `wsl bash -lc '...'`-style invocations don't pick it up without an explicit eval.
 
 === Build
 


### PR DESCRIPTION
## Summary

- README "Prerequisites" listed 5 opam packages but `dune build` actually requires ~13 (the full `dune-project` `depends` block). On a fresh switch with the documented set you fail at `js/playground.bc.js` with `Library "js_of_ocaml" not found`.
- Adds the missing deps, a one-shot `opam install` snippet, an `eval $(opam env)` note for non-interactive shells, the `dune build lib/ bin/ test/` no-JS fallback, and a flag on the OCaml `>= 5.1` constraint drift (the tree also builds clean on 4.14.2).

## Why this matters

Another claude session checked the repo out, ran `dune` from a fresh shell, got "dune missing" (it wasn't — opam env just wasn't on PATH), tried installing the documented deps, hit `js_of_ocaml` failures, and concluded "Building OCaml toolchain here would be a long detour." The README is the contract for that first-five-minutes experience; this PR makes it honest.

## Test plan

- [x] `dune build` exits 0 on the post-fix switch
- [x] `dune runtest` → 209/209 green
- [x] Snippet copy-pasted from a clean state successfully provisions a switch end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
