### PR TITLE
feat(effects): thread parametric Throws[E] type argument (Refs #59)

### DIFF
--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -452,7 +452,22 @@ and lower_effect_expr (ctx : context) (ee : effect_expr) : eff =
   in
   match ee with
   | EffVar { name; _ } -> resolve name
-  | EffCon ({ name; _ }, _args) -> resolve name
+  | EffCon ({ name; _ }, args) ->
+    (* Parametric effect, e.g. `Throws[MyErr]` (issue #59). Effect
+       *tracking* only: carry the type argument by mangling it into the
+       singleton name, so `Throws[A]`, `Throws[B]` and bare `Throws` are
+       distinct under the string-equality unification of `eff` — without
+       growing the `eff` ADT (which would ripple across every effect
+       operation). The base name is still validated via `resolve`. *)
+    (match resolve name with
+     | ESingleton base when args <> [] ->
+       let arg_str =
+         args
+         |> List.map (fun (TyArg te) -> ty_to_string (lower_type_expr ctx te))
+         |> String.concat ", "
+       in
+       ESingleton (base ^ "[" ^ arg_str ^ "]")
+     | other -> other)
   | EffUnion (e1, e2) ->
     EUnion [lower_effect_expr ctx e1; lower_effect_expr ctx e2]
 


### PR DESCRIPTION
## STAGE-B cleanup — parametric `Throws[E]`

`lower_effect_expr` dropped `EffCon` type args, so `Throws[MyErr]` collapsed to bare `Throws` — the type parameter the #59 v1 list specifies (`Throws[E]`) was invisible in the effect representation.

### Change

`EffCon` args are now mangled into the effect singleton: `Throws[MyErr]` → `ESingleton "Throws[MyErr]"`, distinct from `Throws[Other]` and bare `Throws` under `eff`'s string-equality unification.

Chosen over adding a parametric variant to the `eff` ADT — that would ripple across every effect operation in `effect.ml`/`unify.ml`, disproportionate for a cleanup. The base name is still validated through the v1 registry.

### Scope (honest)

This is effect **tracking** only. AffineScript does **not** currently *enforce* effect-annotation subsumption at call sites — verified: even `IO` body vs `Mut` decl, or pure body vs `IO` decl, pass today. Strict effect checking / handler semantics are the separately-deferred work (migration-stance guide; #59: "tracking alone gives most of the value"). This PR makes the tracked form carry `E`; it deliberately does not add enforcement.

### Verification

- `dune build` clean; `dune test --force` **253/253**, zero regression.
- `Bogus[Int]` still rejected → the parametric path runs and base-name validation works.
- `Throws[Int]` lowers distinctly from `Throws[String]` / bare `Throws` by construction.

Refs #59
