### PR TITLE
feat(vscode): function-value callback ABI — registerCommand/onDidSave/withProgress (Refs #199)

### DIFF
--- a/editors/vscode/src/extension.affine
+++ b/editors/vscode/src/extension.affine
@@ -142,15 +142,15 @@ fn start_lsp() -> Int {
 pub fn activate(ctx: ExtensionContext) -> Int {
   let _ = consoleLog("AffineScript extension activated");
 
-  // Register commands. The integer second argument to registerCommand is
-  // the wasm-table index of the handler — populated by the JS-side adapter
-  // from the `__indirect_function_table` export. The order here must
-  // match the order handlers appear in the file.
-  let _ = pushSubscription(ctx, registerCommand("affinescript.check", 0));
-  let _ = pushSubscription(ctx, registerCommand("affinescript.eval", 1));
-  let _ = pushSubscription(ctx, registerCommand("affinescript.compile", 2));
-  let _ = pushSubscription(ctx, registerCommand("affinescript.format", 3));
-  let _ = pushSubscription(ctx, registerCommand("affinescript.restartLsp", 4));
+  // Register commands. The handler is now a function value (#199
+  // function-value callback ABI) — no more brittle wasm-table indices.
+  // Each lambda takes the explicit `Unit` param (zero-param-fn return-
+  // type collapse) and delegates to the named handler.
+  let _ = pushSubscription(ctx, registerCommand("affinescript.check", fn(u: Unit) => handler_check()));
+  let _ = pushSubscription(ctx, registerCommand("affinescript.eval", fn(u: Unit) => handler_eval()));
+  let _ = pushSubscription(ctx, registerCommand("affinescript.compile", fn(u: Unit) => handler_compile()));
+  let _ = pushSubscription(ctx, registerCommand("affinescript.format", fn(u: Unit) => handler_format()));
+  let _ = pushSubscription(ctx, registerCommand("affinescript.restartLsp", fn(u: Unit) => handler_restart_lsp()));
 
   let cfg = getConfiguration("affinescript");
   if workspaceConfigGetBool(cfg, "lsp.enabled", 1) != 0 {

--- a/examples/vscode_extension_minimal.affine
+++ b/examples/vscode_extension_minimal.affine
@@ -23,7 +23,7 @@ pub fn handler_0() -> Int {
 }
 
 pub fn activate(ctx: ExtensionContext) -> Int {
-  let d = registerCommand("affinescript.helloAffine", 0);  // 0 = handler table index
+  let d = registerCommand("affinescript.helloAffine", fn(u: Unit) => handler_0());
   let _ = pushSubscription(ctx, d);
   return 0;
 }

--- a/stdlib/Vscode.affine
+++ b/stdlib/Vscode.affine
@@ -51,9 +51,11 @@ pub extern type TextDocument;
 // ── vscode.commands ───────────────────────────────────────────────────
 
 /// `vscode.commands.registerCommand(name, handler)`.
-/// `handler` is a function-pointer index into the Wasm table; the JS shim
-/// wraps it as a JS callback that re-enters Wasm when invoked.
-pub extern fn registerCommand(name: String, handler: Int) -> Disposable;
+/// `handler` is a function value (#199 function-value callback ABI). The
+/// `Unit` parameter is explicit because AffineScript types a zero-param
+/// function as its bare return type — `fn() -> Int` would collapse to
+/// `Int`; `fn(Unit) -> Int` is the honest callback shape.
+pub extern fn registerCommand(name: String, handler: fn(Unit) -> Int) -> Disposable;
 
 // ── vscode.workspace ──────────────────────────────────────────────────
 
@@ -263,7 +265,7 @@ pub extern fn clipboardWriteText(text: String) -> Int;
 /// `editorActiveFilePath()` from inside the thunk. That covers the
 /// 95% case where the saved doc is the active editor; the remaining
 /// cases (background-saved docs) degrade to "no action".
-pub extern fn onDidSaveTextDocument(handler: Int) -> Disposable;
+pub extern fn onDidSaveTextDocument(handler: fn(Unit) -> Int) -> Disposable;
 
 // ── Path helpers ─────────────────────────────────────────────────────
 
@@ -295,10 +297,11 @@ pub extern fn extensionAbsolutePath(ctx: ExtensionContext, rel_path: String) -> 
 // JS implementation lives in packages/affine-vscode/mod.js (follow-up
 // slice); these declarations are the binding surface + effect tracking.
 
-pub extern type Thenable;
+// `Thenable` is already declared in the opaque-type block above; no
+// re-declaration here (the duplicate from #198 is removed at source).
 
 /// `vscode.window.withProgress({ location: Notification, title }, task)`.
-/// `work_thunk` is a wasm/host table index of the `() -> Thenable` task
-/// (same thunk-handle convention as `onDidSaveTextDocument`). Returns the
-/// progress Thenable.
-pub extern fn withProgressNotification(title: String, work_thunk: Int) -> Thenable / Async;
+/// `work` is the task function (#199 function-value callback ABI; the
+/// explicit `Unit` param avoids the zero-param-fn return-type collapse).
+/// Returns the progress Thenable.
+pub extern fn withProgressNotification(title: String, work: fn(Unit) -> Thenable) -> Thenable / Async;


### PR DESCRIPTION
## #199 PR-5a — function-value callback ABI

Owner chose the function-value ABI. Replaces the brittle wasm-table-index `handler: Int` convention with real function values.

### ABI shape decision (no compiler change)

`handler: fn(Unit) -> R`, **not** `fn() -> R`. AffineScript deliberately types a zero-param function as its bare return type (`typecheck.ml:752`), so `fn() -> Int` collapses to `Int` and won't unify. The explicit `Unit` param is the honest realisation and needs **zero compiler change** (verified). Full rationale in #199.

### Change

- **`stdlib/Vscode.affine`**: `registerCommand` / `onDidSaveTextDocument` / `withProgressNotification` handler params `Int → fn(Unit) -> R`. Also **removes the duplicate `extern type Thenable;`** introduced in #198 (line 43 already declares it) — resolved at source.
- **`examples/vscode_extension_minimal.affine`** + **`editors/vscode/src/extension.affine`**: call sites migrated from numbered table indices to `fn(u: Unit) => handler_x()` lambdas. Behaviour-preserving — the named handler functions are unchanged.

### Verification

- stdlib / example / editors extension all typecheck.
- `dune test --force` **253/253**. (A transient Examples-parse failure was my own `_u` typo — leading-underscore identifiers parse-error as params; a separate minor lexer observation, used `u`.)
- Deno-ESM emits `registerCommand("…", ((u) => handler_0()))` — a real JS arrow passed directly. So the **Deno fn-value extern path (PR-5b) needs no codegen change** and is proven here.

### Follow-ups

- **PR-5c**: wasm `mod.js` marshalling (`wrapHandler` currently expects an `Int` table index; now receives a function value).
- **PR-5d**: rsr-certifier pilot restore (now unblocked — `withProgress` takes a function).

Refs #199
