### PR TITLE
fix(stdlib): rename try->attempt, ref->make_ref (#135 slice 6)

### DIFF
--- a/stdlib/effects.affine
+++ b/stdlib/effects.affine
@@ -18,7 +18,9 @@ extern fn read_file(path: String) -> String / io;
 extern fn write_file(path: String, content: String) -> Unit / io;
 
 // Built-in State operations
-extern fn ref<T>(x: T) -> Ref<T> / state;
+// `make_ref` (not `ref`) because `ref` is a reserved ownership keyword;
+// see #135 keyword-as-identifier slice.
+extern fn make_ref<T>(x: T) -> Ref<T> / state;
 extern fn get<T>(r: Ref<T>) -> T / state;
 extern fn set<T>(r: Ref<T>, x: T) -> Unit / state;
 

--- a/stdlib/result.affine
+++ b/stdlib/result.affine
@@ -225,8 +225,10 @@ fn result_or<T, E>(a: Result<T, E>, b: Result<T, E>) -> Result<T, E> {
 // Error Handling Patterns
 // ============================================================================
 
-/// Try block emulation - execute function and catch panics as Err
-fn try<T>(f: () -> T) -> Result<T, String> {
+/// Try block emulation - execute function and catch panics as Err.
+/// Named `attempt` (not `try`) because `try` is a reserved keyword
+/// (try/catch/finally); see #135 keyword-as-identifier slice.
+fn attempt<T>(f: () -> T) -> Result<T, String> {
   // TODO: Requires exception handling support
   try {
     Ok(f())


### PR DESCRIPTION
## What
#135 slice 6 — keyword-as-identifier. `result.affine fn try<T>` (`try` = try/catch keyword) → `attempt`; `effects.affine extern fn ref<T>` (`ref` = ownership keyword) → `make_ref`.

Pure stdlib rename — **zero grammar/compiler change, zero risk**. No other stdlib file referenced the old names (verified). The triage doc recommended rename (local + safe) over a broad contextual-keyword grammar change.

## Verification
Both files clear the keyword parse wall and advance to deeper, distinct later-slice defects (`result` → empty-array `(T,Int)` = slice 7; `effects` → generic-extern kind-checking). Suite unaffected (stdlib-only change; 226 green).

Advances #135 (does not close). Refs #128, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)