### PR TITLE
ci(spark): adopt estate SPARK Theatre Gate (#135)

### DIFF
--- a/.github/workflows/spark-theatre-gate.yml
+++ b/.github/workflows/spark-theatre-gate.yml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: PMPL-1.0
+# Estate SPARK Theatre Gate — thin caller of the reusable workflow in
+# hyperpolymath/standards (#135 / #141). Pinned by commit SHA per the
+# estate action-pinning policy. Regenerate the pin only when the reusable
+# workflow is intentionally bumped.
+name: SPARK Theatre Gate
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  spark-theatre-gate:
+    uses: hyperpolymath/standards/.github/workflows/spark-theatre-gate.yml@462003782f3ebb93ea763e81d0d199ce13ef7d73
+    with:
+      paths: "."
+      enforce_zero_contract: false


### PR DESCRIPTION
Thin caller of the reusable `hyperpolymath/standards` SPARK Theatre Gate, pinned to the #141 merge commit `462003782f3ebb93ea763e81d0d199ce13ef7d73` per the estate action-pinning policy. Makes anti-theatre enforcement live here.

Refs hyperpolymath/standards#124
Refs hyperpolymath/standards#135