### PR TITLE
fix(codegen): implement `++` list concatenation (was placeholder I32Add) (Closes #264)

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -466,6 +466,60 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
         end
     end
 
+  | ExprBinary (left, OpConcat, right) ->
+    (* List concatenation `a ++ b`. `OpConcat` was a placeholder `I32Add`
+       (it just summed the two list pointers), so every `++` produced a
+       garbage/zero-length list. Real implementation, in the canonical
+       list layout fixed by #255: `[len@+0][elem i @ +4 + i*4]`.
+       Allocate len(a)+len(b), copy a's then b's elements. *)
+    let* (ctx1, left_code)  = gen_expr ctx  left  in
+    let* (ctx2, right_code) = gen_expr ctx1 right in
+    let (ctx3, heap_idx) = ensure_heap_ptr ctx2 in
+    let (ctx4, a)   = alloc_local ctx3 "__cat_a"   in
+    let (ctx5, b)   = alloc_local ctx4 "__cat_b"   in
+    let (ctx6, la)  = alloc_local ctx5 "__cat_la"  in
+    let (ctx7, lb)  = alloc_local ctx6 "__cat_lb"  in
+    let (ctx8, dst) = alloc_local ctx7 "__cat_dst" in
+    let (ctx9, k)   = alloc_local ctx8 "__cat_k"   in
+    let copy_loop src_ptr count dst_base_off =
+      (* for k in 0..count: dst[dst_base_off + k] = src[k]
+         element addr = ptr + idx*4, value/store via static +4 offset
+         (skips the length word) — exactly the #255 convention. *)
+      [ I32Const 0l; LocalSet k;
+        Block (BtEmpty, [ Loop (BtEmpty, [
+          LocalGet k; LocalGet count; I32GeS; BrIf 1;
+          (* dst slot: dst + (dst_base_off + k)*4 *)
+          LocalGet dst;
+          LocalGet dst_base_off; LocalGet k; I32Add;
+          I32Const 4l; I32Mul; I32Add;
+          (* value: src[k] = *(src + k*4 + 4) *)
+          LocalGet src_ptr; LocalGet k; I32Const 4l; I32Mul; I32Add;
+          I32Load (2, 4);
+          I32Store (2, 4);
+          LocalGet k; I32Const 1l; I32Add; LocalSet k;
+          Br 0 ]) ]) ]
+    in
+    let (ctxA, zero) = alloc_local ctx9 "__cat_zero" in
+    let code =
+      left_code @ [LocalSet a] @ right_code @ [LocalSet b] @
+      [ LocalGet a; I32Load (2, 0); LocalSet la;
+        LocalGet b; I32Load (2, 0); LocalSet lb;
+        I32Const 0l; LocalSet zero;
+        (* dst = heap; heap += 4 + (la+lb)*4 *)
+        GlobalGet heap_idx; LocalSet dst;
+        GlobalGet heap_idx;
+        I32Const 4l;
+        LocalGet la; LocalGet lb; I32Add; I32Const 4l; I32Mul;
+        I32Add; I32Add;
+        GlobalSet heap_idx;
+        (* dst length = la + lb *)
+        LocalGet dst; LocalGet la; LocalGet lb; I32Add; I32Store (2, 0) ]
+      @ copy_loop a la zero   (* dst[0..la)  := a *)
+      @ copy_loop b lb la     (* dst[la..)   := b *)
+      @ [ LocalGet dst ]
+    in
+    Ok (ctxA, code)
+
   | ExprBinary (left, op, right) ->
     let* (ctx', left_code) = gen_expr ctx left in
     let* (ctx'', right_code) = gen_expr ctx' right in

--- a/tests/codegen/list_concat.affine
+++ b/tests/codegen/list_concat.affine
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// Regression for the `++` list-concat codegen defect. `OpConcat` was a
+// placeholder `I32Add` (it summed the two list *pointers*), so every
+// `a ++ b` produced a garbage/zero-length list. Like #255's loop bug
+// this had ZERO coverage — no asserted fixture exercised `++`. Covers
+// the three real shapes: literal++literal, mut-accumulate append in a
+// loop, and prepend in a loop.
+
+fn sum(xs: [Int]) -> Int {
+  let mut s = 0;
+  for x in xs {
+    s = s + x;
+  }
+  s
+}
+
+fn main() -> Int {
+  let a = [10, 20] ++ [30, 40, 50];      // -> [10,20,30,40,50], sum 150
+
+  let mut b = [];
+  let mut i = 1;
+  while i <= 4 {
+    b = b ++ [i];                        // append: [1,2,3,4], sum 10
+    i = i + 1;
+  }
+
+  let mut c = [];
+  let mut j = 1;
+  while j <= 3 {
+    c = [j] ++ c;                        // prepend: [3,2,1], sum 6
+    j = j + 1;
+  }
+
+  sum(a) + sum(b) + sum(c)               // 150 + 10 + 6 = 166
+}

--- a/tests/codegen/test_list_concat.mjs
+++ b/tests/codegen/test_list_concat.mjs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT OR AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// Regression: `++` list concatenation must actually concatenate.
+// Pre-fix this returned 0 (OpConcat was a placeholder I32Add).
+
+import { readFile } from 'fs/promises';
+
+const wasmBuffer = await readFile('./tests/codegen/list_concat.wasm');
+const { instance } = await WebAssembly.instantiate(wasmBuffer, {
+  wasi_snapshot_preview1: { fd_write: () => 0 },
+});
+const result = instance.exports.main();
+
+console.log(`Result: ${result}`);
+console.log('Expected: 166');
+console.log(`Test ${result === 166 ? 'PASSED ✓' : 'FAILED ✗'}`);
+process.exit(result === 166 ? 0 : 1);


### PR DESCRIPTION
## Fix #264 — `++` list concatenation was a placeholder

`lib/codegen.ml` `gen_binop`: `OpConcat -> I32Add (* Placeholder *)`. `a ++ b` summed the two list **pointers** → garbage/zero-length list; any iteration over a `++` result saw 0 elements.

Pre-existing and untested (same class as #255): `++` is used in stdlib (`collections.affine`) but AOT only checks compile and no asserted fixture exercised it. Surfaced implementing #225 PR3d (`Http.readResponse` builds `headers` via `headers ++ [pair]`).

### Fix
Real concat in the `ExprBinary` handler, canonical `[len@+0][elem i@+4+i*4]` layout (the #255 convention): eval both operands → alloc `len(a)+len(b)` → store combined length → two index-loop element copies. Added asserting `tests/codegen/list_concat.{affine,mjs}` (literal++literal, loop-append, loop-prepend ⇒ 166).

### Verification
`dune test --force` **278/278**; `tools/run_codegen_wasm_tests.sh` all pass incl. the new regression. Zero regression.

Closes #264. Refs #225 #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
