### PR TITLE
feat(stdlib): async-extern binding surface — Thenable + withProgress/sendRequest (Refs #103)

### DIFF
--- a/stdlib/Vscode.affine
+++ b/stdlib/Vscode.affine
@@ -283,3 +283,22 @@ pub extern fn processPlatform() -> String;
 /// `context.asAbsolutePath(rel_path)` — resolves a path relative to the
 /// extension's install location.
 pub extern fn extensionAbsolutePath(ctx: ExtensionContext, rel_path: String) -> String;
+
+// ── Async-extern ABI (issue #103) ────────────────────────────────────
+//
+// AffineScript's extern-call shape is synchronous, but most of vscode's
+// interactive surface returns a JS Thenable. `Thenable` is an opaque
+// host handle; the Deno/Node source-to-source backend lowers a
+// Thenable-returning extern to a plain host call, so the emitted JS is a
+// real Promise and a consumer's `await` is valid source JS. The `Async`
+// effect (v1 registry, #59) tracks this in signatures. The vscode-host
+// JS implementation lives in packages/affine-vscode/mod.js (follow-up
+// slice); these declarations are the binding surface + effect tracking.
+
+pub extern type Thenable;
+
+/// `vscode.window.withProgress({ location: Notification, title }, task)`.
+/// `work_thunk` is a wasm/host table index of the `() -> Thenable` task
+/// (same thunk-handle convention as `onDidSaveTextDocument`). Returns the
+/// progress Thenable.
+pub extern fn withProgressNotification(title: String, work_thunk: Int) -> Thenable / Async;

--- a/stdlib/VscodeLanguageClient.affine
+++ b/stdlib/VscodeLanguageClient.affine
@@ -31,3 +31,16 @@ pub extern fn newLanguageClient(id: String,
 
 pub extern fn languageClientStart(c: LanguageClient) -> Int;
 pub extern fn languageClientStop(c: LanguageClient) -> Int;
+
+// ── Async-extern ABI (issue #103) ────────────────────────────────────
+// Opaque host handle, declared per-module (these binding modules are
+// self-contained; the host erases the type). See stdlib/Vscode.affine.
+
+pub extern type Thenable;
+
+/// `LanguageClient.sendRequest(method, params)` — returns a Thenable of
+/// the JSON-encoded response. `params_json` is the request params encoded
+/// as a JSON string; the host shim parses it before the LSP call.
+pub extern fn languageClientSendRequest(c: LanguageClient,
+                                        method: String,
+                                        params_json: String) -> Thenable / Async;


### PR DESCRIPTION
## Root cause (#103)

AffineScript's extern-call shape is synchronous, so Thenable-returning vscode APIs (most of the interactive surface) could not be bound at all. The rsr-certifier vscode port fell back to shelling out to the `rsr` CLI, losing status-bar/diagnostics/webview behaviour.

## Decision

Owner chose the **Promise-returning extern** shape (smallest slice; no language change, no thunk table). The Deno/Node backend is source-to-source: an unlisted extern lowers to a plain host call, so a `Thenable`-returning extern emits a real JS Promise and a consumer's `await` is valid source JS.

## Change (slice 1 — binding surface only)

- `stdlib/Vscode.affine`: `extern type Thenable;` + `withProgressNotification(title, work_thunk: Int) -> Thenable / Async`.
- `stdlib/VscodeLanguageClient.affine`: `languageClientSendRequest(c, method, params_json) -> Thenable / Async`.

`Async` is tracked via the v1 effect registry (PR-1, #196). **No backend change** — the existing "unlisted extern → plain host call" lowering is exactly the desired Promise behaviour.

## Verification

- Both binding files typecheck standalone; `dune test --force` **253/253** (incl. the AOT Vscode smoke gate), zero regression.
- A consumer compiled with `--deno-esm` emits `return languageClientSendRequest("rsr/getCompliance", "{}")` — a plain awaitable host call.

## Deferred to follow-up slices (scoped out by decision)

- vscode-host JS implementation in `packages/affine-vscode/mod.js`
- rsr-certifier pilot restore (standards#46)

Refs #103
