### PR TITLE
fix(stdlib): module visibility + imports per ADR-011 (#135 slice 8)

### DIFF
--- a/stdlib/collections.affine
+++ b/stdlib/collections.affine
@@ -3,6 +3,12 @@
 //
 // Collections - Advanced list, array, and data structure operations
 
+module collections;
+
+// `Option` + constructors and the generic list utilities are owned by
+// `prelude` (ADR-011); collections is a consumer module (#135 slice 8).
+use prelude::{Option, Some, None, filter, map, range, any};
+
 // ============================================================================
 // List Operations
 // ============================================================================

--- a/stdlib/option.affine
+++ b/stdlib/option.affine
@@ -6,7 +6,7 @@
 module option;
 
 // `Option`/`Result` types + constructors are owned by `prelude` (ADR-011).
-use prelude::{Option, Some, None, Result, Ok, Err};
+use prelude::{Option, Some, None, Result, Ok, Err, map};
 
 // This module is the single canonical home for the Option *operations*
 // (is_some/is_none/unwrap/unwrap_or/map/filter/contains/…). #133 removed

--- a/stdlib/prelude.affine
+++ b/stdlib/prelude.affine
@@ -16,15 +16,15 @@ module prelude;
 // the single canonical bindings for those.
 // ============================================================================
 
-type Option<T> = Some(T) | None
+pub type Option<T> = Some(T) | None
 
-type Result<T, E> = Ok(T) | Err(E)
+pub type Result<T, E> = Ok(T) | Err(E)
 
 // ============================================================================
 // List utilities
 // ============================================================================
 
-fn map<T, U>(arr: [T], f: T -> U) -> [U] {
+pub fn map<T, U>(arr: [T], f: T -> U) -> [U] {
   let mut result = [];
   for x in arr {
     result = result ++ [f(x)];
@@ -32,7 +32,7 @@ fn map<T, U>(arr: [T], f: T -> U) -> [U] {
   result
 }
 
-fn filter<T>(arr: [T], predicate: T -> Bool) -> [T] {
+pub fn filter<T>(arr: [T], predicate: T -> Bool) -> [T] {
   let mut result = [];
   for x in arr {
     if predicate(x) {
@@ -42,7 +42,7 @@ fn filter<T>(arr: [T], predicate: T -> Bool) -> [T] {
   result
 }
 
-fn fold<T, U>(arr: [T], init: U, f: (U, T) -> U) -> U {
+pub fn fold<T, U>(arr: [T], init: U, f: (U, T) -> U) -> U {
   let mut acc = init;
   for x in arr {
     acc = f(acc, x);
@@ -51,7 +51,7 @@ fn fold<T, U>(arr: [T], init: U, f: (U, T) -> U) -> U {
 }
 
 /// Conforms to aLib collection/contains spec v1.0
-fn contains<T>(arr: [T], element: T) -> Bool {
+pub fn contains<T>(arr: [T], element: T) -> Bool {
   for x in arr {
     if x == element {
       return true;
@@ -60,11 +60,11 @@ fn contains<T>(arr: [T], element: T) -> Bool {
   false
 }
 
-fn sum(arr: [Int]) -> Int {
+pub fn sum(arr: [Int]) -> Int {
   fold(arr, 0, |acc, x| acc + x)
 }
 
-fn product(arr: [Int]) -> Int {
+pub fn product(arr: [Int]) -> Int {
   fold(arr, 1, |acc, x| acc * x)
 }
 
@@ -72,15 +72,15 @@ fn product(arr: [Int]) -> Int {
 // Comparison and ordering
 // ============================================================================
 
-fn min(a: Int, b: Int) -> Int {
+pub fn min(a: Int, b: Int) -> Int {
   if a < b { a } else { b }
 }
 
-fn max(a: Int, b: Int) -> Int {
+pub fn max(a: Int, b: Int) -> Int {
   if a > b { a } else { b }
 }
 
-fn clamp(value: Int, min_val: Int, max_val: Int) -> Int {
+pub fn clamp(value: Int, min_val: Int, max_val: Int) -> Int {
   if value < min_val {
     min_val
   } else if value > max_val {
@@ -94,11 +94,11 @@ fn clamp(value: Int, min_val: Int, max_val: Int) -> Int {
 // Boolean utilities
 // ============================================================================
 
-fn not(b: Bool) -> Bool {
+pub fn not(b: Bool) -> Bool {
   if b { false } else { true }
 }
 
-fn all(arr: [Bool]) -> Bool {
+pub fn all(arr: [Bool]) -> Bool {
   for b in arr {
     if not(b) {
       return false;
@@ -107,7 +107,7 @@ fn all(arr: [Bool]) -> Bool {
   true
 }
 
-fn any(arr: [Bool]) -> Bool {
+pub fn any(arr: [Bool]) -> Bool {
   for b in arr {
     if b {
       return true;
@@ -120,7 +120,7 @@ fn any(arr: [Bool]) -> Bool {
 // Range and iteration utilities
 // ============================================================================
 
-fn range(start: Int, end: Int) -> [Int] {
+pub fn range(start: Int, end: Int) -> [Int] {
   let mut result = [];
   let mut i = start;
   while i < end {
@@ -130,7 +130,7 @@ fn range(start: Int, end: Int) -> [Int] {
   result
 }
 
-fn repeat<T>(value: T, n: Int) -> [T] {
+pub fn repeat<T>(value: T, n: Int) -> [T] {
   let mut result = [];
   let mut i = 0;
   while i < n {

--- a/stdlib/result.affine
+++ b/stdlib/result.affine
@@ -6,7 +6,7 @@
 module result;
 
 // `Option`/`Result` types + constructors are owned by `prelude` (ADR-011).
-use prelude::{Result, Ok, Err, Option, Some, None};
+use prelude::{Result, Ok, Err, Option, Some, None, map};
 
 // This module is the single canonical home for the Result *operations*
 // (is_ok/is_err/unwrap/unwrap_or/map_ok/map_err/…). #133 removed the
@@ -187,7 +187,7 @@ fn partition_results<T, E>(results: [Result<T, E>]) -> ([T], [E]) {
 
 /// Try to apply function to all elements, collecting errors
 fn try_map<T, U, E>(f: T -> Result<U, E>, list: [T]) -> Result<[U], E> {
-  let results = map(f, list);
+  let results = map(list, f);
   collect(results)
 }
 


### PR DESCRIPTION
## What
#135 slice 8 — module visibility/imports per ADR-011.

- **prelude.affine** public API now `pub` (Option/Result + 14 utils); was non-`pub` → importers hit `Resolve.VisibilityError`.
- **result/option**: `use prelude::{…, map}` (both call prelude `map`).
- **collections.affine**: add `module collections;` + `use prelude::{Option,Some,None,filter,map,range,any}` (had no module/use).
- **result `try_map`**: `map(f,list)` → `map(list,f)` — genuine stdlib bug (prelude `map` is `(arr,f)`), surfaced once imports resolved.

## Result
**`prelude.affine` compiles end-to-end.** result/option/collections clear ALL import-resolution. `result` now reaches typecheck (deeper issue, separate). `collections` hits a **distinct pre-existing defect**: the resolver has no forward-reference support between top-level fns (repro'd even without `module`) — a new resolver slice, not slice 8. `io` still needs cross-module `split` (slice-8 tail).

Full suite green (**230 tests**), no regression. Advances #135 (does not close). Refs #128, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)