### PR TITLE
feat(affine-vscode): languageClientSendRequest host binding (Refs #103)

### DIFF
--- a/packages/affine-vscode/mod.js
+++ b/packages/affine-vscode/mod.js
@@ -345,6 +345,27 @@ module.exports = function makeVscodeBindings(vscode, lcModule, hostShim) {
       if (c) c.stop();
       return 0;
     },
+    // `LanguageClient.sendRequest(method, params)` (issue #103). `params`
+    // arrives as a JSON string (the binding's synchronous extern shape);
+    // we parse it, invoke the LSP request, and register the returned
+    // Thenable in the handle table. The consumer awaits it on the
+    // source-to-source path (the wasm path additionally needs the
+    // thenable-resolution primitives — tracked in #199). An empty or
+    // malformed params string is treated as no params.
+    languageClientSendRequest: (cHandle, methodPtr, paramsJsonPtr) => {
+      const c = get(cHandle);
+      if (!c) return 0;
+      const method = readString(methodPtr);
+      const raw = readString(paramsJsonPtr);
+      let params;
+      if (raw && raw.length > 0) {
+        try { params = JSON.parse(raw); } catch (_e) { params = undefined; }
+      }
+      const thenable = params === undefined
+        ? c.sendRequest(method)
+        : c.sendRequest(method, params);
+      return reg(thenable);
+    },
   };
 
   return { Vscode, VscodeLanguageClient };


### PR DESCRIPTION
## #103 slice-2 — `sendRequest` host binding

Owner-scoped split: ship the no-callback `sendRequest` half now; the callback half (`withProgress`/`registerCommand`/`onDidSave` on the source-to-source backend) is the separate one-way-door issue **#199**.

## Change

Adds `languageClientSendRequest` to the `VscodeLanguageClient` binding map in `packages/affine-vscode/mod.js` (the JS-side impl the #103 acceptance names). Reads method + JSON params string, parses params (empty/malformed → no params), calls `c.sendRequest(...)`, registers the returned Thenable — same pattern as `newLanguageClient`/`start`/`stop`. No host→guest callback, so unaffected by the Deno callback-ABI gap.

`node --check` clean. `mod.js` is a JS package (not dune-built) → no 253-gate impact. Pairs with the binding surface from #198 (`languageClientSendRequest -> Thenable / Async`).

## Pilot status (honest)

The rsr-certifier extension calls `sendRequest` **inside** a `vscode.window.withProgress` wrapper. `withProgress` requires the host→guest callback ABI the source-to-source backend lacks (#199). So the full pilot restore is **blocked on #199**; a `withProgress`-less partial rewrite of a cross-repo production extension would be a damaging partial change and is deliberately not done. This PR delivers the enabling binding; the pilot follows #199.

## STAGE-B status

PR-1 #196 (registry, merged) · PR-2 #197 (braced syntax) · PR-3 #198 (binding surface) · **PR-4 (this, sendRequest impl)** · #199 (callback ABI, blocks withProgress + pilot).

Refs #103
