### PR TITLE
docs(coc): replace placeholders in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,28 +1,8 @@
 # Code of Conduct
 
-<!-- 
-============================================================================
-TEMPLATE INSTRUCTIONS (delete this block before publishing)
-============================================================================
-Replace all {{PLACEHOLDER}} values:
-  {{PROJECT_NAME}}     - Your project name
-  {{OWNER}}            - GitHub/GitLab username or org
-  {{REPO}}             - Repository name
-  {{CONDUCT_EMAIL}}    - Email for conduct reports
-  {{CONDUCT_TEAM}}     - Name of conduct team/committee
-  {{RESPONSE_TIME}}    - Initial response SLA (e.g., 48 hours)
-  {{CURRENT_YEAR}}     - Current year
-
-Review and customise:
-- Adjust enforcement ladder for your community size
-- Add/remove examples based on your context
-- Ensure contact methods work for your team
-============================================================================
--->
-
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in {{PROJECT_NAME}} a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, colour, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in AffineScript a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, colour, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
@@ -136,9 +116,8 @@ If you experience or witness unacceptable behaviour, or have any other concerns,
 
 | Method | Details | Best For |
 |--------|---------|----------|
-| **Email** | {{CONDUCT_EMAIL}} | Detailed reports, sensitive matters |
+| **Email** | jonathan.jewell@gmail.com | Detailed reports, sensitive matters |
 | **Private Message** | Contact any maintainer directly | Quick questions, minor issues |
-| **Anonymous Form** | [Link to form if available] | When you need anonymity |
 
 **What to Include**
 
@@ -152,8 +131,8 @@ If you experience or witness unacceptable behaviour, or have any other concerns,
 
 **What Happens Next**
 
-1. You will receive acknowledgment within **{{RESPONSE_TIME}}**
-2. The {{CONDUCT_TEAM}} will review the report
+1. You will receive acknowledgment within **7 days**
+2. The maintainers will review the report
 3. We may ask for additional information
 4. We will determine appropriate action
 5. We will inform you of the outcome (respecting others' privacy)
@@ -169,17 +148,17 @@ All reports will be handled with discretion:
 
 ### Conflicts of Interest
 
-If a {{CONDUCT_TEAM}} member is involved in an incident:
+If a maintainer is involved in an incident:
 
 - They will recuse themselves from the process
-- Another maintainer or external party will handle the report
+- An uninvolved party will handle the report
 - We will disclose any potential conflicts
 
 ---
 
 ## Enforcement Guidelines
 
-The {{CONDUCT_TEAM}} will follow these guidelines in determining consequences:
+The maintainers will follow these guidelines in determining consequences:
 
 ### 1. Correction
 
@@ -213,17 +192,6 @@ The {{CONDUCT_TEAM}} will follow these guidelines in determining consequences:
 
 **Duration**: Permanent (with appeal rights after 12 months)
 
-### Enforcement Across Perimeters
-
-For contributors with elevated access (Perimeter 2 or 1):
-
-| Level | Additional Consequence |
-|-------|----------------------|
-| Correction | Noted in contributor record |
-| Warning | Access privileges may be temporarily reduced |
-| Temporary Ban | Access reduced to Perimeter 3 for ban duration |
-| Permanent Ban | All access revoked |
-
 ---
 
 ## Appeals
@@ -231,13 +199,13 @@ For contributors with elevated access (Perimeter 2 or 1):
 If you believe an enforcement decision was made in error:
 
 1. **Wait 7 days** after the decision (cooling-off period)
-2. **Email** {{CONDUCT_EMAIL}} with subject line "Appeal: [Original Report ID]"
+2. **Email** jonathan.jewell@gmail.com with subject line "Appeal: [Original Report ID]"
 3. **Explain** why you believe the decision should be reconsidered
 4. **Provide** any new information not previously available
 
 **Appeals Process**
 
-- Appeals are reviewed by a different {{CONDUCT_TEAM}} member than the original
+- Appeals are reviewed after consultation with an uninvolved party where possible
 - You will receive a response within 14 days
 - The appeals decision is final
 - You may only appeal once per incident
@@ -277,8 +245,6 @@ Beyond enforcement, we actively work to prevent issues:
 
 **Onboarding**
 - All contributors are expected to read this Code of Conduct
-- Perimeter 2 applicants must confirm they've read and understood it
-- Maintainers receive additional training on enforcement
 
 **Culture**
 - We model the behaviour we expect
@@ -310,8 +276,8 @@ We thank these communities for their leadership in creating welcoming spaces.
 
 If you have questions about this Code of Conduct:
 
-- Open a [Discussion](https://{{FORGE}}/{{OWNER}}/{{REPO}}/discussions) (for general questions)
-- Email {{CONDUCT_EMAIL}} (for private questions)
+- Open a [Discussion](https://github.com/hyperpolymath/affinescript/discussions) (for general questions)
+- Email jonathan.jewell@gmail.com (for private questions)
 - Contact any maintainer directly
 
 ---
@@ -324,4 +290,4 @@ We're all here because we care about this project. Let's make it a place where e
 
 ---
 
-<sub>Last updated: {{CURRENT_YEAR}} · Based on Contributor Covenant 2.1</sub>
+<sub>Last updated: 2026 · Based on Contributor Covenant 2.1</sub>


### PR DESCRIPTION
## Summary

Follow-up to #112 / #113 — clears the last placeholder-template file in the repo root.

`CODE_OF_CONDUCT.md` shipped with a `TEMPLATE INSTRUCTIONS` HTML-comment block and eight `{{...}}` placeholders unresolved. Fills them with real values, drops the Perimeter-framework table and Onboarding line (template-only vocabulary, also removed from CONTRIBUTING.md in #113), drops the dangling `[Link to form if available]` anonymous-form row and the "additional training" aspirational bullet, and reworks the few "different team member" mechanics so they're honest about a solo-maintained project.

Concrete substitutions:

- `{{PROJECT_NAME}}` → **AffineScript**
- `{{CONDUCT_EMAIL}}` → **jonathan.jewell@gmail.com** (project owner's contact; same as on profile)
- `{{CONDUCT_TEAM}}` → **the maintainers** (not "team" / "committee" — overpromises for a personal-estate repo)
- `{{RESPONSE_TIME}}` → **7 days** (instead of the template's suggested 48h SLA, which would be misleading for a solo project)
- `{{CURRENT_YEAR}}` → **2026**
- `{{FORGE}}` / `{{OWNER}}` / `{{REPO}}` → **github.com / hyperpolymath / affinescript**

Base Contributor Covenant 2.1 attribution preserved.

## Test plan

- [x] `grep -E '\{\{|[Pp]erimeter' CODE_OF_CONDUCT.md` — no matches
- [x] All hyperlinks resolve to real `github.com/hyperpolymath/affinescript/...` paths
- [x] Conduct email is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
