### PR TITLE
feat(parser)!: #{ record-literal sigil; { is always a block [#218]

### DIFF
--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -165,6 +165,9 @@ let rec token state buf =
   | "->" -> ARROW
   | "=>" -> FAT_ARROW
   | "::" -> COLONCOLON
+  (* Record-literal opener (affinescript#215): `#{` is the unambiguous
+     record/struct-literal sigil; bare `{` is always a block. *)
+  | "#{" -> HASH_LBRACE
   (* Row variable "..name" — must come before ".." so sedlex prefers the longer match *)
   | "..", lower_ident ->
     let s = Sedlexing.Utf8.lexeme buf in

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -66,6 +66,7 @@ let rec effect_union_of_list = function
 
 /* Punctuation */
 %token LPAREN RPAREN LBRACE RBRACE LBRACKET RBRACKET
+%token HASH_LBRACE   /* `#{` record-literal opener (affinescript#215) */
 %token COMMA SEMICOLON COLON COLONCOLON DOT DOTDOT
 %token ARROW FAT_ARROW PIPE AT UNDERSCORE BACKSLASH QUESTION
 
@@ -768,10 +769,11 @@ expr_primary:
      ordinary parameter binding named "self". */
   | SELF_KW { ExprVar (mk_ident "self" $startpos $endpos) }
   | name = lower_ident { ExprVar (mk_ident name $startpos $endpos) }
-  /* Struct literal: `Point { x: v, y: w }`.  Must come before the plain
-     upper_ident production so Menhir shifts LBRACE rather than reducing
-     upper_ident to ExprVar when the next token is LBRACE. */
-  | _ty = upper_ident LBRACE b = expr_record_body RBRACE
+  /* Struct literal: `Point #{ x: v, y: w }` (affinescript#215). The `#{`
+     sigil makes this unambiguous against a bare block and removes the
+     Rust-style struct-literal-in-`if`/`match`-scrutinee hazard entirely;
+     no production-ordering hack needed any more. */
+  | _ty = upper_ident HASH_LBRACE b = expr_record_body RBRACE
     { ExprRecord { er_fields = fst b; er_spread = snd b } }
   | name = upper_ident { ExprVar (mk_ident name $startpos $endpos) }
   | ty = upper_ident COLONCOLON variant = upper_ident
@@ -787,11 +789,12 @@ expr_primary:
   /* Arrays */
   | LBRACKET es = separated_list(COMMA, expr) RBRACKET { ExprArray es }
 
-  /* Records — use a recursive rule (expr_record_body / expr_record_rest) to
-     avoid the LALR(1) greedy-separator conflict that arises when a ROW_VAR
-     spread like `..record` follows a COMMA that `separated_list` has already
-     consumed expecting another record_field. */
-  | LBRACE b = expr_record_body RBRACE
+  /* Anonymous record `#{ f: v, ..spread }` (affinescript#215). The `#{`
+     sigil removes the entire block-vs-record-literal ambiguity (family
+     C+D) by construction — bare `{` is now unconditionally a block.
+     expr_record_body / expr_record_rest stay recursive to avoid the
+     ROW_VAR greedy-separator conflict on `..spread` after a COMMA. */
+  | HASH_LBRACE b = expr_record_body RBRACE
     { ExprRecord { er_fields = fst b; er_spread = snd b } }
 
   /* Block */

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -73,6 +73,7 @@ type t =
   | RPAREN
   | LBRACE
   | RBRACE
+  | HASH_LBRACE   (** #{ — record-literal opener (affinescript#215) *)
   | LBRACKET
   | RBRACKET
   | COMMA
@@ -187,6 +188,7 @@ let to_string = function
   | RPAREN -> ")"
   | LBRACE -> "{"
   | RBRACE -> "}"
+  | HASH_LBRACE -> "#{"
   | LBRACKET -> "["
   | RBRACKET -> "]"
   | COMMA -> ","


### PR DESCRIPTION
## #218 — Rust-like record syntax: bare `{` = block, records use `#{ }`

Structurally eliminates the block-vs-record-literal ambiguity (#215
families C+D) with no lookahead heuristic, per the owner-approved model.

### Grammar (`fc1aa88`)
- `HASH_LBRACE` token (`token.ml`), `#{` lexer rule (`lexer.ml`; `#`
  was previously unused → longest-match is collision-free), both
  `ExprRecord` productions rerouted `LBRACE → HASH_LBRACE`
  (`parser.mly`), and the `Token → Parser` mapping (`parse_driver.ml`).
- Record *patterns* unchanged (pattern position has no block
  alternative — no ambiguity there).

**Menhir conflicts** (base `a45b021`, which already has #216/#217):

| | S/R | R/R |
|---|---|---|
| before | 72 (23 states) | 10 (4 states) |
| after  | **68 (21 states)** | **7 (1 state)** |

Build clean.

### Migration (`d41315d`)
45 in-repo `.affine` files (stdlib, tests, golden, e2e fixtures,
examples) rewritten `{…}` → `#{…}` by a **sound convergent codemod**
that depends only on the new unambiguous grammar (parse → at each
error insert `#` before the innermost enclosing record `{` → iterate
to fixpoint; codepoint-correct). Tooling intentionally not committed.

### Gate
`dune runtest` = **257/257 green** — identical to the pre-change
baseline. No regression; `#{` is the record syntax across the suite.

### Out of scope (follow-on, per #218 plan steps 3–4 / #215)
- Estate-wide `.affine` sweep in other repos.
- ~24 **non-gating** files the convergent codemod left pristine (LR
  error reported past the record's `}`): `conformance/valid/*`,
  `docs/guides/warmup/*`, `codegen-deno/*`, some `tests/types/*`.
  Plus intentional `conformance/invalid/*` error fixtures and
  face-syntax examples which must stay as-is. None in the 257 gate.
- Residual #215 conflict families (B `return`-greedy, state-401 R/R).

Refs #218 #215 — *not* `Closes` (issue closure is human-gated per the
estate `requirements-target` rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
