### PR TITLE
feat(affine-vscode): implement withProgressNotification runtime adapter (#212)

### DIFF
--- a/packages/affine-vscode/mod.js
+++ b/packages/affine-vscode/mod.js
@@ -405,6 +405,37 @@ module.exports = function makeVscodeBindings(vscode, lcModule, hostShim) {
         return reg("");
       }
     },
+
+    // `withProgressNotification(title, work)` (issue #212) — wrap a guest
+    // async unit of work in a VS Code progress notification. `work` is the
+    // #199 closure (`fn(Unit) -> Thenable`); invoking it returns the guest's
+    // Thenable *handle*, which we resolve through the shared handle table.
+    // We register the overall progress Thenable so the guest observes
+    // completion with thenableThen / thenableResultJson, identical to
+    // httpPostJson. If the host has no withProgress (non-VS Code / test
+    // runner) the work still runs — only the progress chrome is skipped.
+    // Failures settle as { __error } (the established reject shape).
+    withProgressNotification: (titlePtr, workPtr) => {
+      const title = readString(titlePtr);
+      const work = wrapHandler(workPtr);
+      const runWork = () => {
+        const h = work();
+        const inner = (typeof h === "number") ? get(h) : h;
+        return Promise.resolve(inner);
+      };
+      const canProgress =
+        typeof vscode.window.withProgress === "function" &&
+        vscode.ProgressLocation;
+      const result = canProgress
+        ? vscode.window.withProgress(
+            { location: vscode.ProgressLocation.Notification, title },
+            () => runWork()
+          )
+        : runWork();
+      return reg(
+        Promise.resolve(result).catch((err) => ({ __error: String(err) }))
+      );
+    },
   };
 
   const VscodeLanguageClient = {


### PR DESCRIPTION
feat(affine-vscode): implement withProgressNotification runtime adapter

stdlib/Vscode.affine:307 declares
`withProgressNotification(title, work: fn(Unit) -> Thenable) -> Thenable / Async`,
but packages/affine-vscode/mod.js had no runtime impl — calling it from
the wasm/Node backend faulted (undefined extern). Surfaced by the first
#205 consumer (rsr-certifier extension rewire, standards#123), which had
to omit progress UI and document the gap.

Adds the impl following the established async-extern convention exactly:

  - `work` is the #199 closure (`fn(Unit) -> Thenable`); invoking it via
    wrapHandler returns the guest's Thenable *handle*, resolved through
    the shared handle table.
  - The overall progress Thenable is `reg`-ed so the guest observes
    completion with thenableThen / thenableResultJson, identical to
    httpPostJson (#210).
  - Failures settle as `{ __error }` — the same reject shape thenableThen
    / httpPostJson use, so guests branch to a fallback uniformly.
  - Graceful degradation: if the host has no `withProgress`
    (non-VS Code / test runner), the work still runs; only the progress
    chrome is skipped (mirrors httpPostJson's fetch-unavailable stance).

Pure adapter addition — no stdlib/compiler change (the extern was
already declared). Node syntax-checked; full dune gate green (257/257),
zero regression.

Closes #212
Refs #199 #205 #210 #211 ; consumer hyperpolymath/standards#123

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
