### PR TITLE
fix(parse): map Token.EXTERN in Parse.parse_file token bridge (runtime Match_failure on all extern code)

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -85,6 +85,7 @@ let next_token state () =
     | Token.PUB -> Parser.PUB
     | Token.AS -> Parser.AS
     | Token.UNSAFE -> Parser.UNSAFE
+    | Token.EXTERN -> Parser.EXTERN
     | Token.ASSUME -> Parser.ASSUME
     | Token.SELF_KW -> Parser.SELF_KW
     | Token.TRANSMUTE -> Parser.TRANSMUTE


### PR DESCRIPTION
parse.ml next_token's Token→Parser match omitted `EXTERN`. Warning-8 demotion in lib/dune let the non-exhaustive match compile, then it raised `Match_failure` at runtime on any `extern` token — breaking `Parse.parse_file` for all FFI-heavy stdlib (Deno/Vscode/Network/Sqlite/Crypto/…). One-arm wiring; `Parser.EXTERN` already existed.

Verified: previously-crashing stdlib/Deno|Vscode|Network now parse OK; `dune test --force` 257/257 green.

Surfaced by the #218 record-migration codemod (relies on Parse.parse_file).

Refs #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)