### PR TITLE
fix(stdlib): prelude unwrap/unwrap_result diverge via panic (#134)

### DIFF
--- a/stdlib/prelude.affine
+++ b/stdlib/prelude.affine
@@ -25,10 +25,7 @@ fn is_none<T>(opt: Option<T>) -> Bool {
 fn unwrap<T>(opt: Option<T>) -> T {
   match opt {
     Some(value) => value,
-    None => {
-      println("Called unwrap on None");
-      // TODO: panic!() once implemented
-    }
+    None => panic("Called unwrap on None")
   }
 }
 
@@ -62,10 +59,7 @@ fn is_err<T, E>(res: Result<T, E>) -> Bool {
 fn unwrap_result<T, E>(res: Result<T, E>) -> T {
   match res {
     Ok(value) => value,
-    Err(_) => {
-      println("Called unwrap on Err");
-      // TODO: panic!() once implemented
-    }
+    Err(_) => panic("Called unwrap on Err")
   }
 }
 

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -774,12 +774,55 @@ let test_interp_full_pipeline () =
   | Error msg -> Alcotest.fail msg
   | Ok _env -> ()
 
+(* Issue #134: prelude `unwrap`/`unwrap_result` previously only println'd on
+   None/Err and fell through returning Unit (unsound for a `-> T` signature).
+   They must now diverge via `panic`. These assert the panic path. *)
+let test_unwrap_none_panics () =
+  let src = {|
+type Option<T> = Some(T) | None
+fn unwrap<T>(opt: Option<T>) -> T {
+  match opt {
+    Some(value) => value,
+    None => panic("Called unwrap on None")
+  }
+}
+const result: Int = unwrap(None);
+|} in
+  let prog = Parse_driver.parse_string ~file:"<test>" src in
+  match Interp.eval_program prog with
+  | Ok _ -> Alcotest.fail "expected unwrap(None) to panic; evaluation succeeded"
+  | Error (Value.RuntimeError msg) ->
+      Alcotest.(check string) "panic message" "Called unwrap on None" msg
+  | Error e -> Alcotest.failf "expected RuntimeError, got: %s"
+                 (Value.show_eval_error e)
+
+let test_unwrap_result_err_panics () =
+  let src = {|
+type Result<T, E> = Ok(T) | Err(E)
+fn unwrap_result<T, E>(res: Result<T, E>) -> T {
+  match res {
+    Ok(value) => value,
+    Err(_) => panic("Called unwrap on Err")
+  }
+}
+const result: Int = unwrap_result(Err("boom"));
+|} in
+  let prog = Parse_driver.parse_string ~file:"<test>" src in
+  match Interp.eval_program prog with
+  | Ok _ -> Alcotest.fail "expected unwrap_result(Err) to panic; evaluation succeeded"
+  | Error (Value.RuntimeError msg) ->
+      Alcotest.(check string) "panic message" "Called unwrap on Err" msg
+  | Error e -> Alcotest.failf "expected RuntimeError, got: %s"
+                 (Value.show_eval_error e)
+
 let interp_tests = [
   Alcotest.test_case "simple evaluation" `Quick test_interp_simple;
   Alcotest.test_case "bitwise"    `Quick test_interp_bitwise;
   Alcotest.test_case "arithmetic" `Quick test_interp_arithmetic;
   Alcotest.test_case "lambda" `Quick test_interp_lambda;
   Alcotest.test_case "full pipeline" `Quick test_interp_full_pipeline;
+  Alcotest.test_case "#134 unwrap(None) panics" `Quick test_unwrap_none_panics;
+  Alcotest.test_case "#134 unwrap_result(Err) panics" `Quick test_unwrap_result_err_panics;
 ]
 
 (* ============================================================================


### PR DESCRIPTION
## What

Fixes #134 (independent sub-item of the #128 stdlib-AOT epic). `prelude.affine`'s `unwrap`/`unwrap_result` only `println`'d on the `None`/`Err` arm then fell through, returning Unit from a `-> T` signature — an interpreter-era soundness bug (the `Unify.TypeMismatch (T, Unit)` seen during #128 triage).

## How

Replace the `println` + fall-through arms with `panic(...)` — the existing `panic(String) -> Never` builtin, matching what `option.affine` / `result.affine` already do. The failure arm now has type `Never`, so the typed return is sound.

## Verification

- Two new interpreter tests assert the panic path: `unwrap(None)` and `unwrap_result(Err _)` each raise the documented `RuntimeError`.
- Full suite green: **216 tests**, zero regressions.

Independent of the other #128 sub-items. Closes #134. Refs #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)