### PR TITLE
fix(typecheck): infer Ref<T> kind as arity-1 ctor (#135 slice 10)

### DIFF
--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -311,7 +311,7 @@ let rec infer_kind (ctx : context) (ty : ty) : kind result =
     end
   | TCon name ->
     begin match name with
-      | "Array" | "Option" | "List" | "Vec" | "Cmd" -> Ok (KArrow (KType, KType))
+      | "Array" | "Option" | "List" | "Vec" | "Cmd" | "Ref" -> Ok (KArrow (KType, KType))
       | "Result" -> Ok (KArrow (KType, KArrow (KType, KType)))
       | _ -> Ok KType
     end


### PR DESCRIPTION
## Slice 10 — effects.affine kind-check

effects.affine externs (make_ref/get/set) use Ref<T>, an undeclared opaque type constructor from the `state` effect. infer_kind hardcodes opaque ctors (Array|Option|List|Vec|Cmd arity-1, Result arity-2) and falls back to KType otherwise, so TApp(Ref,[T]) hit check_kind_app's NotImplemented "Too many arguments for kind".

Ref is the direct analogue of Cmd (Stage-11 opaque effect ctor already in the list). Fix = add Ref to the arity-1 arm. One line, matches precedent.

### Verification
- effects.affine compiles resolve->typecheck
- Full stdlib sweep: 12/19 green (was 11), zero regression — all previously-green files still pass.

Refs #128