### PR TITLE
refactor(effects): rename stdlib io/state/exn→IO/Mut/Throws, retire aliases (Refs #59)

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -67,7 +67,7 @@ fn add(x: Int, y: Int) -> Int {
 }
 
 // Impure function with IO effect
-fn main() -> Unit / io {
+fn main() -> Unit / IO {
   println("Hello, AffineScript!");
   let result = add(40, 2);
   println(int_to_string(result));
@@ -79,11 +79,11 @@ fn main() -> Unit / io {
 ```affinescript
 // Pure functions cannot call impure functions
 fn pure() -> Int {
-  return read_line();  // ❌ ERROR: Cannot perform effect io in pure context
+  return read_line();  // ❌ ERROR: Cannot perform effect IO in pure context
 }
 
 // Impure functions can call pure or impure
-fn impure() -> Int / io {
+fn impure() -> Int / IO {
   return read_line();  // ✅ OK
 }
 ```
@@ -95,7 +95,7 @@ fn use_value(x: @affine String) -> Unit {
   println(x);  // x is consumed here
 }
 
-fn main() -> Unit / io {
+fn main() -> Unit / IO {
   let s = "hello";
   use_value(s);
   println(s);  // ❌ ERROR: use after move

--- a/lib/effect.ml
+++ b/lib/effect.ml
@@ -137,14 +137,13 @@ let v1_effects = [ "IO"; "Async"; "Partial"; "Throws"; "Mut" ]
     yet wired into the stdlib. *)
 let reserved_effects = [ "Random"; "Time"; "Net" ]
 
-(** Legacy lowercase stdlib effects → canonical v1.  Kept as aliases so
-    [stdlib/effects.affine] and existing code compile unchanged
-    (additive migration; a rename sweep is a later, separate change). *)
-let legacy_aliases = [ ("io", "IO"); ("state", "Mut"); ("exn", "Throws") ]
-
 (** Canonical registry name for a source effect name, or [None] if it is
-    neither a v1/reserved name nor a legacy alias.  Callers additionally
-    accept user-declared effects (`effect <name>;`). *)
+    neither a v1 nor a reserved name.  Callers additionally accept
+    user-declared effects (`effect <name>;`).
+
+    The lowercase [io]/[state]/[exn] migration aliases were retired once
+    [stdlib/effects.affine] was renamed to the canonical names; legacy
+    lowercase effect names are now only valid if explicitly declared. *)
 let canonical_effect_name (s : string) : string option =
   if List.mem s v1_effects || List.mem s reserved_effects then Some s
-  else List.assoc_opt s legacy_aliases
+  else None

--- a/lib/effect.mli
+++ b/lib/effect.mli
@@ -35,9 +35,6 @@ val v1_effects : string list
 (** Reserved-for-v1.x effect names. *)
 val reserved_effects : string list
 
-(** Legacy lowercase stdlib effect → canonical v1 name. *)
-val legacy_aliases : (string * string) list
-
 (** Canonical registry name for a source effect name, or [None] if
     unknown to the registry (caller also accepts declared effects). *)
 val canonical_effect_name : string -> string option

--- a/stdlib/effects.affine
+++ b/stdlib/effects.affine
@@ -2,31 +2,31 @@
 // AffineScript Standard Library - Effect Declarations
 
 // Core IO effect - file and console operations
-effect io;
+effect IO;
 
 // State effect - mutable references
-effect state;
+effect Mut;
 
 // Exception effect - panics and error handling
-effect exn;
+effect Throws;
 
 // Built-in IO operations
-extern fn print(s: String) -> Unit / io;
-extern fn println(s: String) -> Unit / io;
-extern fn read_line() -> String / io;
-extern fn read_file(path: String) -> String / io;
-extern fn write_file(path: String, content: String) -> Unit / io;
+extern fn print(s: String) -> Unit / IO;
+extern fn println(s: String) -> Unit / IO;
+extern fn read_line() -> String / IO;
+extern fn read_file(path: String) -> String / IO;
+extern fn write_file(path: String, content: String) -> Unit / IO;
 
 // Built-in State operations
 // `make_ref` (not `ref`) because `ref` is a reserved ownership keyword;
 // see #135 keyword-as-identifier slice.
-extern fn make_ref<T>(x: T) -> Ref<T> / state;
-extern fn get<T>(r: Ref<T>) -> T / state;
-extern fn set<T>(r: Ref<T>, x: T) -> Unit / state;
+extern fn make_ref<T>(x: T) -> Ref<T> / Mut;
+extern fn get<T>(r: Ref<T>) -> T / Mut;
+extern fn set<T>(r: Ref<T>, x: T) -> Unit / Mut;
 
 // Built-in Exception operations
-extern fn panic(msg: String) -> Never / exn;
-extern fn error<T>(msg: String) -> T / exn;
+extern fn panic(msg: String) -> Never / Throws;
+extern fn error<T>(msg: String) -> T / Throws;
 
 // Pure operations (no effects)
 extern fn int_to_string(n: Int) -> String;


### PR DESCRIPTION
## STAGE-B cleanup — retire the legacy effect aliases

PR-1 (#196) introduced `io→IO` / `state→Mut` / `exn→Throws` as a migration bridge. Nothing depends on them now, so retire them and move the stdlib to canonical v1 names.

### Change

- **`stdlib/effects.affine`**: `effect io/state/exn;` → `IO/Mut/Throws`; all 10 `/ io|state|exn` annotations → canonical.
- **`effect.ml` / `effect.mli`**: remove `legacy_aliases`; `canonical_effect_name` is now `v1 ∪ reserved` only. Lowercase names are valid henceforth only if explicitly `effect <name>;`-declared.
- **`editors/vscode/README.md`**: doc snippets `/ io` → `/ IO` (alias retired → doc accuracy).

### Verification

- `dune build` clean; `dune test --force` **253/253**, zero regression.
- Includes the AOT `effects` smoke and the `test_e2e.ml` `effect io;` case — the latter still passes because it *declares* `io`, so it never depended on the alias.

Refs #59
