### PR TITLE
fix(licence): #3 Tranche 2 — clear scaffold-placeholder leak (affinescript)

### DIFF
--- a/.machine_readable/contractiles/dust/Dustfile
+++ b/.machine_readable/contractiles/dust/Dustfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PLMP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Dustfile template - recovery and rollback semantics
 
 version: 1

--- a/.machine_readable/contractiles/must/Mustfile
+++ b/.machine_readable/contractiles/must/Mustfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PLMP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Mustfile - declarative state contract (template)
 # See: https://github.com/hyperpolymath/mustfile
 

--- a/.machine_readable/contractiles/trust/Trustfile.hs
+++ b/.machine_readable/contractiles/trust/Trustfile.hs
@@ -1,4 +1,4 @@
--- SPDX-License-Identifier: PLMP-1.0-or-later
+-- SPDX-License-Identifier: PMPL-1.0-or-later
 -- Trustfile template - cryptographic and provenance verification
 
 module Trustfile where

--- a/ROADMAP.adoc
+++ b/ROADMAP.adoc
@@ -312,7 +312,7 @@ Priority areas for contributors:
 
 == License
 
-SPDX-License-Identifier: PMPL-1.0-or-later-or-later
+SPDX-License-Identifier: PMPL-1.0-or-later
 
 == See Also
 

--- a/RSR_OUTLINE.adoc
+++ b/RSR_OUTLINE.adoc
@@ -209,7 +209,7 @@ This template is part of:
 
 == License
 
-SPDX-License-Identifier: PMPL-1.0-or-later-or-later
+SPDX-License-Identifier: PMPL-1.0-or-later
 
 == Links
 


### PR DESCRIPTION
#3 Tranche 2 (post-pilot #32-shape). Scaffold-placeholder leak per `standards/LICENCE-POLICY.adoc` **A5** — NOT relicensing. PLMP/PMLP + doubled-suffix substituted to this repo's correct id `PMPL-1.0-or-later`. **5 file(s).** Gates: dirty-repo skip, diff-shape asserted (SPDX-only, auto-revert on anomaly), zero residual, no 3c file. 🤖 Generated with [Claude Code](https://claude.com/claude-code)