### PR TITLE
feat: Deno-ESM target + grammar-v2 build-out (Refs #122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Run codegen WASM tests
         run: opam exec -- ./tools/run_codegen_wasm_tests.sh
 
+      - name: Run codegen Deno-ESM tests (issue #122)
+        # Compiles tests/codegen-deno/*.affine with the --deno-esm backend
+        # and runs the *.harness.mjs under Node (CI has Node 20, not Deno;
+        # the Phase 1 fixtures are pure logic so Node ESM exercises them).
+        run: opam exec -- ./tools/run_codegen_deno_tests.sh
+
       - name: Run face-transformer regression tests
         run: opam exec -- ./tools/run_face_transformer_tests.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,9 @@ htmlcov/
 *.bak
 *.wasm
 /a.out
+
+# issue #122: generated Deno-ESM regression outputs (compiled from the
+# committed *.affine fixtures by tools/run_codegen_deno_tests.sh).
+/tests/codegen-deno/*.deno.js
+# Local-only build workaround (see file header); never committed.
+/dune-workspace

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -478,7 +478,7 @@ let repl_cmd_fn () =
     compilation errors.  With [--wasm-gc], targets the WebAssembly GC
     proposal instead of WASM 1.0 linear memory. *)
 let compile_file face json wasm_gc vscode_ext vscode_adapter vscode_no_lc
-    path output =
+    deno_esm path output =
   let face = resolve_face ~quiet:json face path in
   if json then begin
     let diags = ref [] in
@@ -512,8 +512,9 @@ let compile_file face json wasm_gc vscode_ext vscode_adapter vscode_no_lc
                use the original [prog] because they handle imports natively
                via Codegen.gen_imports / the import section. *)
             let flat_prog = Affinescript.Module_loader.flatten_imports loader prog in
+            let is_deno = deno_esm || Filename.check_suffix output ".deno.js" in
             let is_julia = Filename.check_suffix output ".jl" in
-            let is_js = Filename.check_suffix output ".js" in
+            let is_js = (not is_deno) && Filename.check_suffix output ".js" in
             let is_c = Filename.check_suffix output ".c" in
             let is_wgsl = Filename.check_suffix output ".wgsl" in
             let is_faust = Filename.check_suffix output ".dsp" in
@@ -534,7 +535,17 @@ let compile_file face json wasm_gc vscode_ext vscode_adapter vscode_no_lc
             let is_why3 = Filename.check_suffix output ".mlw" in
             let is_lean = Filename.check_suffix output ".lean" in
             let is_spirv = Filename.check_suffix output ".spv" in
-            if is_julia then begin
+            if is_deno then begin
+              match Affinescript.Codegen_deno.codegen_deno flat_prog resolve_ctx.symbols with
+              | Error msg ->
+                add { severity = Error; code = "E0824";
+                      message = Printf.sprintf "Deno-ESM codegen error: %s" msg;
+                      span = Affinescript.Span.dummy; help = None; labels = [] }
+              | Ok esm_code ->
+                let oc = open_out output in
+                output_string oc esm_code;
+                close_out oc
+            end else if is_julia then begin
               match Affinescript.Julia_codegen.codegen_julia flat_prog resolve_ctx.symbols with
               | Error msg ->
                 add { severity = Error; code = "E0800";
@@ -725,8 +736,9 @@ let compile_file face json wasm_gc vscode_ext vscode_adapter vscode_no_lc
                cross-module imports for backends that don't have native
                module-system support. Wasm/Wasm-GC keep the original [prog]. *)
             let flat_prog = Affinescript.Module_loader.flatten_imports loader prog in
+            let is_deno = deno_esm || Filename.check_suffix output ".deno.js" in
             let is_julia = Filename.check_suffix output ".jl" in
-            let is_js = Filename.check_suffix output ".js" in
+            let is_js = (not is_deno) && Filename.check_suffix output ".js" in
             let is_c = Filename.check_suffix output ".c" in
             let is_wgsl = Filename.check_suffix output ".wgsl" in
             let is_faust = Filename.check_suffix output ".dsp" in
@@ -747,7 +759,18 @@ let compile_file face json wasm_gc vscode_ext vscode_adapter vscode_no_lc
             let is_why3 = Filename.check_suffix output ".mlw" in
             let is_lean = Filename.check_suffix output ".lean" in
             let is_spirv = Filename.check_suffix output ".spv" in
-            if is_julia then
+            if is_deno then
+              (match Affinescript.Codegen_deno.codegen_deno flat_prog resolve_ctx.symbols with
+              | Error e ->
+                Format.eprintf "@[<v>Deno-ESM codegen error: %s@]@." e;
+                `Error (false, "Deno-ESM codegen error")
+              | Ok esm_code ->
+                let oc = open_out output in
+                output_string oc esm_code;
+                close_out oc;
+                Format.printf "Compiled %s -> %s (Deno-ESM)@." path output;
+                `Ok ())
+            else if is_julia then
               (match Affinescript.Julia_codegen.codegen_julia flat_prog resolve_ctx.symbols with
               | Error e ->
                 Format.eprintf "@[<v>Julia codegen error: %s@]@." e;
@@ -1178,6 +1201,20 @@ let vscode_no_lc_arg =
           dependency for extensions that ship no language client; the \
           wiring passes null in its place.")
 
+(* Issue #122: --deno-esm. Selects the direct AST -> ES-module backend
+   ({!Affinescript.Codegen_deno}) regardless of output extension, so a
+   drop-in `.js` ES module can be produced (e.g. `-o src/storage.js
+   --deno-esm`). A `.deno.js` output extension also routes here without
+   the flag, as a convenience for the test corpus / ad-hoc use. *)
+let deno_esm_arg =
+  Arg.(value & flag & info ["deno-esm"]
+    ~doc:"Emit a standalone Deno/Node ES module directly from the AST \
+          (issue #122): `export class` for struct+impl, `export` for \
+          public fns/consts, and `extern fn` lowered to direct host \
+          calls (Deno.*Sync / JSON / WebAssembly). No wasm, no require, \
+          no handle table — the output is a drop-in importable ESM. A \
+          `.deno.js` output extension selects this backend implicitly.")
+
 (** Shared --face flag: select the parser surface-syntax face. *)
 let face_arg =
   let faces = Arg.enum [
@@ -1524,7 +1561,7 @@ let compile_cmd =
   let doc = "Compile a file to WebAssembly (1.0 or GC proposal), Julia (.jl), JavaScript (.js), C (.c), a WGSL compute kernel (.wgsl), a Faust DSP program (.dsp), or an ONNX model (.onnx)" in
   let info = Cmd.info "compile" ~doc in
   Cmd.v info Term.(ret (const compile_file $ face_arg $ json_arg $ wasm_gc_arg
-    $ vscode_ext_arg $ vscode_adapter_arg $ vscode_no_lc_arg
+    $ vscode_ext_arg $ vscode_adapter_arg $ vscode_no_lc_arg $ deno_esm_arg
     $ path_arg $ output_arg))
 
 let fmt_cmd =

--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -175,6 +175,17 @@ let () =
   b "jsonStringify"       (fun a -> Printf.sprintf "JSON.stringify(%s)" (arg 0 a));
   b "jsonStringifyPretty" (fun a -> Printf.sprintf "JSON.stringify(%s, null, 2)" (arg 0 a));
   b "jsonParse"           (fun a -> Printf.sprintf "JSON.parse(%s)" (arg 0 a));
+  b "jsonNull"            (fun _ -> "null");
+  (* Opaque-object field/index read (the boundary primitive for treating
+     an arbitrary JS value as data — ubicity's `experience.id` etc.). *)
+  b "jsonGet"     (fun a -> Printf.sprintf "(%s)[%s]" (arg 0 a) (arg 1 a));
+  b "jsonGetStr"  (fun a -> Printf.sprintf "String((%s)[%s])" (arg 0 a) (arg 1 a));
+  (* Nullish default — preserves a JS default parameter when the arg is
+     omitted (`new ExperienceStorage()` -> './ubicity-data'). *)
+  b "orDefault"   (fun a -> Printf.sprintf "(%s ?? %s)" (arg 0 a) (arg 1 a));
+  (* Kilobyte display string: `(n/1024).toFixed(2)` — runtime number
+     formatting is an honest host primitive in every language. *)
+  b "kbString"    (fun a -> Printf.sprintf "(Number(%s) / 1024).toFixed(2)" (arg 0 a));
   (* ---- misc host ---- *)
   b "dateNow"     (fun _ -> "Date.now()");
   b "wasmInstance" (fun a -> Printf.sprintf "__as_wasmInstance(%s)" (arg 0 a));
@@ -199,7 +210,8 @@ let () =
   b "parse_float"    (fun a -> Printf.sprintf "__as_parseFloat(%s)" (arg 0 a));
   b "char_to_int"    (fun a -> Printf.sprintf "__as_charToInt(%s)" (arg 0 a));
   b "int_to_char"    (fun a -> Printf.sprintf "__as_intToChar(%s)" (arg 0 a));
-  b "show"           (fun a -> Printf.sprintf "__as_show(%s)" (arg 0 a))
+  b "show"           (fun a -> Printf.sprintf "__as_show(%s)" (arg 0 a));
+  b "panic"          (fun a -> Printf.sprintf "(() => { throw new Error(%s); })()" (arg 0 a))
 
 (* ============================================================================
    Identifier sanitisation (JS reserved words -> trailing underscore)

--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -1,0 +1,770 @@
+(* SPDX-License-Identifier: PMPL-1.0-or-later *)
+(* SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell *)
+
+(** Deno-ESM Emit Mode (issue #122, Refs #35 #103).
+
+    A *direct* AffineScript-AST → ES-module transpiler. Unlike
+    {!Codegen_node} (which wraps a compiled [Wasm.wasm_module] in a CJS
+    shim), this backend emits standalone ES2020 module source — no wasm,
+    no [require], no handle table — so the output is a drop-in [.js] /
+    [.mjs] ES module a Deno (or Node ESM) consumer can [import] directly.
+
+    Why a direct transpiler and not a wasm-wrapping ESM shim: the
+    motivating consumer ([hyperpolymath/ubicity]'s [storage.ts] /
+    [wasm-bridge.ts]) is pure JS-value orchestration — it [JSON.stringify]s
+    arbitrary opaque objects, [JSON.parse]s file contents back into JS
+    objects, and returns those objects to JS callers. AffineScript's wasm
+    ABI is i32-only ([Codegen]: params/ret all [I32]); an opaque JS object
+    and [JSON.stringify(obj)] cannot cross that boundary. There is
+    essentially no computation here that belongs in wasm. The correct tool
+    is therefore source-to-source emission, where [extern fn]s lower to
+    direct host calls ([Deno.writeTextFileSync], [JSON.stringify], ...) and
+    a struct + its [impl] block lower to a real [export class].
+
+    Relationship to the other JS-ish backends:
+    - {!Js_codegen} — standalone ES2020 from AST, but CommonJS-flavoured,
+      uses [require("fs")], and *erases* [impl] blocks
+      ([// impl block (erased)]). This module reuses its proven
+      expression/statement/pattern lowering shape but: emits ESM
+      ([export] / no [require]); emits [export class] for struct+impl;
+      and lowers [extern fn] to direct Deno/JS host calls.
+    - {!Codegen_node} — wasm-wrapping CJS shim (issue #35). Distinct track.
+
+    Out of scope (documented future work on #122 / #103): an async-extern
+    ABI. Not needed here — every Deno FS op used by the motivating consumer
+    has a synchronous form ([*Sync]); [await] on a synchronously-returned
+    value is valid JS so [async]-looking consumer code keeps working. *)
+
+open Ast
+
+(* ============================================================================
+   Code-generation context
+   ============================================================================ *)
+
+type codegen_ctx = {
+  output : Buffer.t;
+  indent : int;
+  symbols : Symbol.t;
+  (* Names declared as [extern fn] (after import flattening these arrive as
+     [TopExternFn]). A call to one of these lowers via {!deno_builtin}
+     rather than as an ordinary AffineScript function call. *)
+  externs : (string, unit) Hashtbl.t;
+  (* When emitting a method body, the receiver parameter is rewritten to
+     [this]; this holds that parameter's source name (if any). *)
+  self_name : string option;
+  (* Associated-function name -> emitted method name. A call to one of
+     these whose first argument is the active receiver lowers to
+     [this.<method>(rest)]; with any other first argument it lowers to
+     [(<arg0>).<method>(rest)] (a call on another instance). Lets the
+     receiver-first free-function source style (the only form the current
+     grammar accepts — no [self]/inherent-[impl]) read as real methods. *)
+  assoc : (string, string) Hashtbl.t;
+}
+
+let create_ctx symbols = {
+  output = Buffer.create 1024;
+  indent = 0;
+  symbols;
+  externs = Hashtbl.create 32;
+  self_name = None;
+  assoc = Hashtbl.create 32;
+}
+
+let emit ctx str = Buffer.add_string ctx.output str
+
+let emit_line ctx str =
+  Buffer.add_string ctx.output (String.make (ctx.indent * 2) ' ');
+  Buffer.add_string ctx.output str;
+  Buffer.add_char ctx.output '\n'
+
+let increase_indent ctx = { ctx with indent = ctx.indent + 1 }
+
+(* ============================================================================
+   Runtime prelude (ESM, Deno-flavoured)
+
+   Emitted once at the top of every module. No library deps, no [require]:
+   `deno run foo.js` / an ESM `import` is enough. `print` uses Deno.stdout
+   (Node ESM also exposes a `Deno` global only under compat, so consumers
+   that need Node should target the .cjs backend instead).
+   ============================================================================ *)
+
+let prelude = {|// ---- AffineScript Deno-ESM runtime ----
+const Some = (value) => ({ tag: "Some", value });
+const None = { tag: "None" };
+const Ok   = (value) => ({ tag: "Ok",  value });
+const Err  = (error) => ({ tag: "Err", error });
+const Unit = null;
+const print   = (s) => { Deno.stdout.writeSync(new TextEncoder().encode(String(s))); };
+const println = (s) => { console.log(String(s)); };
+// ---- Deno host shims (extern fn lowering targets, issue #122) ----
+// Kept tiny + inlined so emitted modules are genuinely drop-in (no extra
+// package to publish or resolve). The same surface is mirrored, for
+// standalone `deno test`, by packages/affine-deno/mod.js.
+const __as_ensureDir = (p) => {
+  try { Deno.mkdirSync(p, { recursive: true }); }
+  catch (e) { if (!(e instanceof Deno.errors.AlreadyExists)) throw e; }
+};
+const __as_pathJoin = (a, b) => {
+  if (a.length === 0) return b;
+  const sep = a.endsWith("/") || a.endsWith("\\") ? "" : "/";
+  return a + sep + b;
+};
+const __as_readDirNames = (p) => {
+  const names = [];
+  for (const entry of Deno.readDirSync(p)) {
+    if (entry.isFile) names.push(entry.name);
+  }
+  return names;
+};
+const __as_isNotFound = (e) => (e instanceof Deno.errors.NotFound);
+const __as_endsWith = (s, suffix) => String(s).endsWith(suffix);
+const __as_stripSuffix = (s, suffix) =>
+  String(s).endsWith(suffix) ? String(s).slice(0, -suffix.length) : String(s);
+const __as_wasmInstance = (bytes) =>
+  new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports;
+// ---- end runtime ----
+
+|}
+
+(* Lowering table: extern-fn name -> a function from rendered-arg list to a
+   JS expression string. Covers the Deno FS / JSON / Wasm / string surface
+   declared by stdlib/Deno.affine (issue #122). An extern not in this table
+   is assumed to be a host symbol of the same name already in scope (e.g.
+   imported by a hand-written shim); it lowers as a plain call. *)
+let deno_builtins :
+  (string, string list -> string) Hashtbl.t = Hashtbl.create 32
+
+let () =
+  let b name f = Hashtbl.replace deno_builtins name f in
+  let arg n a = List.nth a n in
+  (* ---- filesystem (synchronous; see module docstring re: async) ---- *)
+  b "writeTextFile" (fun a -> Printf.sprintf "Deno.writeTextFileSync(%s, %s)" (arg 0 a) (arg 1 a));
+  b "readTextFile"  (fun a -> Printf.sprintf "Deno.readTextFileSync(%s)" (arg 0 a));
+  b "readFileBytes" (fun a -> Printf.sprintf "Deno.readFileSync(%s)" (arg 0 a));
+  b "removePath"    (fun a -> Printf.sprintf "Deno.removeSync(%s)" (arg 0 a));
+  b "mkdirRecursive" (fun a -> Printf.sprintf "Deno.mkdirSync(%s, { recursive: true })" (arg 0 a));
+  b "ensureDir"     (fun a -> Printf.sprintf "__as_ensureDir(%s)" (arg 0 a));
+  b "readDirNames"  (fun a -> Printf.sprintf "__as_readDirNames(%s)" (arg 0 a));
+  b "statSize"      (fun a -> Printf.sprintf "Deno.statSync(%s).size" (arg 0 a));
+  b "pathJoin"      (fun a -> Printf.sprintf "__as_pathJoin(%s, %s)" (arg 0 a) (arg 1 a));
+  b "isNotFound"    (fun a -> Printf.sprintf "__as_isNotFound(%s)" (arg 0 a));
+  (* ---- JSON ---- *)
+  b "jsonStringify"       (fun a -> Printf.sprintf "JSON.stringify(%s)" (arg 0 a));
+  b "jsonStringifyPretty" (fun a -> Printf.sprintf "JSON.stringify(%s, null, 2)" (arg 0 a));
+  b "jsonParse"           (fun a -> Printf.sprintf "JSON.parse(%s)" (arg 0 a));
+  (* ---- misc host ---- *)
+  b "dateNow"     (fun _ -> "Date.now()");
+  b "endsWith"    (fun a -> Printf.sprintf "__as_endsWith(%s, %s)" (arg 0 a) (arg 1 a));
+  b "stripSuffix" (fun a -> Printf.sprintf "__as_stripSuffix(%s, %s)" (arg 0 a) (arg 1 a));
+  b "wasmInstance" (fun a -> Printf.sprintf "__as_wasmInstance(%s)" (arg 0 a));
+  (* Generic JS array push helper (returns the array, fluent). *)
+  b "arrayPush" (fun a -> Printf.sprintf "(%s.push(%s), %s)" (arg 0 a) (arg 1 a) (arg 0 a))
+
+(* ============================================================================
+   Identifier sanitisation (JS reserved words -> trailing underscore)
+   ============================================================================ *)
+
+(* Real ECMAScript reserved words + strict-mode (ES modules are strict)
+   future-reserved words + restricted names. Deliberately excludes the
+   Java-ism primitives ([double], [int], [boolean], [byte], [char],
+   [float], [long], [short], [abstract], [final], [native], ...) that
+   {!Js_codegen} carries: those are valid JS identifiers, and mangling
+   them would silently corrupt a consumer's required ESM export surface
+   (issue #122 requires the *exact* surface, e.g. ubicity). *)
+let js_reserved = [
+  "arguments"; "await"; "break"; "case"; "catch"; "class"; "const";
+  "continue"; "debugger"; "default"; "delete"; "do"; "else"; "enum";
+  "eval"; "export"; "extends"; "false"; "finally"; "for"; "function";
+  "if"; "implements"; "import"; "in"; "instanceof"; "interface"; "let";
+  "new"; "null"; "package"; "private"; "protected"; "public"; "return";
+  "static"; "super"; "switch"; "this"; "throw"; "true"; "try"; "typeof";
+  "var"; "void"; "while"; "with"; "yield";
+]
+
+let mangle (name : string) : string =
+  if List.mem name js_reserved then name ^ "_" else name
+
+(* Resolve a variable reference, honouring the active [self] rename. *)
+let resolve_var ctx (name : string) : string =
+  match ctx.self_name with
+  | Some s when s = name -> "this"
+  | _ -> mangle name
+
+(* ============================================================================
+   Expression code generation
+
+   Shape adapted from {!Js_codegen}; the divergences are: variable
+   resolution goes through {!resolve_var} (for [self] -> [this]); and a
+   call whose head is a known [extern fn] lowers via {!deno_builtins}.
+   ============================================================================ *)
+
+let rec gen_expr ctx (expr : expr) : string =
+  match expr with
+  | ExprLit lit -> gen_literal lit
+  | ExprVar name -> resolve_var ctx name.name
+  | ExprApp (func, args) ->
+      (match func with
+       | ExprVar id when Hashtbl.mem ctx.assoc id.name && args <> [] ->
+           (* Receiver-first associated call -> method call. *)
+           let m = Hashtbl.find ctx.assoc id.name in
+           let recv =
+             match List.hd args with
+             | ExprVar v
+               when (match ctx.self_name with Some s -> s = v.name | None -> false) ->
+                 "this"
+             | other -> "(" ^ gen_expr ctx other ^ ")"
+           in
+           let rest = List.map (gen_expr ctx) (List.tl args) in
+           (* Synthesised methods are all [async]; an associated call is
+              an expression sub-term, so await it (valid: it only occurs
+              inside the [async] method bodies we emit). *)
+           "(await " ^ recv ^ "." ^ m ^ "(" ^ String.concat ", " rest ^ "))"
+       | ExprVar id when Hashtbl.mem ctx.externs id.name ->
+           let arg_strs = List.map (gen_expr ctx) args in
+           (match Hashtbl.find_opt deno_builtins id.name with
+            | Some lower -> lower arg_strs
+            | None ->
+                (* Unknown extern: assume a same-named host symbol in scope. *)
+                mangle id.name ^ "(" ^ String.concat ", " arg_strs ^ ")")
+       | _ ->
+           let arg_strs = List.map (gen_expr ctx) args in
+           gen_expr ctx func ^ "(" ^ String.concat ", " arg_strs ^ ")")
+  | ExprBinary (e1, op, e2) ->
+      let op_str = match op with
+        | OpAdd -> "+" | OpSub -> "-" | OpMul -> "*" | OpDiv -> "/"
+        | OpMod -> "%" | OpEq -> "===" | OpNe -> "!==" | OpLt -> "<"
+        | OpLe -> "<=" | OpGt -> ">" | OpGe -> ">=" | OpAnd -> "&&"
+        | OpOr -> "||" | OpBitAnd -> "&" | OpBitOr -> "|" | OpBitXor -> "^"
+        | OpShl -> "<<" | OpShr -> ">>" | OpConcat -> "+"
+      in
+      "(" ^ gen_expr ctx e1 ^ " " ^ op_str ^ " " ^ gen_expr ctx e2 ^ ")"
+  | ExprUnary (op, e) ->
+      (match op with
+       | OpNeg    -> "(-" ^ gen_expr ctx e ^ ")"
+       | OpNot    -> "(!" ^ gen_expr ctx e ^ ")"
+       | OpBitNot -> "(~" ^ gen_expr ctx e ^ ")"
+       | OpRef    -> "({ get: () => " ^ gen_expr ctx e ^ ", set: (_) => {} })"
+       | OpDeref  -> "(" ^ gen_expr ctx e ^ ".get())")
+  | ExprIf { ei_cond; ei_then; ei_else } ->
+      let else_str = match ei_else with
+        | Some e -> gen_expr ctx e | None -> "Unit"
+      in
+      "(" ^ gen_expr ctx ei_cond ^ " ? " ^ gen_expr ctx ei_then ^ " : "
+      ^ else_str ^ ")"
+  | ExprLet { el_pat; el_value; el_body; el_mut; el_quantity = _; el_ty = _ } ->
+      let pat_str = gen_pattern ctx el_pat in
+      let val_str = gen_expr ctx el_value in
+      let kw = if el_mut then "let" else "const" in
+      (match el_body with
+       | Some body ->
+           "((() => { " ^ kw ^ " " ^ pat_str ^ " = " ^ val_str ^ "; return "
+           ^ gen_expr ctx body ^ "; })())"
+       | None ->
+           "((() => { " ^ kw ^ " " ^ pat_str ^ " = " ^ val_str
+           ^ "; return Unit; })())")
+  | ExprTuple exprs | ExprArray exprs ->
+      "[" ^ String.concat ", " (List.map (gen_expr ctx) exprs) ^ "]"
+  | ExprIndex (arr, idx) ->
+      gen_expr ctx arr ^ "[" ^ gen_expr ctx idx ^ "]"
+  | ExprTupleIndex (e, n) ->
+      gen_expr ctx e ^ "[" ^ string_of_int n ^ "]"
+  | ExprRecord { er_fields; er_spread } ->
+      let field_strs = List.map (fun (name, e_opt) ->
+        let v = match e_opt with
+          | Some e -> gen_expr ctx e
+          | None   -> resolve_var ctx name.name
+        in
+        mangle name.name ^ ": " ^ v
+      ) er_fields in
+      let spread_str = match er_spread with
+        | Some e -> "...(" ^ gen_expr ctx e ^ "), " | None -> ""
+      in
+      "({ " ^ spread_str ^ String.concat ", " field_strs ^ " })"
+  | ExprField (record, field) ->
+      gen_expr ctx record ^ "." ^ mangle field.name
+  | ExprMatch { em_scrutinee; em_arms } ->
+      gen_match ctx em_scrutinee em_arms
+  | ExprBlock block -> gen_block_expr ctx block
+  | ExprReturn (Some e) -> "(() => { return " ^ gen_expr ctx e ^ "; })()"
+  | ExprReturn None     -> "(() => { return Unit; })()"
+  | ExprLambda { elam_params; elam_body; elam_ret_ty = _ } ->
+      let ps = List.map (fun (p : param) -> mangle p.p_name.name) elam_params in
+      "((" ^ String.concat ", " ps ^ ") => " ^ gen_expr ctx elam_body ^ ")"
+  | ExprTry { et_body; et_catch; et_finally } ->
+      gen_try ctx et_body et_catch et_finally
+  | ExprVariant (ty, ctor) ->
+      (match ty.name, ctor.name with
+       | _, "None" -> "None" | _, "Some" -> "Some"
+       | _, "Ok"   -> "Ok"   | _, "Err"  -> "Err"
+       | _, name   -> Printf.sprintf "({ tag: %S })" name)
+  | ExprSpan (inner, _) -> gen_expr ctx inner
+  | ExprRowRestrict (e, _) -> gen_expr ctx e
+  | ExprHandle { eh_body; eh_handlers = _ } -> gen_expr ctx eh_body
+  | ExprResume (Some e) -> gen_expr ctx e
+  | ExprResume None     -> "Unit"
+  | ExprUnsafe _ ->
+      "(() => { throw new Error('unsafe op not supported in Deno-ESM backend'); })()"
+
+and gen_literal (lit : literal) : string =
+  match lit with
+  | LitInt (n, _)      -> string_of_int n
+  | LitFloat (f, _)    ->
+      let s = string_of_float f in
+      if String.length s > 0 && s.[String.length s - 1] = '.' then s ^ "0" else s
+  | LitBool (true, _)  -> "true"
+  | LitBool (false, _) -> "false"
+  | LitString (s, _)   -> "\"" ^ String.escaped s ^ "\""
+  | LitChar (c, _)     -> "\"" ^ Char.escaped c ^ "\""
+  | LitUnit _          -> "Unit"
+
+and gen_pattern ctx (pat : pattern) : string =
+  match pat with
+  | PatWildcard _ -> "_"
+  | PatVar name   -> mangle name.name
+  | PatLit _      -> "_"
+  | PatTuple pats ->
+      "[" ^ String.concat ", " (List.map (gen_pattern ctx) pats) ^ "]"
+  | PatRecord (fields, _) ->
+      let strs = List.map (fun (n, sub) ->
+        match sub with
+        | None     -> mangle n.name
+        | Some sub -> mangle n.name ^ ": " ^ gen_pattern ctx sub
+      ) fields in
+      "{ " ^ String.concat ", " strs ^ " }"
+  | PatAs (id, _)  -> mangle id.name
+  | PatCon (id, _) -> mangle id.name
+  | PatOr (p, _)   -> gen_pattern ctx p
+
+and gen_match ctx scrutinee arms =
+  let scrutinee_str = gen_expr ctx scrutinee in
+  let scrut_var = "__scrut" in
+  let rec gen_arms = function
+    | [] -> "throw new Error(\"non-exhaustive match\");"
+    | arm :: rest ->
+        let cond = gen_pattern_test scrut_var arm.ma_pat in
+        let bindings = gen_pattern_bindings scrut_var arm.ma_pat in
+        let body = gen_expr ctx arm.ma_body in
+        let prefix =
+          if bindings = "" then
+            let guard = match arm.ma_guard with
+              | Some g -> " && (" ^ gen_expr ctx g ^ ")" | None -> ""
+            in
+            "if (" ^ cond ^ guard ^ ") { return " ^ body ^ "; }"
+          else if arm.ma_guard = None then
+            "if (" ^ cond ^ ") { " ^ bindings ^ " return " ^ body ^ "; }"
+          else
+            "if (" ^ cond ^ ") { " ^ bindings ^ " if ("
+            ^ (match arm.ma_guard with Some g -> gen_expr ctx g | None -> "true")
+            ^ ") { return " ^ body ^ "; } }"
+        in
+        prefix ^ " " ^ gen_arms rest
+  in
+  "((" ^ scrut_var ^ ") => { " ^ gen_arms arms ^ " })(" ^ scrutinee_str ^ ")"
+
+and gen_pattern_test scrut pat =
+  match pat with
+  | PatWildcard _ | PatVar _ -> "true"
+  | PatLit lit -> scrut ^ " === " ^ gen_literal lit
+  | PatCon (id, _) -> scrut ^ ".tag === " ^ Printf.sprintf "%S" id.name
+  | PatTuple pats ->
+      let conds = List.mapi (fun i p ->
+        gen_pattern_test (scrut ^ "[" ^ string_of_int i ^ "]") p) pats in
+      String.concat " && " (("Array.isArray(" ^ scrut ^ ")") :: conds)
+  | PatRecord (fields, _) ->
+      let conds = List.map (fun (n, sub) ->
+        match sub with
+        | None -> "true"
+        | Some sub -> gen_pattern_test (scrut ^ "." ^ mangle n.name) sub
+      ) fields in
+      String.concat " && " conds
+  | PatAs (_, p) -> gen_pattern_test scrut p
+  | PatOr (p1, p2) ->
+      "((" ^ gen_pattern_test scrut p1 ^ ") || ("
+      ^ gen_pattern_test scrut p2 ^ "))"
+
+and gen_pattern_bindings scrut pat =
+  let buf = Buffer.create 64 in
+  let rec walk path = function
+    | PatWildcard _ | PatLit _ -> ()
+    | PatVar id ->
+        Buffer.add_string buf ("const " ^ mangle id.name ^ " = " ^ path ^ "; ")
+    | PatTuple pats ->
+        List.iteri (fun i p -> walk (path ^ "[" ^ string_of_int i ^ "]") p) pats
+    | PatRecord (fields, _) ->
+        List.iter (fun (n, sub) ->
+          let sub_path = path ^ "." ^ mangle n.name in
+          match sub with
+          | None -> Buffer.add_string buf
+                      ("const " ^ mangle n.name ^ " = " ^ sub_path ^ "; ")
+          | Some sub -> walk sub_path sub
+        ) fields
+    | PatCon (_, args) ->
+        (match args with
+         | [] -> ()
+         | [single] -> walk (path ^ ".value") single
+         | many -> List.iteri (fun i p ->
+             walk (path ^ ".values[" ^ string_of_int i ^ "]") p) many)
+    | PatAs (id, sub) ->
+        Buffer.add_string buf ("const " ^ mangle id.name ^ " = " ^ path ^ "; ");
+        walk path sub
+    | PatOr (p, _) -> walk path p
+  in
+  walk scrut pat;
+  Buffer.contents buf
+
+and gen_block_expr ctx block =
+  let body = Buffer.create 64 in
+  List.iter (fun s ->
+    Buffer.add_string body (gen_stmt ctx s);
+    Buffer.add_string body " ") block.blk_stmts;
+  let result = match block.blk_expr with
+    | Some e -> "return " ^ gen_expr ctx e ^ ";"
+    | None   -> "return Unit;"
+  in
+  "(() => { " ^ Buffer.contents body ^ result ^ " })()"
+
+and gen_try ctx body catch finally =
+  let body_str = gen_block_expr ctx body in
+  let catch_str = match catch with
+    | None | Some [] -> "catch (__e) { throw __e; }"
+    | Some (arm :: _) ->
+        let bind = match arm.ma_pat with
+          | PatVar id -> "const " ^ mangle id.name ^ " = __e; "
+          | _ -> ""
+        in
+        "catch (__e) { " ^ bind ^ "return " ^ gen_expr ctx arm.ma_body ^ "; }"
+  in
+  let finally_str = match finally with
+    | None -> ""
+    | Some blk -> " finally { " ^ gen_block_expr ctx blk ^ "; }"
+  in
+  "(() => { try { return " ^ body_str ^ "; } " ^ catch_str ^ finally_str
+  ^ " })()"
+
+and gen_stmt ctx (stmt : stmt) : string =
+  match stmt with
+  | StmtLet { sl_pat; sl_value; sl_mut; sl_quantity = _; sl_ty = _ } ->
+      let kw = if sl_mut then "let" else "const" in
+      kw ^ " " ^ gen_pattern ctx sl_pat ^ " = " ^ gen_expr ctx sl_value ^ ";"
+  | StmtExpr e -> gen_expr ctx e ^ ";"
+  | StmtAssign (lhs, op, rhs) ->
+      let op_str = match op with
+        | AssignEq -> "=" | AssignAdd -> "+=" | AssignSub -> "-="
+        | AssignMul -> "*=" | AssignDiv -> "/="
+      in
+      gen_expr ctx lhs ^ " " ^ op_str ^ " " ^ gen_expr ctx rhs ^ ";"
+  | StmtWhile (cond, body) ->
+      "while (" ^ gen_expr ctx cond ^ ") { "
+      ^ String.concat " " (List.map (gen_stmt ctx) body.blk_stmts)
+      ^ (match body.blk_expr with
+         | Some e -> " " ^ gen_expr ctx e ^ ";" | None -> "")
+      ^ " }"
+  | StmtFor (pat, iter, body) ->
+      "for (const " ^ gen_pattern ctx pat ^ " of " ^ gen_expr ctx iter ^ ") { "
+      ^ String.concat " " (List.map (gen_stmt ctx) body.blk_stmts)
+      ^ (match body.blk_expr with
+         | Some e -> " " ^ gen_expr ctx e ^ ";" | None -> "")
+      ^ " }"
+
+(* ============================================================================
+   Top-level declarations + class emission
+   ============================================================================ *)
+
+let visibility_is_public = function
+  | Public | PubCrate | PubSuper | PubIn _ -> true
+  | Private -> false
+
+(* Render a method/function body (block or expr) into [ctx]. *)
+let gen_body ctx (fb : fn_body) : unit =
+  match fb with
+  | FnExpr e ->
+      emit_line ctx ("return " ^ gen_expr ctx e ^ ";")
+  | FnBlock block ->
+      List.iter (fun s -> emit_line ctx (gen_stmt ctx s)) block.blk_stmts;
+      (match block.blk_expr with
+       | Some e -> emit_line ctx ("return " ^ gen_expr ctx e ^ ";")
+       | None   -> ())
+  | FnExtern -> ()
+
+let gen_function ctx (fd : fn_decl) : unit =
+  let name = mangle fd.fd_name.name in
+  let params =
+    List.map (fun (p : param) -> mangle p.p_name.name) fd.fd_params in
+  let kw =
+    if visibility_is_public fd.fd_vis then "export function" else "function" in
+  emit_line ctx
+    (Printf.sprintf "%s %s(%s) {" kw name (String.concat ", " params));
+  gen_body (increase_indent ctx) fd.fd_body;
+  emit_line ctx "}";
+  emit ctx "\n"
+
+(* Head name of a (possibly ref/own/mut/applied) type expression. *)
+let rec type_expr_name : type_expr -> string option = function
+  | TyCon id | TyVar id -> Some id.name
+  | TyApp (id, _)       -> Some id.name
+  | TyOwn t | TyRef t | TyMut t -> type_expr_name t
+  | _ -> None
+
+(* The struct (if any, among [known]) that [fd]'s first parameter is typed
+   as — i.e. [fd] is a receiver-first method of that struct. *)
+let receiver_struct ~(known : (string, 'a) Hashtbl.t) (fd : fn_decl)
+  : (string * string) option =
+  match fd.fd_params with
+  | p :: _ ->
+      (match type_expr_name p.p_ty with
+       | Some s when Hashtbl.mem known s -> Some (s, p.p_name.name)
+       | _ -> None)
+  | [] -> None
+
+(* The struct (if any, among [known]) that [fd] returns — a constructor
+   candidate for that struct. *)
+let returns_struct ~(known : (string, 'a) Hashtbl.t) (fd : fn_decl)
+  : string option =
+  match fd.fd_ret_ty with
+  | Some t ->
+      (match type_expr_name t with
+       | Some s when Hashtbl.mem known s -> Some s | _ -> None)
+  | None -> None
+
+let ctor_name_hint (n : string) : bool =
+  let n = String.lowercase_ascii n in
+  List.exists (fun k ->
+    let kl = String.length k and nl = String.length n in
+    n = k
+    || (nl > kl && String.sub n 0 (kl + 1) = k ^ "_")
+    || (nl > kl && String.sub n (nl - kl - 1) (kl + 1) = "_" ^ k))
+    ["new"; "make"; "create"; "init"; "from"]
+
+(* Emitted method name: strip a leading "<Struct>_" prefix (case-insensitive
+   on the struct name) from the source fn name if present. *)
+let method_js_name ~(struct_name : string) (fn : string) : string =
+  let pfx = struct_name ^ "_" in
+  let lc = String.lowercase_ascii in
+  if String.length fn > String.length pfx
+     && lc (String.sub fn 0 (String.length pfx)) = lc pfx then
+    String.sub fn (String.length pfx) (String.length fn - String.length pfx)
+  else fn
+
+(* Emit a class method from a receiver-first free function: the receiver
+   parameter is dropped from the JS signature and rewritten to [this].
+   All methods are emitted [async] — the motivating consumer's surface is
+   entirely [async] and callers [await]; [await] on a synchronously
+   returned value is valid JS, so this preserves the exact consumer API
+   with no async ABI (issue #122 scope; async-extern #103 not required). *)
+let gen_method ctx ~(recv_name : string) ~(js_name : string)
+    (fd : fn_decl) : unit =
+  let rest_params = match fd.fd_params with _ :: t -> t | [] -> [] in
+  let params =
+    List.map (fun (p : param) -> mangle p.p_name.name) rest_params in
+  let ctx_m = { ctx with self_name = Some recv_name } in
+  emit_line ctx_m
+    (Printf.sprintf "async %s(%s) {" (mangle js_name)
+       (String.concat ", " params));
+  gen_body (increase_indent ctx_m) fd.fd_body;
+  emit_line ctx_m "}";
+  emit ctx_m ""
+
+(* Constructor from a free function returning the struct: a returned record
+   literal becomes [this.f = e;] assignments. *)
+let gen_constructor ctx (fd : fn_decl) : unit =
+  let params =
+    List.map (fun (p : param) -> mangle p.p_name.name) fd.fd_params in
+  emit_line ctx
+    (Printf.sprintf "constructor(%s) {" (String.concat ", " params));
+  let body_ctx = increase_indent ctx in
+  let rec assign_record e =
+    match e with
+    | ExprSpan (inner, _) -> assign_record inner
+    | ExprRecord { er_fields; er_spread = _ } ->
+        List.iter (fun (name, e_opt) ->
+          let v = match e_opt with
+            | Some e -> gen_expr body_ctx e
+            | None   -> resolve_var body_ctx name.name
+          in
+          emit_line body_ctx
+            (Printf.sprintf "this.%s = %s;" (mangle name.name) v)
+        ) er_fields;
+        true
+    | _ -> false
+  in
+  let handled =
+    match fd.fd_body with
+    | FnExpr e -> assign_record e
+    | FnBlock { blk_stmts; blk_expr = Some e } ->
+        List.iter (fun s -> emit_line body_ctx (gen_stmt body_ctx s)) blk_stmts;
+        assign_record e
+    | _ -> false
+  in
+  if not handled then gen_body body_ctx fd.fd_body;
+  emit_line ctx "}";
+  emit ctx ""
+
+(* Synthesised constructor when the struct has methods but no fn returns
+   it: one parameter per field, assigned positionally. *)
+let gen_default_constructor ctx (fields : struct_field list) : unit =
+  let ps = List.map (fun (sf : struct_field) -> mangle sf.sf_name.name) fields in
+  emit_line ctx (Printf.sprintf "constructor(%s) {" (String.concat ", " ps));
+  let b = increase_indent ctx in
+  List.iter (fun (sf : struct_field) ->
+    let f = mangle sf.sf_name.name in
+    emit_line b (Printf.sprintf "this.%s = %s;" f f)) fields;
+  emit_line ctx "}";
+  emit ctx ""
+
+(* Emit `export class Name { ... }`. [ctor] is the constructor fn (or a
+   field-wise default is synthesised); [methods] are (recv_name, js_name,
+   fn) receiver-first associated functions. *)
+let gen_class ctx ~(name : string) ~(fields : struct_field list)
+    ~(ctor : fn_decl option)
+    ~(methods : (string * string * fn_decl) list) : unit =
+  emit_line ctx (Printf.sprintf "export class %s {" name);
+  let cls = increase_indent ctx in
+  (match ctor with
+   | Some fd -> gen_constructor cls fd
+   | None    -> gen_default_constructor cls fields);
+  List.iter (fun (recv_name, js_name, fd) ->
+    gen_method cls ~recv_name ~js_name fd) methods;
+  emit_line ctx "}";
+  emit ctx "\n"
+
+let gen_type_decl ctx (td : type_decl) : unit =
+  match td.td_body with
+  | TyEnum variants ->
+      let exp = if visibility_is_public td.td_vis then "export " else "" in
+      List.iter (fun (vd : variant_decl) ->
+        let name = mangle vd.vd_name.name in
+        let arity = List.length vd.vd_fields in
+        if arity = 0 then
+          emit_line ctx
+            (Printf.sprintf "%sconst %s = { tag: \"%s\" };" exp name
+               vd.vd_name.name)
+        else if arity = 1 then
+          emit_line ctx
+            (Printf.sprintf "%sconst %s = (value) => ({ tag: \"%s\", value });"
+               exp name vd.vd_name.name)
+        else
+          let ps = List.init arity (fun i -> "v" ^ string_of_int i) in
+          emit_line ctx
+            (Printf.sprintf
+               "%sconst %s = (%s) => ({ tag: \"%s\", values: [%s] });"
+               exp name (String.concat ", " ps) vd.vd_name.name
+               (String.concat ", " ps))
+      ) variants;
+      emit ctx "\n"
+  | TyStruct _ | TyAlias _ | TyExtern ->
+      (* Struct shape surfaces via {!gen_class} when an impl block exists;
+         a bare struct/alias/extern type carries no runtime value. *)
+      emit_line ctx (Printf.sprintf "// type %s" td.td_name.name)
+
+let generate (program : program) (symbols : Symbol.t) : string =
+  let ctx = create_ctx symbols in
+  (* Register extern names so calls lower via the builtin table. *)
+  List.iter (function
+    | TopExternFn { ef_name; _ } ->
+        Hashtbl.replace ctx.externs ef_name.name ()
+    | TopFn fd when fd.fd_body = FnExtern ->
+        Hashtbl.replace ctx.externs fd.fd_name.name ()
+    | _ -> ()) program.prog_decls;
+
+  emit_line ctx "// Generated by AffineScript compiler (Deno-ESM target, issue #122)";
+  emit_line ctx "// SPDX-License-Identifier: PMPL-1.0-or-later";
+  emit ctx prelude;
+
+  (* Collect structs. AffineScript's grammar accepts neither inherent
+     [impl Type {}] nor a [self] expression (SELF_KW has no expression
+     production — even stdlib/traits.affine fails to parse), so an
+     "instance method" is necessarily a free function taking the struct
+     as its first parameter. We synthesise `export class` from a struct
+     plus its receiver-first / struct-returning free functions. *)
+  let structs = Hashtbl.create 16 in
+  List.iter (function
+    | TopType ({ td_body = TyStruct fields; _ } as td) ->
+        Hashtbl.replace structs td.td_name.name fields
+    | _ -> ()) program.prog_decls;
+
+  (* methods_of : struct -> (recv_name, js_name, fd) list (decl order)
+     ctors_of   : struct -> fd list (struct-returning candidates)
+     consumed   : fn names emitted inside a class, not as free functions *)
+  let methods_of = Hashtbl.create 16 in
+  let ctors_of   = Hashtbl.create 16 in
+  let consumed   = Hashtbl.create 32 in
+  let push tbl k v =
+    Hashtbl.replace tbl k (v :: (try Hashtbl.find tbl k with Not_found -> [])) in
+  List.iter (function
+    | TopFn fd when fd.fd_body <> FnExtern ->
+        (match receiver_struct ~known:structs fd with
+         | Some (s, rn) ->
+             let js = method_js_name ~struct_name:s fd.fd_name.name in
+             push methods_of s (rn, js, fd);
+             Hashtbl.replace ctx.assoc fd.fd_name.name js;
+             Hashtbl.replace consumed fd.fd_name.name ()
+         | None ->
+             (match returns_struct ~known:structs fd with
+              | Some s ->
+                  push ctors_of s fd;
+                  Hashtbl.replace consumed fd.fd_name.name ()
+              | None -> ()))
+    | _ -> ()) program.prog_decls;
+  let methods_for s =
+    List.rev (try Hashtbl.find methods_of s with Not_found -> []) in
+  let ctor_for s =
+    match (try Hashtbl.find ctors_of s with Not_found -> []) with
+    | [] -> None
+    | cs ->
+        let cs = List.rev cs in
+        (match List.find_opt
+                 (fun fd -> ctor_name_hint fd.fd_name.name) cs with
+         | Some fd -> Some fd
+         | None -> Some (List.hd cs))
+  in
+  let is_class s =
+    Hashtbl.mem methods_of s || Hashtbl.mem ctors_of s in
+
+  let emitted_class = Hashtbl.create 16 in
+  let emit_class_for s fields =
+    if not (Hashtbl.mem emitted_class s) then begin
+      gen_class ctx ~name:s ~fields ~ctor:(ctor_for s)
+        ~methods:(methods_for s);
+      Hashtbl.replace emitted_class s ()
+    end
+  in
+  List.iter (fun top ->
+    match top with
+    | TopFn fd when fd.fd_body <> FnExtern ->
+        if not (Hashtbl.mem consumed fd.fd_name.name) then
+          gen_function ctx fd
+    | TopFn _ -> ()  (* extern-as-fn: lowered at call sites *)
+    | TopExternFn _ | TopExternType _ -> ()  (* lowered at call sites *)
+    | TopType td ->
+        (match td.td_body with
+         | TyStruct fields when is_class td.td_name.name ->
+             emit_class_for td.td_name.name fields
+         | _ -> gen_type_decl ctx td)
+    | TopImpl ib ->
+        (* Inherent/trait impls don't parse in the current grammar; this
+           is a defensive fallback only. *)
+        List.iter (function
+          | ImplFn fd -> gen_function ctx fd
+          | ImplType _ -> ()) ib.ib_items
+    | TopConst { tc_vis; tc_name; tc_value; _ } ->
+        let exp = if visibility_is_public tc_vis then "export " else "" in
+        emit_line ctx
+          (Printf.sprintf "%sconst %s = %s;" exp (mangle tc_name.name)
+             (gen_expr ctx tc_value))
+    | TopEffect _ -> emit_line ctx "// effect declaration (erased)"
+    | TopTrait _  -> emit_line ctx "// trait declaration (erased)"
+  ) program.prog_decls;
+
+  (* If a `main` exists, invoke it (await — it may be async-shaped). *)
+  let has_main = List.exists (function
+    | TopFn fd -> fd.fd_name.name = "main" | _ -> false)
+    program.prog_decls in
+  if has_main then emit_line ctx "await main();";
+  Buffer.contents ctx.output
+
+let codegen_deno (program : program) (symbols : Symbol.t)
+  : (string, string) result =
+  try Ok (generate program symbols)
+  with
+  | Failure msg -> Error ("Deno-ESM codegen error: " ^ msg)
+  | e           -> Error ("Deno-ESM codegen error: " ^ Printexc.to_string e)

--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -154,6 +154,7 @@ let () =
   b "jsonParse"           (fun a -> Printf.sprintf "JSON.parse(%s)" (arg 0 a));
   (* ---- misc host ---- *)
   b "dateNow"     (fun _ -> "Date.now()");
+  b "numToFixed2" (fun a -> Printf.sprintf "(Number(%s) / 1024).toFixed(2)" (arg 0 a));
   b "endsWith"    (fun a -> Printf.sprintf "__as_endsWith(%s, %s)" (arg 0 a) (arg 1 a));
   b "stripSuffix" (fun a -> Printf.sprintf "__as_stripSuffix(%s, %s)" (arg 0 a) (arg 1 a));
   b "wasmInstance" (fun a -> Printf.sprintf "__as_wasmInstance(%s)" (arg 0 a));
@@ -441,12 +442,87 @@ and gen_try ctx body catch finally =
   "(() => { try { return " ^ body_str ^ "; } " ^ catch_str ^ finally_str
   ^ " })()"
 
+(* Unwrap span markers to inspect an expression's real head. *)
+and unspan = function
+  | ExprSpan (e, _) -> unspan e
+  | e -> e
+
+(* Lower an expression in STATEMENT position, where `return` and control
+   flow are real JS statements (not IIFE-wrapped — that was the inherited
+   js_codegen bug: a statement-position `return e;` became
+   `(() => { return e; })();`, discarding the value, so the enclosing
+   function returned undefined). [gen_expr] keeps the IIFE form for the
+   genuine expression-position cases. *)
+and gen_stmt_expr ctx (e : expr) : string =
+  match unspan e with
+  | ExprReturn (Some e) -> "return " ^ gen_expr ctx e ^ ";"
+  | ExprReturn None     -> "return;"
+  | ExprIf { ei_cond; ei_then; ei_else } ->
+      let elseb = match ei_else with
+        | Some e -> " else { " ^ gen_branch ctx e ^ " }"
+        | None   -> ""
+      in
+      "if (" ^ gen_expr ctx ei_cond ^ ") { " ^ gen_branch ctx ei_then
+      ^ " }" ^ elseb
+  | ExprBlock blk -> gen_stmt_seq ctx blk
+  | ExprMatch { em_scrutinee; em_arms } ->
+      gen_match_stmt ctx em_scrutinee em_arms
+  | ExprTry { et_body; et_catch; et_finally } ->
+      gen_try_stmt ctx et_body et_catch et_finally
+  | other -> gen_expr ctx other ^ ";"
+
+(* An if/try/match branch body: splice a block's statements, else treat
+   the expression as a single statement. *)
+and gen_branch ctx e =
+  match unspan e with
+  | ExprBlock blk -> gen_stmt_seq ctx blk
+  | other -> gen_stmt_expr ctx other
+
+and gen_stmt_seq ctx blk =
+  let b = Buffer.create 64 in
+  List.iter (fun s ->
+    Buffer.add_string b (gen_stmt ctx s);
+    Buffer.add_char b ' ') blk.blk_stmts;
+  (match blk.blk_expr with
+   | Some e -> Buffer.add_string b (gen_stmt_expr ctx e)
+   | None   -> ());
+  Buffer.contents b
+
+and gen_match_stmt ctx scrut arms =
+  let sv = "__scrut" in
+  let rec arms_js = function
+    | [] -> "throw new Error(\"non-exhaustive match\");"
+    | arm :: rest ->
+        let cond = gen_pattern_test sv arm.ma_pat in
+        let binds = gen_pattern_bindings sv arm.ma_pat in
+        let guard = match arm.ma_guard with
+          | Some g -> " && (" ^ gen_expr ctx g ^ ")" | None -> "" in
+        "if (" ^ cond ^ guard ^ ") { " ^ binds
+        ^ gen_branch ctx arm.ma_body ^ " } else " ^ arms_js rest
+  in
+  "{ const " ^ sv ^ " = " ^ gen_expr ctx scrut ^ "; " ^ arms_js arms ^ " }"
+
+and gen_try_stmt ctx body catch finally =
+  let b = gen_stmt_seq ctx body in
+  let c = match catch with
+    | None | Some [] -> "catch (__e) { throw __e; }"
+    | Some (arm :: _) ->
+        let bind = match arm.ma_pat with
+          | PatVar id -> "const " ^ mangle id.name ^ " = __e; " | _ -> ""
+        in
+        "catch (__e) { " ^ bind ^ gen_branch ctx arm.ma_body ^ " }"
+  in
+  let f = match finally with
+    | None -> "" | Some blk -> " finally { " ^ gen_stmt_seq ctx blk ^ " }"
+  in
+  "try { " ^ b ^ " } " ^ c ^ f
+
 and gen_stmt ctx (stmt : stmt) : string =
   match stmt with
   | StmtLet { sl_pat; sl_value; sl_mut; sl_quantity = _; sl_ty = _ } ->
       let kw = if sl_mut then "let" else "const" in
       kw ^ " " ^ gen_pattern ctx sl_pat ^ " = " ^ gen_expr ctx sl_value ^ ";"
-  | StmtExpr e -> gen_expr ctx e ^ ";"
+  | StmtExpr e -> gen_stmt_expr ctx e
   | StmtAssign (lhs, op, rhs) ->
       let op_str = match op with
         | AssignEq -> "=" | AssignAdd -> "+=" | AssignSub -> "-="
@@ -457,13 +533,13 @@ and gen_stmt ctx (stmt : stmt) : string =
       "while (" ^ gen_expr ctx cond ^ ") { "
       ^ String.concat " " (List.map (gen_stmt ctx) body.blk_stmts)
       ^ (match body.blk_expr with
-         | Some e -> " " ^ gen_expr ctx e ^ ";" | None -> "")
+         | Some e -> " " ^ gen_stmt_expr ctx e | None -> "")
       ^ " }"
   | StmtFor (pat, iter, body) ->
       "for (const " ^ gen_pattern ctx pat ^ " of " ^ gen_expr ctx iter ^ ") { "
       ^ String.concat " " (List.map (gen_stmt ctx) body.blk_stmts)
       ^ (match body.blk_expr with
-         | Some e -> " " ^ gen_expr ctx e ^ ";" | None -> "")
+         | Some e -> " " ^ gen_stmt_expr ctx e | None -> "")
       ^ " }"
 
 (* ============================================================================

--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -59,6 +59,10 @@ type codegen_ctx = {
      receiver-first free-function source style (the only form the current
      grammar accepts — no [self]/inherent-[impl]) read as real methods. *)
   assoc : (string, string) Hashtbl.t;
+  (* Top-level functions/consts defined in this program. A user
+     definition shadows a same-named host intrinsic ({!deno_builtins}),
+     so e.g. a user `fn len(xs: IntList)` is NOT lowered to `.length`. *)
+  local_fns : (string, unit) Hashtbl.t;
 }
 
 let create_ctx symbols = {
@@ -68,6 +72,7 @@ let create_ctx symbols = {
   externs = Hashtbl.create 32;
   self_name = None;
   assoc = Hashtbl.create 32;
+  local_fns = Hashtbl.create 64;
 }
 
 let emit ctx str = Buffer.add_string ctx.output str
@@ -117,11 +122,29 @@ const __as_readDirNames = (p) => {
   return names;
 };
 const __as_isNotFound = (e) => (e instanceof Deno.errors.NotFound);
-const __as_endsWith = (s, suffix) => String(s).endsWith(suffix);
-const __as_stripSuffix = (s, suffix) =>
-  String(s).endsWith(suffix) ? String(s).slice(0, -suffix.length) : String(s);
 const __as_wasmInstance = (bytes) =>
   new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports;
+// `++` is overloaded (string concat / array concat); `a + b` would
+// stringify arrays. Dispatch on shape so stdlib/string.affine's
+// `result ++ [x]` and `a ++ b` are both correct.
+const __as_concat = (a, b) => Array.isArray(a) ? a.concat(b) : (a + b);
+// Honest host/runtime primitives underpinning the AffineScript-level
+// stdlib/string.affine (its is_empty/starts_with/ends_with/split/join/
+// replace/... are real AffineScript on top of these).
+const __as_strSub = (s, start, n) => String(s).slice(start, start + n);
+const __as_strGet = (s, i) => String(s)[i];
+const __as_strFind = (s, n) => String(s).indexOf(n);
+const __as_charToInt = (c) => String(c).codePointAt(0);
+const __as_intToChar = (n) => String.fromCodePoint(n);
+const __as_parseInt = (s) => {
+  const n = parseInt(String(s), 10);
+  return Number.isNaN(n) ? None : Some(n);
+};
+const __as_parseFloat = (s) => {
+  const n = parseFloat(String(s));
+  return Number.isNaN(n) ? None : Some(n);
+};
+const __as_show = (v) => (typeof v === "string" ? v : JSON.stringify(v));
 // ---- end runtime ----
 
 |}
@@ -154,12 +177,29 @@ let () =
   b "jsonParse"           (fun a -> Printf.sprintf "JSON.parse(%s)" (arg 0 a));
   (* ---- misc host ---- *)
   b "dateNow"     (fun _ -> "Date.now()");
-  b "numToFixed2" (fun a -> Printf.sprintf "(Number(%s) / 1024).toFixed(2)" (arg 0 a));
-  b "endsWith"    (fun a -> Printf.sprintf "__as_endsWith(%s, %s)" (arg 0 a) (arg 1 a));
-  b "stripSuffix" (fun a -> Printf.sprintf "__as_stripSuffix(%s, %s)" (arg 0 a) (arg 1 a));
   b "wasmInstance" (fun a -> Printf.sprintf "__as_wasmInstance(%s)" (arg 0 a));
   (* Generic JS array push helper (returns the array, fluent). *)
-  b "arrayPush" (fun a -> Printf.sprintf "(%s.push(%s), %s)" (arg 0 a) (arg 1 a) (arg 0 a))
+  b "arrayPush" (fun a -> Printf.sprintf "(%s.push(%s), %s)" (arg 0 a) (arg 1 a) (arg 0 a));
+  (* ---- honest string/number primitives underpinning the
+     AffineScript-level stdlib/string.affine. These are intrinsics (no
+     AffineScript definition exists; the interpreter binds them too),
+     not externs — endsWith/stripSuffix/pathJoin/etc. are NOT here:
+     they are real AffineScript built on `ends_with`/`substring`/`++`. *)
+  b "len"            (fun a -> Printf.sprintf "((%s).length)" (arg 0 a));
+  b "string_length"  (fun a -> Printf.sprintf "((%s).length)" (arg 0 a));
+  b "string_get"     (fun a -> Printf.sprintf "__as_strGet(%s, %s)" (arg 0 a) (arg 1 a));
+  b "string_sub"     (fun a -> Printf.sprintf "__as_strSub(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  b "string_find"    (fun a -> Printf.sprintf "__as_strFind(%s, %s)" (arg 0 a) (arg 1 a));
+  b "to_lowercase"   (fun a -> Printf.sprintf "String(%s).toLowerCase()" (arg 0 a));
+  b "to_uppercase"   (fun a -> Printf.sprintf "String(%s).toUpperCase()" (arg 0 a));
+  b "trim"           (fun a -> Printf.sprintf "String(%s).trim()" (arg 0 a));
+  b "int_to_string"  (fun a -> Printf.sprintf "String(%s)" (arg 0 a));
+  b "float_to_string" (fun a -> Printf.sprintf "String(%s)" (arg 0 a));
+  b "parse_int"      (fun a -> Printf.sprintf "__as_parseInt(%s)" (arg 0 a));
+  b "parse_float"    (fun a -> Printf.sprintf "__as_parseFloat(%s)" (arg 0 a));
+  b "char_to_int"    (fun a -> Printf.sprintf "__as_charToInt(%s)" (arg 0 a));
+  b "int_to_char"    (fun a -> Printf.sprintf "__as_intToChar(%s)" (arg 0 a));
+  b "show"           (fun a -> Printf.sprintf "__as_show(%s)" (arg 0 a))
 
 (* ============================================================================
    Identifier sanitisation (JS reserved words -> trailing underscore)
@@ -220,23 +260,34 @@ let rec gen_expr ctx (expr : expr) : string =
               an expression sub-term, so await it (valid: it only occurs
               inside the [async] method bodies we emit). *)
            "(await " ^ recv ^ "." ^ m ^ "(" ^ String.concat ", " rest ^ "))"
+       | ExprVar id
+         when Hashtbl.mem deno_builtins id.name
+              && not (Hashtbl.mem ctx.local_fns id.name) ->
+           (* Honest host/runtime intrinsic (FS/JSON/Date/Wasm extern or
+              a string/number primitive underpinning stdlib/string.affine).
+              Applied to ANY matching call head, not only declared externs,
+              so AffineScript-level stdlib compiled here resolves — but a
+              same-named user definition shadows it (e.g. a user `len`). *)
+           (Hashtbl.find deno_builtins id.name) (List.map (gen_expr ctx) args)
        | ExprVar id when Hashtbl.mem ctx.externs id.name ->
+           (* Declared extern with no intrinsic lowering: assume a
+              same-named host symbol is in scope. *)
            let arg_strs = List.map (gen_expr ctx) args in
-           (match Hashtbl.find_opt deno_builtins id.name with
-            | Some lower -> lower arg_strs
-            | None ->
-                (* Unknown extern: assume a same-named host symbol in scope. *)
-                mangle id.name ^ "(" ^ String.concat ", " arg_strs ^ ")")
+           mangle id.name ^ "(" ^ String.concat ", " arg_strs ^ ")"
        | _ ->
            let arg_strs = List.map (gen_expr ctx) args in
            gen_expr ctx func ^ "(" ^ String.concat ", " arg_strs ^ ")")
+  | ExprBinary (e1, OpConcat, e2) ->
+      (* `++` is string- OR array-concat; dispatch on shape at runtime so
+         `a ++ b` (string) and `acc ++ [x]` (array) are both correct. *)
+      "__as_concat(" ^ gen_expr ctx e1 ^ ", " ^ gen_expr ctx e2 ^ ")"
   | ExprBinary (e1, op, e2) ->
       let op_str = match op with
         | OpAdd -> "+" | OpSub -> "-" | OpMul -> "*" | OpDiv -> "/"
         | OpMod -> "%" | OpEq -> "===" | OpNe -> "!==" | OpLt -> "<"
         | OpLe -> "<=" | OpGt -> ">" | OpGe -> ">=" | OpAnd -> "&&"
         | OpOr -> "||" | OpBitAnd -> "&" | OpBitOr -> "|" | OpBitXor -> "^"
-        | OpShl -> "<<" | OpShr -> ">>" | OpConcat -> "+"
+        | OpShl -> "<<" | OpShr -> ">>" | OpConcat -> "+" (* unreachable *)
       in
       "(" ^ gen_expr ctx e1 ^ " " ^ op_str ^ " " ^ gen_expr ctx e2 ^ ")"
   | ExprUnary (op, e) ->
@@ -734,12 +785,21 @@ let gen_type_decl ctx (td : type_decl) : unit =
 
 let generate (program : program) (symbols : Symbol.t) : string =
   let ctx = create_ctx symbols in
-  (* Register extern names so calls lower via the builtin table. *)
+  (* Register extern names so calls lower via the builtin table, and
+     user-defined top-level names so they shadow host intrinsics. *)
   List.iter (function
     | TopExternFn { ef_name; _ } ->
         Hashtbl.replace ctx.externs ef_name.name ()
     | TopFn fd when fd.fd_body = FnExtern ->
         Hashtbl.replace ctx.externs fd.fd_name.name ()
+    | TopFn fd ->
+        Hashtbl.replace ctx.local_fns fd.fd_name.name ()
+    | TopConst { tc_name; _ } ->
+        Hashtbl.replace ctx.local_fns tc_name.name ()
+    | TopImpl ib ->
+        List.iter (function
+          | ImplFn fd -> Hashtbl.replace ctx.local_fns fd.fd_name.name ()
+          | ImplType _ -> ()) ib.ib_items
     | _ -> ()) program.prog_decls;
 
   emit_line ctx "// Generated by AffineScript compiler (Deno-ESM target, issue #122)";

--- a/lib/dune
+++ b/lib/dune
@@ -8,6 +8,7 @@
   c_codegen
   cafe_face
   codegen
+  codegen_deno
   codegen_gc
   codegen_node
   desugar_traits

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -20,6 +20,18 @@ let mk_span startpos endpos =
 let mk_ident name startpos endpos =
   { name; span = mk_span startpos endpos }
 
+(* issue #122 v2: inherent-impl support. The old grammar pre-committed to
+   `impl_trait_ref? self_ty` where both alternatives start with an ident,
+   so `impl Counter {` (inherent) was a parse error at `{`. The rule now
+   parses one type_expr unconditionally, then an optional `FOR type_expr`;
+   when the `FOR` is present the leading type was the trait. This recovers
+   the trait name/args from that leading type_expr. *)
+let trait_ref_of_type_expr (t : type_expr) : trait_ref =
+  match t with
+  | TyCon id | TyVar id -> { tr_name = id; tr_args = [] }
+  | TyApp (id, args)    -> { tr_name = id; tr_args = args }
+  | _ -> failwith "impl: trait reference must be a named type"
+
 %}
 
 /* Tokens with values */
@@ -535,20 +547,23 @@ fn_sig:
 
 impl_block:
   | IMPL type_params = type_params?
-    trait_ref = impl_trait_ref?
-    self_ty = type_expr
+    head = type_expr
+    forspec = impl_for?
     where_clause = where_clause?
     LBRACE items = list(impl_item) RBRACE
-    { { ib_type_params = Option.value type_params ~default:[];
+    { let trait_ref, self_ty =
+        match forspec with
+        | Some st -> (Some (trait_ref_of_type_expr head), st)
+        | None    -> (None, head)
+      in
+      { ib_type_params = Option.value type_params ~default:[];
         ib_trait_ref = trait_ref;
         ib_self_ty = self_ty;
         ib_where = Option.value where_clause ~default:[];
         ib_items = items } }
 
-impl_trait_ref:
-  | name = ident FOR { { tr_name = name; tr_args = [] } }
-  | name = ident LBRACKET args = separated_list(COMMA, type_arg) RBRACKET FOR
-    { { tr_name = name; tr_args = args } }
+impl_for:
+  | FOR self_ty = type_expr { self_ty }
 
 impl_item:
   | f = fn_decl { ImplFn f }
@@ -646,6 +661,14 @@ expr_primary:
   | FALSE { ExprLit (LitBool (false, mk_span $startpos $endpos)) }
 
   /* Identifiers */
+  /* `self` in expression position (issue #122 v2). The method-receiver
+     param productions already bind a parameter named "self"; this lets
+     the body actually reference it (`self.field`, `self.method(x)`).
+     Without this production SELF_KW had no expression form, so every
+     method body referencing self was a parse error — even
+     stdlib/traits.affine failed to parse. Resolves/typechecks as an
+     ordinary parameter binding named "self". */
+  | SELF_KW { ExprVar (mk_ident "self" $startpos $endpos) }
   | name = lower_ident { ExprVar (mk_ident name $startpos $endpos) }
   /* Struct literal: `Point { x: v, y: w }`.  Must come before the plain
      upper_ident production so Menhir shifts LBRACE rather than reducing

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -918,6 +918,17 @@ pattern_primary:
   | name = upper_ident { PatCon (mk_ident name $startpos $endpos, []) }
   | name = upper_ident LPAREN pats = separated_list(COMMA, pattern) RPAREN
     { PatCon (mk_ident name $startpos(name) $endpos(name), pats) }
+  /* Qualified variant patterns `Type::Variant` / `Type::Variant(p, ..)`
+     (issue #122 v2). The type qualifier is discarded — PatCon carries
+     only the variant name, matching ExprVariant and the codegen tag
+     dispatch (`scrut.tag === "Variant"`). Without these, `match c {
+     Color::Red => .. }` (and stdlib/traits.affine's `Ordering::Less`)
+     was a parse error. */
+  | _ty = upper_ident COLONCOLON name = upper_ident
+    { PatCon (mk_ident name $startpos(name) $endpos(name), []) }
+  | _ty = upper_ident COLONCOLON name = upper_ident
+    LPAREN pats = separated_list(COMMA, pattern) RPAREN
+    { PatCon (mk_ident name $startpos(name) $endpos(name), pats) }
   | LPAREN RPAREN { PatTuple [] }
   | LPAREN p = pattern RPAREN { p }
   | LPAREN p = pattern COMMA ps = separated_nonempty_list(COMMA, pattern) RPAREN

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -869,14 +869,25 @@ let rec synth (ctx : context) (expr : expr) : ty result =
          latter is how stdlib/string.affine's split/join/etc. accumulate.
          Dispatch on the synthesised lhs type. *)
       let* lhs_ty = synth ctx lhs in
-      match repr lhs_ty with
-      | TApp (TCon "Array", [elem]) ->
-        let* () = check ctx rhs (TApp (TCon "Array", [elem])) in
-        Ok (TApp (TCon "Array", [elem]))
-      | _ ->
-        let* () = unify_or_err lhs_ty ty_string in
-        let* () = check ctx rhs ty_string in
-        Ok ty_string
+      (match repr lhs_ty with
+       | TApp (TCon "Array", [elem]) ->
+         let* () = check ctx rhs (TApp (TCon "Array", [elem])) in
+         Ok (TApp (TCon "Array", [elem]))
+       | TCon "String" ->
+         let* () = check ctx rhs ty_string in
+         Ok ty_string
+       | _ ->
+         (* lhs type not yet determined (e.g. `let mut acc = []`):
+            disambiguate on the rhs rather than defaulting to String. *)
+         let* rhs_ty = synth ctx rhs in
+         (match repr rhs_ty with
+          | TApp (TCon "Array", [elem]) ->
+            let* () = unify_or_err lhs_ty (TApp (TCon "Array", [elem])) in
+            Ok (TApp (TCon "Array", [elem]))
+          | _ ->
+            let* () = unify_or_err lhs_ty ty_string in
+            let* () = unify_or_err rhs_ty ty_string in
+            Ok ty_string))
     end else begin
       let (lhs_ty, rhs_ty, result_ty) = type_of_binop op in
       let* () = check ctx lhs lhs_ty in

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -749,10 +749,21 @@ let rec synth (ctx : context) (expr : expr) : ty result =
   (* Field access — first try record-field projection, then trait method lookup *)
   | ExprField (obj, { name = field; _ }) ->
     let* obj_ty = synth ctx obj in
+    (* Auto-deref reference/owned wrappers before record projection
+       (issue #122 v2): `c.field` where `c : ref/own/mut S` projects the
+       field of S — the borrow checker still governs aliasing separately.
+       Without this, `fn(c: ref S) = c.field` failed with
+       "Field 'field' not found in type ref {...}". *)
+    let rec strip_ref t =
+      match repr t with
+      | TRef u | TMut u | TOwn u -> strip_ref u
+      | u -> u
+    in
+    let obj_ty_deref = strip_ref obj_ty in
     let field_ty = fresh_tyvar ctx.level in
     let rest_row = fresh_rowvar ctx.level in
     let expected_record = TRecord (RExtend (field, field_ty, rest_row)) in
-    begin match Unify.unify (repr obj_ty) expected_record with
+    begin match Unify.unify (repr obj_ty_deref) expected_record with
     | Ok () -> Ok field_ty
     | Error _ ->
       (* Record projection failed — try trait method dispatch.

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -863,6 +863,20 @@ let rec synth (ctx : context) (expr : expr) : ty result =
         let* () = unify_or_err lhs_ty lhs_ty' in
         let* () = check ctx rhs rhs_ty in
         Ok result_ty
+    end else if (match op with OpConcat -> true | _ -> false) then begin
+      (* `++` is polymorphic over String and [T] (issue #122 v2.5):
+         `a ++ b` (string concat) and `acc ++ [x]` (array concat) — the
+         latter is how stdlib/string.affine's split/join/etc. accumulate.
+         Dispatch on the synthesised lhs type. *)
+      let* lhs_ty = synth ctx lhs in
+      match repr lhs_ty with
+      | TApp (TCon "Array", [elem]) ->
+        let* () = check ctx rhs (TApp (TCon "Array", [elem])) in
+        Ok (TApp (TCon "Array", [elem]))
+      | _ ->
+        let* () = unify_or_err lhs_ty ty_string in
+        let* () = check ctx rhs ty_string in
+        Ok ty_string
     end else begin
       let (lhs_ty, rhs_ty, result_ty) = type_of_binop op in
       let* () = check ctx lhs lhs_ty in
@@ -1180,8 +1194,35 @@ let register_builtins (ctx : context) : unit =
   bind_var ctx "max" int_binop;
   bind_var ctx "min" int_binop;
   bind_var ctx "pow_float" float_binop;
+  (* `len` is polymorphic over String and [T] (issue #122 v2.5):
+     stdlib/string.affine calls `len` on both. Broadened from
+     Array[tv]->Int to 'a->Int (matches the interpreter's dynamic len;
+     the codegen lowers it to `.length`, valid for string and array). *)
   bind_var ctx "len" (let tv = fresh_tyvar 0 in
-    TArrow (TApp (TCon "Array", [tv]), QOmega, ty_int, EPure));
+    TArrow (tv, QOmega, ty_int, EPure));
+  (* Honest string/char primitives underpinning stdlib/string.affine
+     (issue #122 v2.5). Concrete String/Char types; the Deno-ESM backend
+     lowers each to a JS intrinsic. char ::= TCon "Char". *)
+  let ty_char = TCon "Char" in
+  let opt t = TApp (TCon "Option", [t]) in
+  bind_var ctx "string_get"
+    (TArrow (ty_string, QOmega, TArrow (ty_int, QOmega, ty_char, EPure), EPure));
+  bind_var ctx "string_sub"
+    (TArrow (ty_string, QOmega,
+       TArrow (ty_int, QOmega,
+         TArrow (ty_int, QOmega, ty_string, EPure), EPure), EPure));
+  bind_var ctx "string_find"
+    (TArrow (ty_string, QOmega,
+       TArrow (ty_string, QOmega, ty_int, EPure), EPure));
+  bind_var ctx "to_lowercase" (TArrow (ty_string, QOmega, ty_string, EPure));
+  bind_var ctx "to_uppercase" (TArrow (ty_string, QOmega, ty_string, EPure));
+  bind_var ctx "trim"         (TArrow (ty_string, QOmega, ty_string, EPure));
+  bind_var ctx "parse_int"    (TArrow (ty_string, QOmega, opt ty_int, EPure));
+  bind_var ctx "parse_float"  (TArrow (ty_string, QOmega, opt ty_float, EPure));
+  bind_var ctx "char_to_int"  (TArrow (ty_char, QOmega, ty_int, EPure));
+  bind_var ctx "int_to_char"  (TArrow (ty_int, QOmega, ty_char, EPure));
+  bind_var ctx "show"
+    (let tv = fresh_tyvar 0 in TArrow (tv, QOmega, ty_string, EPure));
   bind_var ctx "panic" (TArrow (ty_string, QOmega, ty_never, EPure));
   bind_var ctx "exit" (TArrow (ty_int, QOmega, ty_never, ESingleton "IO"));
   (* TEA runtime — accepts any record, returns unit with IO effect *)

--- a/stdlib/Deno.affine
+++ b/stdlib/Deno.affine
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Deno.affine — issue #122 host bindings for the Deno-ESM backend.
+//
+// Unlike stdlib/Vscode.affine (issue #35), these externs are NOT a
+// wasm-FFI surface with an Int-handle/readString contract. The
+// `--deno-esm` backend (lib/codegen_deno.ml) is a *direct* AST → ES
+// module transpiler with no wasm boundary, so each `extern fn` below is
+// lowered, at compile time, straight to its host expression:
+//
+//   writeTextFile(p, c)  ->  Deno.writeTextFileSync(p, c)
+//   jsonParse(s)         ->  JSON.parse(s)
+//   dateNow()            ->  Date.now()
+//   ...
+//
+// The lowering table lives in lib/codegen_deno.ml (`deno_builtins`);
+// the non-trivial leaves are emitted inlined into every module's
+// prelude so the output is genuinely drop-in (no runtime adapter, no
+// extra package to resolve). packages/affine-deno/mod.js mirrors the
+// same surface as a standalone ESM module for `deno test`.
+//
+// All FS operations are synchronous (`Deno.*Sync`). `await` on a
+// synchronously-returned value is valid JS, so an async-shaped consumer
+// (e.g. hyperpolymath/ubicity) keeps working without an async-extern
+// ABI (issue #103 — documented future work, not required here).
+//
+// Names here MUST match the `deno_builtins` table keys exactly; an
+// unmatched extern silently falls through to a same-named host symbol.
+
+module Deno;
+
+// ── Opaque host value types ────────────────────────────────────────
+//
+// `Json` is any structured JS value (object/array/string/number/bool/
+// null) crossing the boundary opaquely — the AffineScript side never
+// inspects it, it only routes it between JSON.* and the host. `Bytes`
+// is a Uint8Array; `WasmExports` is an instantiated module's exports.
+
+pub extern type Json;
+pub extern type Bytes;
+pub extern type WasmExports;
+
+// ── Filesystem (synchronous) ───────────────────────────────────────
+
+/// `Deno.writeTextFileSync(path, content)`. Returns 0.
+pub extern fn writeTextFile(path: String, content: String) -> Int;
+
+/// `Deno.readTextFileSync(path)`. Throws on missing file — pair with
+/// `isNotFound` in a `try`/`catch` for the not-found-is-null pattern.
+pub extern fn readTextFile(path: String) -> String;
+
+/// `Deno.readFileSync(path)` — raw bytes (for wasm modules).
+pub extern fn readFileBytes(path: String) -> Bytes;
+
+/// `Deno.removeSync(path)`. Throws if absent (catch + `isNotFound`).
+pub extern fn removePath(path: String) -> Int;
+
+/// `Deno.mkdirSync(path, { recursive: true })`.
+pub extern fn mkdirRecursive(path: String) -> Int;
+
+/// mkdir -p that swallows AlreadyExists (idempotent ensure-directory).
+pub extern fn ensureDir(path: String) -> Int;
+
+/// Names of the *file* entries in `path` (skips sub-directories).
+pub extern fn readDirNames(path: String) -> [String];
+
+/// `Deno.statSync(path).size` in bytes.
+pub extern fn statSize(path: String) -> Int;
+
+// ── Path ───────────────────────────────────────────────────────────
+
+/// Single-segment join with a `/` separator (idempotent on a trailing
+/// slash). Sufficient for the storage-layout use-case.
+pub extern fn pathJoin(a: String, b: String) -> String;
+
+// ── Error classification ───────────────────────────────────────────
+
+/// `e instanceof Deno.errors.NotFound` — the only error class the
+/// storage layer special-cases (missing file/dir => null/empty).
+pub extern fn isNotFound(e: Json) -> Bool;
+
+// ── JSON ───────────────────────────────────────────────────────────
+
+pub extern fn jsonStringify(v: Json) -> String;
+
+/// `JSON.stringify(v, null, 2)` — the on-disk pretty form.
+pub extern fn jsonStringifyPretty(v: Json) -> String;
+
+pub extern fn jsonParse(s: String) -> Json;
+
+/// JS `null` as an opaque Json (the not-found / absent sentinel).
+pub extern fn jsonNull() -> Json;
+
+/// Opaque field/index read: `value[key]`. The boundary primitive for
+/// treating an arbitrary host JS value as data without the AffineScript
+/// side modelling its shape (e.g. `experience.id`).
+pub extern fn jsonGet(value: Json, key: String) -> Json;
+pub extern fn jsonGetStr(value: Json, key: String) -> String;
+
+/// Nullish default — `x ?? d`. Preserves a JS default parameter when
+/// the caller omits the argument.
+pub extern fn orDefault(x: String, d: String) -> String;
+
+/// Kilobyte display string: `(bytes / 1024).toFixed(2)`. Runtime number
+/// formatting is an honest host primitive (cf. Rust `format!`).
+pub extern fn kbString(bytes: Int) -> String;
+
+// ── Misc host ──────────────────────────────────────────────────────
+
+/// `Date.now()` — epoch millis (used for timestamped report names).
+pub extern fn dateNow() -> Int;
+
+/// `(Number(bytes) / 1024).toFixed(2)` — kilobyte display string.
+pub extern fn numToFixed2(bytes: Int) -> String;
+
+pub extern fn endsWith(s: String, suffix: String) -> Bool;
+
+/// `s` with a trailing `suffix` removed (no-op if absent).
+pub extern fn stripSuffix(s: String, suffix: String) -> String;
+
+// ── WebAssembly (synchronous instantiate) ──────────────────────────
+
+/// `new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports`.
+pub extern fn wasmInstance(bytes: Bytes) -> WasmExports;
+
+// ── Array helper ───────────────────────────────────────────────────
+//
+// AffineScript has no mutable-array push primitive in this subset;
+// this fluent helper appends and returns the array so accumulation
+// reads functionally: `acc = arrayPush(acc, x)`.
+
+pub extern fn arrayPush(arr: [Json], v: Json) -> [Json];

--- a/tests/codegen-deno/class_basic.affine
+++ b/tests/codegen-deno/class_basic.affine
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 Phase 1 regression: Deno-ESM backend.
+//
+// Exercises: struct + receiver-first free fns -> `export class` (the
+// current grammar accepts neither inherent `impl` nor a `self`
+// expression, so methods are free functions taking the struct first);
+// constructor synthesis from a struct-returning fn; cross-method calls
+// (`Counter_*` -> `this.*`); `extern fn` lowering (jsonStringify ->
+// JSON.stringify); `pub fn`/`pub const`/`pub enum` -> `export`.
+//
+// Pure logic only (no FS / print), so it runs under plain Node ESM —
+// CI has Node 20 but no Deno.
+
+pub extern fn jsonStringify(v: Int) -> String;
+
+struct Counter { start: Int }
+
+pub fn Counter_new(start: Int) -> Counter = Counter { start: start };
+
+pub fn Counter_bumped(c: Counter, by: Int) -> Int = c.start + by;
+
+pub fn Counter_bumpedTwice(c: Counter, by: Int) -> Int =
+  Counter_bumped(c, by) + by;
+
+pub fn Counter_encodedStart(c: Counter) -> String = jsonStringify(c.start);
+
+pub fn double(x: Int) -> Int = x * 2;
+
+pub const ANSWER: Int = 42;
+
+pub enum Color { Red, Green, Blue }

--- a/tests/codegen-deno/class_basic.harness.mjs
+++ b/tests/codegen-deno/class_basic.harness.mjs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 Phase 1 — Node-ESM harness for the Deno-ESM backend.
+// Runnable with plain `node` (the generated module only touches the
+// `Deno` global lazily inside unused helpers; nothing here calls them).
+import assert from "node:assert/strict";
+import {
+  Counter,
+  double,
+  ANSWER,
+  Red,
+  Green,
+} from "./class_basic.deno.js";
+
+// struct + receiver-first fns -> class with synthesised constructor
+const c = new Counter(10);
+assert.equal(c.start, 10, "constructor assigns field");
+
+// receiver-first fn -> async method, `c.start` -> `this.start`
+assert.equal(await c.bumped(5), 15, "method reads this.start");
+
+// cross-method call: Counter_bumped(c, by) -> this.bumped(by)
+assert.equal(await c.bumpedTwice(5), 20, "cross-method this.* call");
+
+// extern fn lowering: jsonStringify -> JSON.stringify
+assert.equal(await c.encodedStart(), "10", "extern lowered to JSON.stringify");
+
+// pub fn / pub const / pub enum -> export
+assert.equal(double(21), 42, "free pub fn export");
+assert.equal(ANSWER, 42, "pub const export");
+assert.deepEqual(Red, { tag: "Red" }, "nullary enum variant");
+assert.deepEqual(Green, { tag: "Green" }, "nullary enum variant");
+
+console.log("class_basic.harness.mjs OK");

--- a/tests/codegen-deno/control_flow.affine
+++ b/tests/codegen-deno/control_flow.affine
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 v2.1 regression: statement-position `return` and control
+// flow must lower to real JS statements, not a discarded IIFE.
+// (Inherited js_codegen bug: `return e;` -> `(() => { return e; })();`
+// so the enclosing function returned undefined.)
+
+pub fn sum_to(n: Int) -> Int {
+  let mut acc = 0;
+  let mut i = 1;
+  while i <= n {
+    acc = acc + i;
+    i = i + 1;
+  }
+  return acc;
+}
+
+pub fn classify(n: Int) -> String {
+  if n < 0 {
+    return "neg";
+  }
+  if n == 0 {
+    return "zero";
+  }
+  return "pos";
+}
+
+pub fn first_even(xs: [Int]) -> Int {
+  for x in xs {
+    if x % 2 == 0 {
+      return x;
+    }
+  }
+  return 0 - 1;
+}

--- a/tests/codegen-deno/control_flow.harness.mjs
+++ b/tests/codegen-deno/control_flow.harness.mjs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 v2.1 — statement-position return / control flow.
+import assert from "node:assert/strict";
+import { sum_to, classify, first_even } from "./control_flow.deno.js";
+
+assert.equal(sum_to(5), 15, "while-loop + trailing return");
+assert.equal(sum_to(0), 0, "while-loop zero iterations");
+assert.equal(classify(-3), "neg", "early return in if (neg)");
+assert.equal(classify(0), "zero", "early return in if (zero)");
+assert.equal(classify(7), "pos", "fallthrough return (pos)");
+assert.equal(first_even([1, 3, 4, 7]), 4, "return inside for+if");
+assert.equal(first_even([1, 3, 5]), -1, "fallthrough after loop");
+
+console.log("control_flow.harness.mjs OK");

--- a/tests/codegen-deno/match_enum.affine
+++ b/tests/codegen-deno/match_enum.affine
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 v2.4 regression: qualified `Type::Variant` patterns in
+// match arms (nullary + payload), as both `= match {..};` expression
+// bodies and recursive functions. Previously a parse error
+// (pattern_primary had no `Type::Variant` production).
+
+pub enum Color { Red, Green, Blue }
+
+pub fn rank(c: Color) -> Int = match c {
+  Color::Red => 1,
+  Color::Green => 2,
+  Color::Blue => 3
+};
+
+pub enum IntList { Nil, Cons(Int, IntList) }
+
+pub fn len(xs: IntList) -> Int {
+  match xs {
+    IntList::Nil => 0,
+    IntList::Cons(h, t) => 1 + len(t)
+  }
+}
+
+pub fn sum(xs: IntList) -> Int {
+  match xs {
+    IntList::Nil => 0,
+    IntList::Cons(h, t) => h + sum(t)
+  }
+}
+
+// Construction uses the bare enum-factory names (Nil / Cons) emitted by
+// the enum codegen; qualified `Type::Variant` is exercised in the match
+// patterns above (the v2.4 feature under test).
+pub fn demo_list() -> IntList = Cons(10, Cons(20, Cons(30, Nil)));

--- a/tests/codegen-deno/match_enum.harness.mjs
+++ b/tests/codegen-deno/match_enum.harness.mjs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 v2.4 — qualified Type::Variant patterns + recursive ADTs.
+import assert from "node:assert/strict";
+import { rank, Red, Blue, len, sum, demo_list } from "./match_enum.deno.js";
+
+assert.equal(rank(Red), 1, "match expr-body, nullary qualified pattern");
+assert.equal(rank(Blue), 3, "match expr-body, last arm");
+
+const xs = demo_list(); // Cons(10, Cons(20, Cons(30, Nil)))
+assert.equal(len(xs), 3, "recursive len over ADT, payload pattern");
+assert.equal(sum(xs), 60, "recursive sum binds payload (h, t)");
+
+console.log("match_enum.harness.mjs OK");

--- a/tests/codegen-deno/ref_fields.affine
+++ b/tests/codegen-deno/ref_fields.affine
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 v2.3 regression: struct field access through ref/own/mut
+// receivers must typecheck (auto-deref before record projection).
+// Previously `fn(c: ref S) = c.field` failed: "Field 'field' not found
+// in type ref {...}".
+
+struct Point { x: Int, y: Int }
+
+pub fn mk_point(x: Int, y: Int) -> Point = Point { x: x, y: y };
+
+pub fn sum_ref(p: ref Point) -> Int = p.x + p.y;
+
+pub fn get_x_own(p: own Point) -> Int = p.x;
+
+pub fn get_y_mut(p: mut Point) -> Int = p.y;

--- a/tests/codegen-deno/ref_fields.harness.mjs
+++ b/tests/codegen-deno/ref_fields.harness.mjs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 v2.3 — field access through ref/own/mut receivers.
+// mk_point returns Point (constructor); sum_ref/get_x_own/get_y_mut
+// take Point first (ref/own/mut) so they synthesise as Point methods —
+// exercising auto-deref field access *and* class synthesis together.
+import assert from "node:assert/strict";
+import { Point } from "./ref_fields.deno.js";
+
+const p = new Point(3, 4);
+assert.equal(p.x, 3, "constructor assigns x");
+assert.equal(p.y, 4, "constructor assigns y");
+assert.equal(await p.sum_ref(), 7, "field access through ref receiver");
+assert.equal(await p.get_x_own(), 3, "field access through own receiver");
+assert.equal(await p.get_y_mut(), 4, "field access through mut receiver");
+
+console.log("ref_fields.harness.mjs OK");

--- a/tests/codegen-deno/string_prims.affine
+++ b/tests/codegen-deno/string_prims.affine
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 v2.5 regression: the honest string/number primitive layer
+// (len/string_sub/string_find/int_to_string + `++` shape dispatch) that
+// lets stdlib/string.affine — real AffineScript — run under Deno-ESM.
+// These mirror the exact primitives stdlib/string.affine is built on.
+
+pub fn ends_with2(s: String, suffix: String) -> Bool {
+  let slen = len(s);
+  let sfxlen = len(suffix);
+  if sfxlen > slen {
+    return false;
+  }
+  return string_sub(s, slen - sfxlen, sfxlen) == suffix;
+}
+
+pub fn strip_suffix(s: String, suffix: String) -> String {
+  if ends_with2(s, suffix) {
+    return string_sub(s, 0, len(s) - len(suffix));
+  }
+  return s;
+}
+
+pub fn find(s: String, needle: String) -> Int = string_find(s, needle);
+
+pub fn n2s(n: Int) -> String = int_to_string(n);
+
+pub fn str_cat(a: String, b: String) -> String = a ++ b;
+
+pub fn arr_cat(xs: [Int]) -> [Int] = xs ++ [99];

--- a/tests/codegen-deno/string_prims.harness.mjs
+++ b/tests/codegen-deno/string_prims.harness.mjs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// issue #122 v2.5 — honest string/number primitive lowering + `++` shape
+// dispatch (string concat vs array concat).
+import assert from "node:assert/strict";
+import {
+  ends_with2,
+  strip_suffix,
+  find,
+  n2s,
+  str_cat,
+  arr_cat,
+} from "./string_prims.deno.js";
+
+assert.equal(ends_with2("foo.json", ".json"), true, "string_sub/len ends_with");
+assert.equal(ends_with2("foo.txt", ".json"), false, "negative ends_with");
+assert.equal(ends_with2("a", ".json"), false, "suffix longer than string");
+assert.equal(strip_suffix("foo.json", ".json"), "foo", "strip_suffix");
+assert.equal(strip_suffix("foo", ".json"), "foo", "strip_suffix no-op");
+assert.equal(find("ab.cd", "."), 2, "string_find");
+assert.equal(n2s(42), "42", "int_to_string");
+assert.equal(str_cat("a", "b"), "ab", "`++` string concat");
+assert.deepEqual(arr_cat([1, 2]), [1, 2, 99], "`++` array concat (not '1,299')");
+
+console.log("string_prims.harness.mjs OK");

--- a/tools/run_codegen_deno_tests.sh
+++ b/tools/run_codegen_deno_tests.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: PMPL-1.0-or-later
+# issue #122 — Deno-ESM backend regression runner.
+#
+# Mirrors tools/run_codegen_wasm_tests.sh: for every fixture in
+# tests/codegen-deno/, compile FILE.affine -> FILE.deno.js with the
+# --deno-esm backend, then run every *.harness.mjs with `node`.
+#
+# Node is used (not deno) deliberately: CI provisions Node 20 but not
+# Deno, and the Phase 1 fixtures are pure logic — the generated module
+# only references the `Deno` global lazily inside helper bodies that the
+# harnesses never call, so plain Node ESM exercises them faithfully.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$ROOT_DIR/tests/codegen-deno"
+
+if [ -x "$ROOT_DIR/_build/default/bin/main.exe" ]; then
+  COMPILE_CMD=("$ROOT_DIR/_build/default/bin/main.exe" compile)
+elif command -v affinescript >/dev/null 2>&1; then
+  COMPILE_CMD=(affinescript compile)
+else
+  COMPILE_CMD=(dune exec affinescript -- compile)
+fi
+
+echo "Using compiler: ${COMPILE_CMD[*]}"
+
+for src in "$TEST_DIR"/*.affine; do
+  out="${src%.affine}.deno.js"
+  echo "Compiling $(basename "$src") -> $(basename "$out")"
+  "${COMPILE_CMD[@]}" "$src" -o "$out" --deno-esm
+done
+
+echo ""
+echo "Running Deno-ESM harnesses (node)"
+for js in "$TEST_DIR"/*.harness.mjs; do
+  echo "node $(basename "$js")"
+  (cd "$TEST_DIR" && node "$(basename "$js")")
+done
+
+echo "All codegen Deno-ESM tests passed."


### PR DESCRIPTION
## Deno-ESM target + grammar-v2 build-out (Refs #122, #35, #103)

A **direct AffineScript-AST → ES-module backend** (`--deno-esm` /
`.deno.js`) plus the language fixes needed to make it produce genuinely
drop-in, dependency-free `.js` for JSON/FS-orchestration consumers
(motivating consumer: `hyperpolymath/ubicity`).

### Why a direct transpiler (not a wasm-wrapping ESM shim)

ubicity's `storage.ts`/`wasm-bridge.ts` is pure JS-value orchestration:
`JSON.stringify` of opaque objects, `JSON.parse` back to JS objects
returned to JS callers. AffineScript's wasm ABI is i32-only — opaque JS
objects/`JSON.stringify` cannot cross it. So source-to-source emission,
where `extern fn` lowers to direct host calls and struct+functions lower
to a real `export class`, is the correct architecture.

### Commits

| | |
|---|---|
| `caf11fe` | Deno-ESM backend: `export` for pub fn/const/enum; `extern fn` → inlined host-call lowering table; struct + receiver-first free fns → `export class` (constructor + `async` methods + cross-method `this.*`). `--deno-esm` flag + `.deno.js` ext in both dispatch paths. `tests/codegen-deno/` + runner + CI step. |
| `76bafec` | Fix inherited js_codegen bug: statement-position `return`/`if`/`match`/`try` were IIFE-wrapped (value discarded → functions returned `undefined`). Distinct statement-position lowering. |
| `3f39c3f` | Grammar: `self` expression production + inherent `impl Type {}` (was unparseable — even `stdlib/traits.affine` failed). |
| `d2578fe` | Typecheck: auto-deref `ref`/`own`/`mut` for struct field access (`fn(c: ref S) = c.x`). |
| `36e7a3d` | Grammar: qualified `Type::Variant` patterns in match arms (recursive ADTs, `Ordering::Less`, …). |
| `925edeb` | Polymorphic `++` (String \| `[T]`) + `len`; bound the honest string/char primitives; codegen intrinsic-lowering layer with user-definition shadow guard. So AffineScript-level string logic compiles through the static pipeline. |

### Verification

- `dune build` clean. `dune runtest` held at the **same 2 pre-existing
  `E2E Node-CJS --vscode-extension` failures** (#116/#117 territory) on
  pristine HEAD *and* every commit here — **214 tests, zero regressions
  introduced by this branch**.
- New `tests/codegen-deno/` suite (5 fixtures + Node harnesses, wired
  into CI via `tools/run_codegen_deno_tests.sh`): class synthesis,
  control flow/return, qualified-variant ADTs, ref/own/mut fields,
  string-primitive layer + `++` shape dispatch — all green under Node 20
  (CI has no Deno; fixtures are pure logic).
- `use Deno::{…}` proven to compile to clean drop-in ESM
  (`Deno.writeTextFileSync`, `JSON.parse(...)`).

### Scope / follow-up

`Refs #122` — **not** `Closes` (requirements-target; only the
maintainer closes it). The `ubicity` consumer migration + `ubicity#30`
is the remaining tracked work (separate repo; needs a couple more
opaque-`Json`-field / nullable-return primitives, scoped in the issue).
The 2 pre-existing vscode-cjs `dune runtest` failures are out of #122
scope (#116/#117). Local-only `dune-workspace` `-no-pie` workaround is
git-ignored, not committed. `affinescript.opam` dedup left unstaged
(pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
