### PR TITLE
fix: green dune runtest — correct vscode-off-by-default e2e false positive (Refs #116, #117)

### DIFF
--- a/lib/codegen_node.ml
+++ b/lib/codegen_node.ml
@@ -228,10 +228,10 @@ function _buildImports() {
       return 0;
     },
   };
-  // Phase 2 hook: callers can replace exports.extraImports with a function
-  // returning a `{ ModuleName: { exportName: fn, ... } }` map of concrete
-  // host bindings (e.g. the @hyperpolymath/affine-vscode adapter). Default
-  // is empty so the shim works standalone.
+  // Phase 2 hook: a caller may install an `extraImports` factory on the
+  // exports object returning a `{ ModuleName: { exportName: fn, ... } }`
+  // map of concrete host bindings (this is what the --vscode-extension
+  // wiring installs). Default is empty so the shim works standalone.
   const extras = (typeof exports.extraImports === "function")
     ? exports.extraImports()
     : %s;

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -2851,8 +2851,11 @@ let test_vscode_extension_off_by_default () =
   let cjs = cjs_of activate_src in
   Alcotest.(check bool) "no extraImports assignment without the flag"
     false (contains cjs "exports.extraImports = function");
+  (* Assert the absence of the actual adapter *wiring* (the require
+     call), not the bare specifier string — the latter legitimately
+     appears in an explanatory comment and is not adapter wiring. *)
   Alcotest.(check bool) "no adapter require without the flag"
-    false (contains cjs "@hyperpolymath/affine-vscode")
+    false (contains cjs {|require("@hyperpolymath/affine-vscode")|})
 
 let test_vscode_extension_inlines_wiring () =
   let cjs = cjs_of ~vscode_extension:true activate_src in


### PR DESCRIPTION
fix(test/codegen-node): correct false-positive in vscode-off-by-default e2e (Refs #116, #117)

The 2 long-standing red `dune runtest` cases (E2E Node-CJS Codegen 2 &
4, "no adapter require without the flag") were a **false positive**, not
a real codegen defect: `emit_node_cjs` already emits the
`--vscode-extension` wiring *only* when the flag is set. The failure was
the assertion doing a bare-substring `contains cjs
"@hyperpolymath/affine-vscode"` — which matched an *explanatory comment*
in the default `_buildImports`, not any adapter `require`/wiring.

Fix (both, defence-in-depth, behaviour unchanged):
- Tighten the assertion to the actual wiring token
  `require("@hyperpolymath/affine-vscode")` so it tests intent ("no
  adapter *require* without the flag") and won't false-trip on docs.
- Reword the default `_buildImports` comment so generated standalone
  shims no longer embed the resolvable adapter specifier (a grep/audit
  for the adapter shouldn't flag every standalone .cjs either).

Result: `dune runtest` is now 214 tests / 0 failures (was 2 pre-existing
failures present since before #123). Deno-ESM harness suite unaffected.
Pre-existing since the #116/#117 --vscode-extension flag work; unrelated
to the #122 Deno-ESM track but was the only red on affinescript main.

Refs #116, #117.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
