### PR TITLE
feat(stdlib): httpPostJson async-extern for out-of-process JSON POST

### DIFF
--- a/packages/affine-vscode/mod.js
+++ b/packages/affine-vscode/mod.js
@@ -363,6 +363,27 @@ module.exports = function makeVscodeBindings(vscode, lcModule, hostShim) {
       try { return reg(JSON.stringify(__thenableResults.get(tHandle))); }
       catch (_e) { return reg(""); }
     },
+
+    // `httpPostJson(url, body_json)` — out-of-process JSON POST for BoJ
+    // cartridge calls (e.g. boj-server :7700 reposystem_run_audit). Like
+    // languageClientSendRequest, we register the response Thenable in the
+    // handle table and let the guest observe it via thenableThen /
+    // thenableResultJson. Resolves with the parsed JSON body so
+    // thenableResultJson re-serialises it consistently; a non-JSON or
+    // failed response settles as { __error } (same shape thenableThen
+    // uses for rejections), so the guest can branch to its fallback.
+    httpPostJson: (urlPtr, bodyPtr) => {
+      const url = readString(urlPtr);
+      const body = readString(bodyPtr);
+      const doFetch = (typeof fetch === "function")
+        ? fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body,
+          }).then((r) => r.json())
+        : Promise.reject(new Error("fetch unavailable"));
+      return reg(doFetch.catch((err) => ({ __error: String(err) })));
+    },
   };
 
   const VscodeLanguageClient = {

--- a/stdlib/Vscode.affine
+++ b/stdlib/Vscode.affine
@@ -322,3 +322,17 @@ pub extern fn thenableThen(t: Thenable, on_settle: fn(Unit) -> Int) -> Disposabl
 /// The resolved value of `t`, JSON-encoded. Empty string until `t` has
 /// settled (i.e. until the `thenableThen` callback has fired).
 pub extern fn thenableResultJson(t: Thenable) -> String;
+
+// ── Out-of-process JSON POST (BoJ cartridge calls) ───────────────────
+//
+// Lets an extension reach a BoJ-server cartridge endpoint (e.g.
+// `reposystem_run_audit` on boj-server :7700) as a real in-process
+// request instead of shelling a CLI. Returns a Thenable of the parsed
+// JSON response; the wasm guest observes it with the #205 primitives
+// (`thenableThen` then `thenableResultJson`), exactly as for
+// `languageClientSendRequest`. Same handle/`Async` convention.
+
+/// POST `body_json` to `url` with `Content-Type: application/json`.
+/// Resolves with the JSON-decoded response body. Use thenableThen /
+/// thenableResultJson to read the settled value from a wasm guest.
+pub extern fn httpPostJson(url: String, body_json: String) -> Thenable / Async;


### PR DESCRIPTION
Adds `pub extern fn httpPostJson(url, body_json) -> Thenable / Async` to `stdlib/Vscode.affine` + canonical runtime impl in `packages/affine-vscode/mod.js`, following the exact #205 thenable convention (register the response Thenable; guest observes via `thenableThen`/`thenableResultJson`, identical to `languageClientSendRequest`).

**Why:** lets a VS Code extension reach a BoJ-server cartridge endpoint (e.g. `reposystem_run_audit` on boj-server :7700) as a real in-process request instead of shelling a CLI. Unblocks the BoJ-primary tier of the rsr-certifier extension rewire (PR-5d-B).

Failed/non-JSON responses settle as `{ __error }` (same shape `thenableThen` uses for rejections) so guests can branch to a fallback.

Full `dune test --force` gate green: **257/257**, zero regression.

Refs #103 #199 #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)