### PR TITLE
fix(stdlib): rename as param -> xs in collections (#135 slice 6b)

### DIFF
--- a/stdlib/collections.affine
+++ b/stdlib/collections.affine
@@ -37,23 +37,23 @@ fn drop<T>(n: Int, list: [T]) -> [T] {
 }
 
 /// Zip two lists together
-fn zip<A, B>(as: [A], bs: [B]) -> [(A, B)] {
-  if len(as) == 0 || len(bs) == 0 {
+fn zip<A, B>(xs: [A], bs: [B]) -> [(A, B)] {
+  if len(xs) == 0 || len(bs) == 0 {
     []
   } else {
-    [(as[0], bs[0])] ++ zip(as[1:], bs[1:])
+    [(xs[0], bs[0])] ++ zip(xs[1:], bs[1:])
   }
 }
 
 /// Unzip a list of pairs
 fn unzip<A, B>(pairs: [(A, B)]) -> ([A], [B]) {
-  let as = [];
+  let xs = [];
   let bs = [];
   for (a, b) in pairs {
-    as = as ++ [a];
+    xs = xs ++ [a];
     bs = bs ++ [b];
   }
-  (as, bs)
+  (xs, bs)
 }
 
 /// Find first element matching predicate


### PR DESCRIPTION
#135 slice 6b — keyword-as-identifier. zip/unzip used `as` (AS keyword) as a param/var name; renamed to `xs`. Pure stdlib rename, zero risk. collections.affine clears its last parse wall (PARSE 40 → RESOLVE). Refs #128, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)