### PR TITLE
ci: fix nonexistent actions/upload-artifact SHA pin (Refs standards#48)

### DIFF
--- a/affinescript-vite/.github/workflows/hypatia-scan.yml
+++ b/affinescript-vite/.github/workflows/hypatia-scan.yml
@@ -74,7 +74,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json

--- a/affinescript-vite/.github/workflows/static-analysis-gate.yml
+++ b/affinescript-vite/.github/workflows/static-analysis-gate.yml
@@ -105,7 +105,7 @@ jobs:
           echo "Skipped: panic-attack not available in this environment." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload panic-attack findings
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: panic-attack-findings
           path: panic-attack-findings.json
@@ -218,7 +218,7 @@ jobs:
           echo "Skipped: Hypatia scanner not available in this environment." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload hypatia findings
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json
@@ -306,7 +306,7 @@ jobs:
           echo "Skipped: panic-attack not available in this environment." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload bridge report
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bridge-report
           path: bridge-report.json
@@ -404,7 +404,7 @@ jobs:
           echo "low=$LOW"           >> "$GITHUB_OUTPUT"
 
       - name: Upload unified findings (fleet scanner picks these up)
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unified-findings
           path: findings/unified-findings.json

--- a/affinescriptiser/.github/workflows/hypatia-scan.yml
+++ b/affinescriptiser/.github/workflows/hypatia-scan.yml
@@ -76,7 +76,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json

--- a/affinescriptiser/.github/workflows/static-analysis-gate.yml
+++ b/affinescriptiser/.github/workflows/static-analysis-gate.yml
@@ -105,7 +105,7 @@ jobs:
           echo "Skipped: panic-attack not available in this environment." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload panic-attack findings
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: panic-attack-findings
           path: panic-attack-findings.json
@@ -217,7 +217,7 @@ jobs:
           echo "Skipped: Hypatia scanner not available in this environment." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload hypatia findings
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json
@@ -300,7 +300,7 @@ jobs:
           echo "low=$LOW"           >> "$GITHUB_OUTPUT"
 
       - name: Upload unified findings (fleet scanner picks these up)
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unified-findings
           path: findings/unified-findings.json

--- a/road-skate/.github/workflows/hypatia-scan.yml
+++ b/road-skate/.github/workflows/hypatia-scan.yml
@@ -74,7 +74,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json

--- a/road-skate/.github/workflows/static-analysis-gate.yml
+++ b/road-skate/.github/workflows/static-analysis-gate.yml
@@ -105,7 +105,7 @@ jobs:
           echo "Skipped: panic-attack not available in this environment." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload panic-attack findings
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: panic-attack-findings
           path: panic-attack-findings.json
@@ -218,7 +218,7 @@ jobs:
           echo "Skipped: Hypatia scanner not available in this environment." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload hypatia findings
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json
@@ -306,7 +306,7 @@ jobs:
           echo "Skipped: panic-attack not available in this environment." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload bridge report
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bridge-report
           path: bridge-report.json
@@ -404,7 +404,7 @@ jobs:
           echo "low=$LOW"           >> "$GITHUB_OUTPUT"
 
       - name: Upload unified findings (fleet scanner picks these up)
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unified-findings
           path: findings/unified-findings.json


### PR DESCRIPTION
Bulk remediation for hyperpolymath/standards#48.

`actions/upload-artifact` was pinned to `65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478` which **does not exist** in `actions/upload-artifact`, breaking every affected workflow at *Set up job*. Replaced with the real **v4.6.2** SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` (the pin already used by the canonical rsr-template-repo / v3-templater generators).

SHA-only replacement; pre-existing version comments left intact (cosmetic).

Refs hyperpolymath/standards#48 — per standards#66 protocol this PR uses `Refs` (not `Closes`); joint-close only on explicit agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)