### PR TITLE
fix(stdlib): Iterator collect uses list not nonexistent Vec (#135 slice 4-traits)

### DIFF
--- a/stdlib/traits.affine
+++ b/stdlib/traits.affine
@@ -119,11 +119,13 @@ pub trait Iterator {
     return n;
   }
 
-  /// Collect into Vec
-  pub fn collect(mut self) -> Vec[Item] {
-    let mut result = Vec::new();
+  /// Collect into a list.  (`Vec` is not a stdlib type; the stdlib
+  /// builds lists with `[]` + `++`, as in prelude/option/result —
+  /// #135 slice 4-traits.)
+  pub fn collect(mut self) -> [Item] {
+    let mut result = [];
     while let Some(item) = self.next() {
-      result.push(item);
+      result = result ++ [item];
     }
     return result;
   }


### PR DESCRIPTION
traits.affine:124 was the last parse blocker. Not a compiler gap — `while let` already parses. Broken stdlib code: `Iterator::collect` returned `Vec[Item]` / used `Vec::new()`/`.push()` but Vec is not defined anywhere in the stdlib (it uses `[]`+`++` everywhere else). Rewrote `collect` in the stdlib's own list idiom instead of adding speculative Vec + associated-fn grammar. traits.affine PARSE 124 -> TYPECHECK (remaining ref-vs-Int is a distinct deeper defect). Pure stdlib, suite unaffected. Refs #128, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)