### PR TITLE
fix(stdlib): option.affine — final STAGE-A file, stdlib 19/19 (#128)

### DIFF
--- a/stdlib/option.affine
+++ b/stdlib/option.affine
@@ -6,7 +6,10 @@
 module option;
 
 // `Option`/`Result` types + constructors are owned by `prelude` (ADR-011).
-use prelude::{Option, Some, None, Result, Ok, Err, map};
+// `map` is defined locally below as the Option map (f, Option<T>);
+// it is NOT imported from prelude (prelude's `map` is the list map
+// with a different signature — importing both would conflict).
+use prelude::{Option, Some, None, Result, Ok, Err};
 
 // This module is the single canonical home for the Option *operations*
 // (is_some/is_none/unwrap/unwrap_or/map/filter/contains/…). #133 removed
@@ -184,14 +187,20 @@ fn unzip<A, B>(opt: Option<(A, B)>) -> (Option<A>, Option<B>) {
 /// Transpose Option of list to list of Option
 fn transpose<T>(opt: Option<[T]>) -> [Option<T>] {
   match opt {
-    Some(list) => map(fn(x) => Some(x), list),
+    Some(list) => {
+      let mut result = [];
+      for x in list {
+        result = result ++ [Some(x)];
+      }
+      result
+    },
     None => []
   }
 }
 
 /// Collect list of Options into Option of list (None on any None)
 fn collect<T>(opts: [Option<T>]) -> Option<[T]> {
-  let values = [];
+  let mut values = [];
   for opt in opts {
     match opt {
       Some(value) => values = values ++ [value],
@@ -203,10 +212,13 @@ fn collect<T>(opts: [Option<T>]) -> Option<[T]> {
 
 /// Filter out Nones from list
 fn cat_options<T>(opts: [Option<T>]) -> [T] {
-  let values = [];
+  let mut values = [];
   for opt in opts {
     match opt {
-      Some(value) => values = values ++ [value],
+      // Statement-block arm so the arm is Unit-typed and matches the
+      // `None => {}` arm (a bare assignment expression is typed as its
+      // RHS, which would clash Array vs Unit across the arms).
+      Some(value) => { values = values ++ [value]; },
       None => {}
     }
   }
@@ -215,7 +227,10 @@ fn cat_options<T>(opts: [Option<T>]) -> [T] {
 
 /// Map list with function returning Option, filtering Nones
 fn map_filter<T, U>(f: T -> Option<U>, list: [T]) -> [U] {
-  let results = map(f, list);
+  let mut results = [];
+  for x in list {
+    results = results ++ [f(x)];
+  }
   cat_options(results)
 }
 
@@ -317,14 +332,14 @@ fn replace_none<T>(opt: Option<T>, replacement: Option<T>) -> Option<T> {
 }
 
 /// Take value from Option, leaving None
-fn take<T>(opt: &mut Option<T>) -> Option<T> {
+fn take<T>(mut opt: Option<T>) -> Option<T> {
   let result = opt;
   opt = None;
   result
 }
 
 /// Insert value into Option if None
-fn get_or_insert<T>(opt: &mut Option<T>, value: T) -> T {
+fn get_or_insert<T>(mut opt: Option<T>, value: T) -> T {
   match opt {
     Some(x) => x,
     None => {


### PR DESCRIPTION
Last failing `stdlib/*.affine`. With this, **every stdlib module type-checks (19/19)**.

- `take`/`get_or_insert`: Rust-style `&mut Option<T>` → AffineScript `mut opt: Option<T>` (grammar has no `&mut`; ownership-prefix is the convention)
- drop prelude `map` import (option defines its own Option `map`; prelude's is the list map — same name-conflict class as #191)
- `transpose`/`map_filter`: rewrite list-map via the file's own for-loop `++` idiom (the shadowed `map` was Option-map)
- `cat_options`: Unit statement-block arm so it matches `None => {}` (a bare assignment expr is typed as its RHS → Array vs Unit; `collect` already works via its `Never` arm)
- `collect`/`cat_options`: reassigned `values` → `let mut`

- stdlib **18 → 19/19** — STAGE A coherence complete
- `dune test` **233/233**, zero regression

Refs #128