### PR TITLE
fix(stdlib): rename total var to tot (#135 slice 4)

### DIFF
--- a/stdlib/math.affine
+++ b/stdlib/math.affine
@@ -351,18 +351,18 @@ fn mean(values: [Float]) -> Float {
   if n == 0 {
     return 0.0;
   }
-  let total = 0.0;
+  let mut tot = 0.0;
   for v in values {
-    total = total + v;
+    tot = tot + v;
   }
-  total / to_float(n)
+  tot / to_float(n)
 }
 
 /// Sum of a list of floats
 fn sum_float(values: [Float]) -> Float {
-  let total = 0.0;
+  let mut tot = 0.0;
   for v in values {
-    total = total + v;
+    tot = tot + v;
   }
-  total
+  tot
 }

--- a/stdlib/testing.affine
+++ b/stdlib/testing.affine
@@ -299,11 +299,11 @@ fn bench(f: () -> (), iterations: Int) -> BenchResult {
     i = i + 1;
   }
 
-  let total = time_now() - start;
+  let tot = time_now() - start;
   {
     iterations: iterations,
-    total_time: total,
-    avg_time: total / (iterations + 0.0)
+    total_time: tot,
+    avg_time: tot / (iterations + 0.0)
   }
 }
 


### PR DESCRIPTION
#135 slice 4. The triage hypothesised a block/statement LR ambiguity for testing.affine:302 / math.affine:354. Precise isolation disproved that — every minimal block/stmt shape parses. Real cause: keyword-as-identifier (slice-6 class) — total is the TOTAL reserved keyword (totality marker). "let total = 0.0;" fails to parse; "let tot = 0.0;" parses.

Renamed the total variable to tot in math.affine (mean/sum_float; also let mut — they reassign in a loop) and testing.affine (bench). The total_time record field is a distinct identifier (left unchanged); string-literal text untouched. Pure stdlib rename — zero grammar/compiler risk.

Verification: math.affine PARSE 354 to RESOLVE (trunc undefined — distinct); testing.affine PARSE 302 to TYPECHECK (distinct deeper defect). Both clear the parse wall. traits.affine:124 is unrelated (while-let pattern binding — genuine separate construct, still tracked). Full suite green (233 tests), stdlib-only, no regression.

Advances #135 (does not close). Refs #128, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)