### PR TITLE
fix(main): thread imported type schemes into check_program (#135)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -181,11 +181,13 @@ let check_file face json path =
       (match Affinescript.Resolve.resolve_program_with_loader prog loader with
       | Error (e, span) ->
         add (Affinescript.Json_output.of_resolve_error e span)
-      | Ok (resolve_ctx, _type_ctx) ->
+      | Ok (resolve_ctx, type_ctx) ->
         (* Phase B+C: capture symbol table and use-site references. *)
         symbols_table := Some resolve_ctx.symbols;
         resolve_refs := List.rev resolve_ctx.references;
-        (match Affinescript.Typecheck.check_program resolve_ctx.symbols prog with
+        (match Affinescript.Typecheck.check_program
+                 ~import_types:type_ctx.Affinescript.Typecheck.name_types
+                 resolve_ctx.symbols prog with
         | Error e ->
           add (Affinescript.Json_output.of_type_error e)
         | Ok _ctx ->
@@ -229,8 +231,10 @@ let check_file face json path =
         Format.eprintf "@[<v>Resolution error: %s@]@."
           (Affinescript.Face.format_resolve_error face e);
         `Error (false, "Resolution error")
-      | Ok (resolve_ctx, _type_ctx) ->
-        (match Affinescript.Typecheck.check_program resolve_ctx.symbols prog with
+      | Ok (resolve_ctx, type_ctx) ->
+        (match Affinescript.Typecheck.check_program
+                 ~import_types:type_ctx.Affinescript.Typecheck.name_types
+                 resolve_ctx.symbols prog with
         | Error e ->
           Format.eprintf "@[<v>%s@]@."
             (Affinescript.Face.format_type_error face e);


### PR DESCRIPTION
`check_file` discarded the resolve `type_ctx` and called `check_program` without `?import_types` → cross-module imported values resolved but were 'Unbound variable' at typecheck. Now passes `~import_types:type_ctx.name_types` in both branches.

Completes the ADR-011 cross-module value-import path at typecheck (io + every `use prelude::{...}` consumer). Suite **233/233**, zero regression; stdlib 12/19 (io/collections/result now fail deeper at genuine type level — progress, no green regressed).

Refs #128