### PR TITLE
fix(resolve): seed `trunc` builtin in resolver context (#135)

### DIFF
--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -64,6 +64,7 @@ let create_context () : context =
   (* Numeric coercions and math *)
   def "int"; def "float";
   def "sqrt"; def "cbrt"; def "pow_float"; def "floor"; def "ceil"; def "round";
+  def "trunc";
   def "abs"; def "max"; def "min";
   def "sin"; def "cos"; def "tan"; def "atan"; def "atan2";
   def "exp"; def "log"; def "log10"; def "log2";


### PR DESCRIPTION
`trunc` is a genuine runtime builtin (interp.ml:674, kernel_sublang builtin set) but missing from the resolver builtin-seed list (siblings floor/ceil/round are seeded), so math.affine failed resolution with `UndefinedVariable "trunc"`. One-line fix: `def "trunc"`.

Verified isolated on origin/main @651cc12: math.affine clears the **resolve** stage (remaining Int/Float TypeMismatch is a separate pre-existing math typecheck bug, out of scope). Full stdlib sweep zero regression.

Refs #128