### PR TITLE
feat(parser): slice/range index e[a:b] (#135 slice 2)

### DIFF
--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -211,6 +211,8 @@ let () =
      not externs — endsWith/stripSuffix/pathJoin/etc. are NOT here:
      they are real AffineScript built on `ends_with`/`substring`/`++`. *)
   b "len"            (fun a -> Printf.sprintf "((%s).length)" (arg 0 a));
+  b "slice"          (fun a -> Printf.sprintf "((%s).slice(%s, %s))"
+                                 (arg 0 a) (arg 1 a) (arg 2 a));
   b "string_length"  (fun a -> Printf.sprintf "((%s).length)" (arg 0 a));
   b "string_get"     (fun a -> Printf.sprintf "__as_strGet(%s, %s)" (arg 0 a) (arg 1 a));
   b "string_sub"     (fun a -> Printf.sprintf "__as_strSub(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));

--- a/lib/interp.ml
+++ b/lib/interp.ml
@@ -526,6 +526,23 @@ let create_initial_env () : env =
       | _ -> Error (TypeMismatch "len expects array or string")
     ));
 
+    (* slice(coll, lo, hi) — issue #135 slice 2. Half-open [lo, hi);
+       negative indices count from the end; bounds are clamped (JS .slice
+       semantics, matching the Deno-ESM backend lowering). *)
+    ("slice", VBuiltin ("slice", fun args ->
+      let norm n i = if i < 0 then max 0 (n + i) else min i n in
+      match args with
+      | [VArray arr; VInt lo; VInt hi] ->
+        let n = Array.length arr in
+        let lo = norm n lo and hi = norm n hi in
+        Ok (VArray (if hi > lo then Array.sub arr lo (hi - lo) else [||]))
+      | [VString s; VInt lo; VInt hi] ->
+        let n = String.length s in
+        let lo = norm n lo and hi = norm n hi in
+        Ok (VString (if hi > lo then String.sub s lo (hi - lo) else ""))
+      | _ -> Error (TypeMismatch "slice expects (array|string, Int, Int)")
+    ));
+
     (* -- String builtins --------------------------------------------------- *)
     ("string_get", VBuiltin ("string_get", fun args ->
       match args with

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -645,6 +645,23 @@ expr_postfix:
   | e = expr_postfix DOT field = field_name { ExprField (e, field) }
   | e = expr_postfix DOT n = INT { ExprTupleIndex (e, n) }
   | e = expr_postfix LBRACKET idx = expr RBRACKET { ExprIndex (e, idx) }
+  /* Slice / range index (issue #135 slice 2): `e[a:b]`, `e[a:]`, `e[:b]`,
+     `e[:]`.  Desugars to the `slice` builtin (a -> Int -> Int -> a; lowered
+     to JS `.slice` on the Deno-ESM backend, like `len`).  No new AST node:
+     missing low = 0, missing high = `len(e)`.  Used by stdlib/option.affine
+     (`list[1:]`) and stdlib/collections.affine. */
+  | e = expr_postfix LBRACKET lo = expr COLON hi = expr RBRACKET
+    { ExprApp (ExprVar (mk_ident "slice" $startpos $endpos), [e; lo; hi]) }
+  | e = expr_postfix LBRACKET lo = expr COLON RBRACKET
+    { ExprApp (ExprVar (mk_ident "slice" $startpos $endpos),
+               [e; lo; ExprApp (ExprVar (mk_ident "len" $startpos $endpos), [e])]) }
+  | e = expr_postfix LBRACKET COLON hi = expr RBRACKET
+    { ExprApp (ExprVar (mk_ident "slice" $startpos $endpos),
+               [e; ExprLit (LitInt (0, mk_span $startpos $endpos)); hi]) }
+  | e = expr_postfix LBRACKET COLON RBRACKET
+    { ExprApp (ExprVar (mk_ident "slice" $startpos $endpos),
+               [e; ExprLit (LitInt (0, mk_span $startpos $endpos));
+                ExprApp (ExprVar (mk_ident "len" $startpos $endpos), [e])]) }
   | e = expr_postfix LPAREN args = separated_list(COMMA, expr) RPAREN { ExprApp (e, args) }
   | e = expr_postfix BACKSLASH field = field_name { ExprRowRestrict (e, field) }
   | e = expr_postfix QUESTION { ExprTry { et_body = { blk_stmts = []; blk_expr = Some e };

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -56,7 +56,7 @@ let create_context () : context =
   (* Console I/O *)
   def "print"; def "println"; def "eprint"; def "eprintln";
   (* String / char builtins *)
-  def "len"; def "string_get"; def "string_sub"; def "string_find";
+  def "len"; def "slice"; def "string_get"; def "string_sub"; def "string_find";
   def "char_to_int"; def "int_to_char"; def "show";
   def "to_lowercase"; def "to_uppercase"; def "trim";
   def "int_to_string"; def "float_to_string"; def "string_length";

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -1220,6 +1220,13 @@ let register_builtins (ctx : context) : unit =
       sc_body = body_of tv }
   in
   bind_scheme ctx "len" (poly1 (fun a -> TArrow (a, QOmega, ty_int, EPure)));
+  (* slice : a -> Int -> Int -> a  (issue #135 slice 2; arrays and strings,
+     mirroring `len`'s permissive `a`).  Curried like other builtin schemes. *)
+  bind_scheme ctx "slice"
+    (poly1 (fun a ->
+       TArrow (a, QOmega,
+         TArrow (ty_int, QOmega,
+           TArrow (ty_int, QOmega, a, EPure), EPure), EPure)));
   (* Honest string/char primitives underpinning stdlib/string.affine
      (issue #122 v2.5). Concrete String/Char types; the Deno-ESM backend
      lowers each to a JS intrinsic. char ::= TCon "Char". *)

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -3318,6 +3318,19 @@ let test_fn_lambda_typed_block () =
     (parse_check_passes
        {|fn use_it() -> Int { let g = fn(x: Int) -> Int { x }; return g(2); }|})
 
+(* Issue #135 slice 2: slice/range index `e[a:b]` / `e[a:]` / `e[:b]` / `e[:]`
+   desugars to the `slice` builtin. Used by option.affine (`list[1:]`) and
+   collections.affine. Plain `e[i]` indexing must be unaffected. *)
+let test_slice_full_range () =
+  Alcotest.(check bool) "xs[1:3] / xs[1:] / xs[:2] / xs[:] parse + typecheck" true
+    (parse_check_passes
+       {|fn s(xs: [Int]) -> [Int] { let a = xs[1:3]; let b = xs[1:]; let c = xs[:2]; return xs[:]; }|})
+
+let test_slice_index_not_regressed () =
+  Alcotest.(check bool) "plain xs[0] index still parses + typechecks" true
+    (parse_check_passes
+       {|fn idx(xs: [Int]) -> Int { return xs[0]; }|})
+
 let test_multi_arg_arrow () =
   Alcotest.(check bool) "(A, B) -> C parses + typechecks" true
     (parse_check_passes
@@ -3368,6 +3381,8 @@ let type_syntax_sugar_tests = [
   Alcotest.test_case "fn(x) => x (#135 fn-lambda expr)"       `Quick test_fn_lambda_arrow_expr;
   Alcotest.test_case "fn(x) => e as arg (#135 fn-lambda)"     `Quick test_fn_lambda_higher_order;
   Alcotest.test_case "fn(x:Int) -> Int { } (#135 fn-lambda)"  `Quick test_fn_lambda_typed_block;
+  Alcotest.test_case "xs[a:b]/[a:]/[:b]/[:] (#135 slice 2)"   `Quick test_slice_full_range;
+  Alcotest.test_case "xs[0] index non-regressed (#135 sl.2)"  `Quick test_slice_index_not_regressed;
   Alcotest.test_case "(A, B) -> C (multi-arg arrow)"          `Quick test_multi_arg_arrow;
   Alcotest.test_case "(A, B) without arrow remains tuple"     `Quick test_tuple_type_still_works;
 ]


### PR DESCRIPTION
## What
#135 slice 2. Adds slice/range index `e[a:b]` / `e[a:]` / `e[:b]` / `e[:]` (used by `option.affine` `list[1:]` and `collections.affine`).

## How
No new AST node (`ExprIndex` reaches ~20 files incl. every codegen). The parser desugars to a `slice` builtin (missing low=0, missing high=`len(e)`), registered like `len` at the four standard points: `resolve.ml`, `typecheck.ml` (`a -> Int -> Int -> a`), `interp.ml` (JS-`.slice` semantics: half-open, negative-from-end, clamped), `codegen_deno.ml` (→ `.slice`).

## Verification
- `option.affine` 238 → 320, `collections.affine` 24 → 40 (further distinct later-slice defects, tracked in the triage doc).
- Plain `e[i]` indexing unaffected; **zero new grammar conflicts** (identical menhir counts).
- 2 regression tests; full suite green (**225 tests**).

Advances #135 (does not close). Refs #128, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)