### PR TITLE
fix(stdlib): io.affine reassigned locals need let mut (#128)

### DIFF
--- a/stdlib/io.affine
+++ b/stdlib/io.affine
@@ -38,8 +38,8 @@ use string::{ split, join };
 ///   printf("Hello, {}! You are {} years old.", ["Alice", 30])
 fn printf(format: String, args: [Any]) -> () {
   let flen = len(format);
-  let arg_idx = 0;
-  let i = 0;
+  let mut arg_idx = 0;
+  let mut i = 0;
 
   while i < flen {
     if i + 1 < flen && string_sub(format, i, 2) == "{}" {
@@ -124,7 +124,7 @@ extern fn remove_dir(path: String) -> Result<(), String>;
 
 /// Join path components with the system separator (/)
 fn path_join(components: [String]) -> String {
-  let result = "";
+  let mut result = "";
   let mut first = true;
   for component in components {
     if first {
@@ -143,7 +143,7 @@ fn path_join(components: [String]) -> String {
 /// Example: path_extension("file.txt") => Some("txt")
 fn path_extension(path: String) -> Option<String> {
   let plen = len(path);
-  let i = plen - 1;
+  let mut i = plen - 1;
   while i >= 0 {
     let ch = string_get(path, i);
     if ch == '.' {
@@ -170,7 +170,7 @@ fn path_filename(path: String) -> String {
   if plen == 0 {
     return "";
   }
-  let i = plen - 1;
+  let mut i = plen - 1;
   while i >= 0 {
     if string_get(path, i) == '/' {
       return string_sub(path, i + 1, plen - i - 1);
@@ -189,7 +189,7 @@ fn path_dirname(path: String) -> String {
   if plen == 0 {
     return ".";
   }
-  let i = plen - 1;
+  let mut i = plen - 1;
   while i >= 0 {
     if string_get(path, i) == '/' {
       if i == 0 {
@@ -209,7 +209,7 @@ fn path_dirname(path: String) -> String {
 fn path_stem(path: String) -> String {
   let filename = path_filename(path);
   let flen = len(filename);
-  let i = flen - 1;
+  let mut i = flen - 1;
   while i > 0 {
     if string_get(filename, i) == '.' {
       return string_sub(filename, 0, i);
@@ -239,8 +239,8 @@ extern fn chdir(path: String) -> Result<(), String>;
 
 /// Read all input from stdin until EOF
 fn read_stdin() -> Result<String, String> {
-  let parts = [];
-  let done = false;
+  let mut parts = [];
+  let mut done = false;
   while !done {
     match read_line() {
       Ok(line) => {


### PR DESCRIPTION
`printf`/`path_join`/`path_dirname`/`path_extname`/`read_lines` reassigned loop counters & accumulators (`arg_idx`, `i`, `result`, `parts`, `done`) declared with plain `let`. Pure stdlib bug.

- stdlib **15 → 16/19**
- `dune test` **233/233**, zero regression

Refs #128