### PR TITLE
fix(stdlib): single-ownership dedup of prelude/option/result (#133)

### DIFF
--- a/stdlib/option.affine
+++ b/stdlib/option.affine
@@ -3,7 +3,14 @@
 //
 // Option - Utilities for Option<T> type
 
-// Option type is defined in prelude, but here are utilities
+module option;
+
+// `Option`/`Result` types + constructors are owned by `prelude` (ADR-011).
+use prelude::{Option, Some, None, Result, Ok, Err};
+
+// This module is the single canonical home for the Option *operations*
+// (is_some/is_none/unwrap/unwrap_or/map/filter/contains/…). #133 removed
+// the duplicate copies that previously also lived in prelude.affine.
 
 // ============================================================================
 // Combinators

--- a/stdlib/prelude.affine
+++ b/stdlib/prelude.affine
@@ -2,73 +2,23 @@
 // AffineScript Standard Library - Prelude
 // Common functions and utilities automatically available
 
+module prelude;
+
 // ============================================================================
-// Option type - represents optional values
+// Core sum types (canonical home — ADR-011)
+//
+// `Option` and `Result` (and their constructors) are owned here, the
+// foundational module. The `option` / `result` modules provide the
+// *operations* over them and `use prelude::{...}` for the types. The
+// duplicate/conflicting Option/Result ops that previously lived here
+// (is_some, is_none, unwrap, unwrap_or, is_ok, is_err, unwrap_result,
+// unwrap_or_result) were removed in #133: option::* and result::* are
+// the single canonical bindings for those.
 // ============================================================================
 
 type Option<T> = Some(T) | None
 
-fn is_some<T>(opt: Option<T>) -> Bool {
-  match opt {
-    Some(_) => true,
-    None => false
-  }
-}
-
-fn is_none<T>(opt: Option<T>) -> Bool {
-  match opt {
-    Some(_) => false,
-    None => true
-  }
-}
-
-fn unwrap<T>(opt: Option<T>) -> T {
-  match opt {
-    Some(value) => value,
-    None => panic("Called unwrap on None")
-  }
-}
-
-fn unwrap_or<T>(opt: Option<T>, default: T) -> T {
-  match opt {
-    Some(value) => value,
-    None => default
-  }
-}
-
-// ============================================================================
-// Result type - represents success or failure
-// ============================================================================
-
 type Result<T, E> = Ok(T) | Err(E)
-
-fn is_ok<T, E>(res: Result<T, E>) -> Bool {
-  match res {
-    Ok(_) => true,
-    Err(_) => false
-  }
-}
-
-fn is_err<T, E>(res: Result<T, E>) -> Bool {
-  match res {
-    Ok(_) => false,
-    Err(_) => true
-  }
-}
-
-fn unwrap_result<T, E>(res: Result<T, E>) -> T {
-  match res {
-    Ok(value) => value,
-    Err(_) => panic("Called unwrap on Err")
-  }
-}
-
-fn unwrap_or_result<T, E>(res: Result<T, E>, default: T) -> T {
-  match res {
-    Ok(value) => value,
-    Err(_) => default
-  }
-}
 
 // ============================================================================
 // List utilities

--- a/stdlib/result.affine
+++ b/stdlib/result.affine
@@ -3,7 +3,15 @@
 //
 // Result - Error handling with Result<T, E> type
 
-// Result type is defined in prelude, but here are utilities
+module result;
+
+// `Option`/`Result` types + constructors are owned by `prelude` (ADR-011).
+use prelude::{Result, Ok, Err, Option, Some, None};
+
+// This module is the single canonical home for the Result *operations*
+// (is_ok/is_err/unwrap/unwrap_or/map_ok/map_err/…). #133 removed the
+// duplicate/redundant copies (is_ok/is_err/unwrap_result/unwrap_or_result)
+// that previously also lived in prelude.affine.
 
 // ============================================================================
 // Constructors and Conversions


### PR DESCRIPTION
## What

Fixes #133 — removes the duplicate & signature-divergent definitions across `prelude`/`option`/`result` so there is exactly one canonical binding per name, per ADR-011 (#132): real modules + single ownership.

## Ownership

| Module | Owns |
|---|---|
| `prelude` | core sum types `Option`/`Result` (+ ctors); generic list/numeric utils (`map`(arr), `filter`(arr), `fold`, `contains`(arr), `sum`, `min`, `range`, …) |
| `option` | all Option ops (`is_some`/`is_none`/`unwrap`/`unwrap_or`/`map`/`filter`/`contains`/…) |
| `result` | all Result ops (`is_ok`/`is_err`/`unwrap`/`unwrap_or`/`map_ok`/…) |

`prelude.affine` drops the 8 duplicate/conflicting Option/Result ops it previously also defined; `option`/`result` declare `module` + `use prelude::{…}` for the types.

The old flat-namespace conflicts (`prelude.map(arr,f)` vs `option.map(f,opt)`; `prelude.unwrap`(Option) vs `result.unwrap`(Result)) are now `module::name` — exactly one definition per owning module ("or properly module-qualified ones", per the issue).

## Verification

- No leftover duplicate defs; no retained prelude util calls a removed op.
- Full suite green: **214 tests**, zero regressions.

## Merge note

This removes the `prelude` `unwrap`/`unwrap_result` that #134 (PR #150) patched. The sound, panicking versions are `option::unwrap` / `result::unwrap` (already correct); #150's regression tests stay valid against those. If #150 lands first, resolve the modify/delete in `prelude.affine` in favour of this deletion.

Depends on the #132 decision (ADR-011). Closes #133. Refs #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)