### PR TITLE
feat(codegen): #234 S4 — retire hardcoded async_primitives (ADR-016 complete)

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1917,29 +1917,25 @@ let simple_pat_name (p : pattern) : string option =
     affinescript#234 for the effect-threaded generalisation). The async
     boundary is a `let` whose RHS is a call to one of these names. Extend
     this list as wasm-path async stdlib primitives are added. *)
-let async_primitives = [ "http_request_thenable" ]
-
-(* ADR-016 / #234 S3: the async boundary is now ANY call whose effect
-   row ⊇ Async (the typecheck side-table, keyed by the shared
-   Effect_sites ordinal, consulted via [Effect_sites.is_async_call]),
-   generalising the structural-conservative hardcoded set. The
-   structural disjunct is retained as the sound table-miss fallback
-   (empty oracle / count-mismatch ⇒ exactly the pre-#234 behaviour;
-   zero regression). S4 retires [async_primitives]. *)
+(* ADR-016 / #234 S4: the hardcoded `async_primitives` name set is
+   RETIRED. The async boundary is exactly "a call whose effect row ⊇
+   Async", decided from the typecheck side-table keyed by the shared
+   [Effect_sites] ordinal ([Effect_sites.is_async_call]). The ADR's
+   "table-miss fallback" is the oracle being empty / count-mismatched
+   (⇒ [is_async_call] is always false ⇒ no transform = exact pre-#234
+   behaviour), NOT a name list — so no structural name disjunct
+   remains. `http_request_thenable` is still detected because
+   stdlib/Http.affine declares it `/ { Net, Async }`. *)
 let is_async_prim_call (e : expr) : bool =
   Effect_sites.is_async_call e
-  ||
-  match e with
-  | ExprApp (ExprVar id, _) -> List.mem id.name async_primitives
-  | _ -> false
 
-(** Any recognised async-primitive name occurring free in [e]. Reuses
-    [find_free_vars] (which traverses call heads), so this catches an
-    async primitive anywhere in a sub-expression — used to enforce the
-    single-boundary rule for PR3a (Async→Async chaining is PR3c). *)
+(** Does [e] contain (at any depth) a call whose effect row ⊇ Async?
+    Enforces the PR3a single-boundary rule (a pre-value must not hide
+    an async call; Async→Async chaining is PR3c). Now effect-driven via
+    the shared [Effect_sites] traversal — same call-site set the
+    numbering uses, so it can never miss a shape the detector counts. *)
 let mentions_async_prim (e : expr) : bool =
-  let fv = find_free_vars [] e in
-  List.exists (fun p -> List.mem p fv) async_primitives
+  Effect_sites.exists_call Effect_sites.is_async_call e
 
 (** Async-fn body recogniser (ADR-013 #225). Returns
     [Some (pre, binder, async_call, cont)] iff the body is, after

--- a/lib/effect_sites.ml
+++ b/lib/effect_sites.ml
@@ -19,8 +19,10 @@
     source order. [TopFn]/[TopConst]/[TopImpl]/[TopTrait] default
     bodies are walked in [prog_decls] order.
 
-    This module is pure and depends only on [Ast]; it has no notion of
-    effects itself (S2a). S2b/S3 build the table on top of it. *)
+    The traversal core ([visit_*]/[fold_calls]/[exists_call]) is pure
+    and depends only on [Ast]. The S3 ordinal-keyed async oracle
+    (bottom of this file) is the producer/consumer bridge built on that
+    numbering (ADR-016 S2b/S3/S4). *)
 
 open Ast
 
@@ -28,90 +30,96 @@ open Ast
    counter (held in a ref captured by the closures, so the ordinal is a
    pure function of traversal position). *)
 
-let fold_calls (type a) (f : a -> int -> expr -> a) (init : a)
-    (prog : program) : a =
-  let acc = ref init in
-  let next = ref 0 in
-  let rec go_expr (e : expr) : unit =
-    (match e with
-     | ExprApp (fn, args) ->
-       (* Number THIS call site before descending (pre-order). *)
-       let ord = !next in
-       incr next;
-       acc := f !acc ord e;
-       go_expr fn;
-       List.iter go_expr args
-     | ExprLit _ | ExprVar _ | ExprVariant _ -> ()
-     | ExprLet l ->
-       go_expr l.el_value;
-       (match l.el_body with Some b -> go_expr b | None -> ())
-     | ExprIf i ->
-       go_expr i.ei_cond;
-       go_expr i.ei_then;
-       (match i.ei_else with Some e -> go_expr e | None -> ())
-     | ExprMatch m ->
-       go_expr m.em_scrutinee;
-       List.iter go_arm m.em_arms
-     | ExprLambda l -> go_expr l.elam_body
-     | ExprField (e, _) | ExprTupleIndex (e, _) | ExprRowRestrict (e, _)
-     | ExprSpan (e, _) | ExprUnary (_, e) ->
-       go_expr e
-     | ExprIndex (a, b) | ExprBinary (a, _, b) ->
-       go_expr a;
-       go_expr b
-     | ExprTuple es | ExprArray es -> List.iter go_expr es
-     | ExprRecord r ->
-       List.iter
-         (fun (_, eo) -> match eo with Some e -> go_expr e | None -> ())
-         r.er_fields;
-       (match r.er_spread with Some e -> go_expr e | None -> ())
-     | ExprBlock b -> go_block b
-     | ExprReturn eo | ExprResume eo ->
-       (match eo with Some e -> go_expr e | None -> ())
-     | ExprTry t ->
-       go_block t.et_body;
-       (match t.et_catch with Some arms -> List.iter go_arm arms | None -> ());
-       (match t.et_finally with Some b -> go_block b | None -> ())
-     | ExprHandle h ->
-       go_expr h.eh_body;
-       List.iter go_handler h.eh_handlers
-     | ExprUnsafe ops -> List.iter go_unsafe ops)
-  and go_arm (a : match_arm) : unit =
+(* Single source of the traversal: [visit] is called on every
+   [ExprApp] node in strict left-to-right pre-order (the call node
+   *before* its callee/args are descended). [fold_calls] (program) and
+   [exists_call] (expr) both use it, so the numbering and any
+   sub-expression call scan can never diverge. *)
+let rec visit_expr (visit : expr -> unit) (e : expr) : unit =
+  let go_expr = visit_expr visit in
+  let go_arm (a : match_arm) : unit =
     (match a.ma_guard with Some g -> go_expr g | None -> ());
     go_expr a.ma_body
-  and go_handler = function
+  in
+  let go_handler = function
     | HandlerReturn (_, e) -> go_expr e
     | HandlerOp (_, _, e) -> go_expr e
-  and go_unsafe = function
+  in
+  let go_unsafe = function
     | UnsafeRead e | UnsafeForget e -> go_expr e
     | UnsafeWrite (a, b) | UnsafeOffset (a, b) ->
       go_expr a;
       go_expr b
     | UnsafeTransmute (_, _, e) -> go_expr e
-  and go_block (b : block) : unit =
-    List.iter go_stmt b.blk_stmts;
-    (match b.blk_expr with Some e -> go_expr e | None -> ())
-  and go_stmt = function
-    | StmtLet l -> go_expr l.sl_value
-    | StmtExpr e -> go_expr e
-    | StmtAssign (a, _, b) ->
-      go_expr a;
-      go_expr b
-    | StmtWhile (c, b) ->
-      go_expr c;
-      go_block b
-    | StmtFor (_, e, b) ->
-      go_expr e;
-      go_block b
   in
+  match e with
+  | ExprApp (fn, args) ->
+    (* Visit THIS call site before descending (pre-order). *)
+    visit e;
+    go_expr fn;
+    List.iter go_expr args
+  | ExprLit _ | ExprVar _ | ExprVariant _ -> ()
+  | ExprLet l ->
+    go_expr l.el_value;
+    (match l.el_body with Some b -> go_expr b | None -> ())
+  | ExprIf i ->
+    go_expr i.ei_cond;
+    go_expr i.ei_then;
+    (match i.ei_else with Some e -> go_expr e | None -> ())
+  | ExprMatch m ->
+    go_expr m.em_scrutinee;
+    List.iter go_arm m.em_arms
+  | ExprLambda l -> go_expr l.elam_body
+  | ExprField (e, _) | ExprTupleIndex (e, _) | ExprRowRestrict (e, _)
+  | ExprSpan (e, _) | ExprUnary (_, e) ->
+    go_expr e
+  | ExprIndex (a, b) | ExprBinary (a, _, b) ->
+    go_expr a;
+    go_expr b
+  | ExprTuple es | ExprArray es -> List.iter go_expr es
+  | ExprRecord r ->
+    List.iter
+      (fun (_, eo) -> match eo with Some e -> go_expr e | None -> ())
+      r.er_fields;
+    (match r.er_spread with Some e -> go_expr e | None -> ())
+  | ExprBlock b -> visit_block visit b
+  | ExprReturn eo | ExprResume eo ->
+    (match eo with Some e -> go_expr e | None -> ())
+  | ExprTry t ->
+    visit_block visit t.et_body;
+    (match t.et_catch with Some arms -> List.iter go_arm arms | None -> ());
+    (match t.et_finally with Some b -> visit_block visit b | None -> ())
+  | ExprHandle h ->
+    go_expr h.eh_body;
+    List.iter go_handler h.eh_handlers
+  | ExprUnsafe ops -> List.iter go_unsafe ops
+
+and visit_block (visit : expr -> unit) (b : block) : unit =
+  let go_stmt = function
+    | StmtLet l -> visit_expr visit l.sl_value
+    | StmtExpr e -> visit_expr visit e
+    | StmtAssign (a, _, b) ->
+      visit_expr visit a;
+      visit_expr visit b
+    | StmtWhile (c, b) ->
+      visit_expr visit c;
+      visit_block visit b
+    | StmtFor (_, e, b) ->
+      visit_expr visit e;
+      visit_block visit b
+  in
+  List.iter go_stmt b.blk_stmts;
+  (match b.blk_expr with Some e -> visit_expr visit e | None -> ())
+
+let visit_program (visit : expr -> unit) (prog : program) : unit =
   let go_fn_body = function
-    | FnBlock b -> go_block b
-    | FnExpr e -> go_expr e
+    | FnBlock b -> visit_block visit b
+    | FnExpr e -> visit_expr visit e
     | FnExtern -> ()
   in
   let go_top = function
     | TopFn fd -> go_fn_body fd.fd_body
-    | TopConst c -> go_expr c.tc_value
+    | TopConst c -> visit_expr visit c.tc_value
     | TopImpl ib ->
       List.iter
         (function ImplFn fd -> go_fn_body fd.fd_body | ImplType _ -> ())
@@ -124,8 +132,28 @@ let fold_calls (type a) (f : a -> int -> expr -> a) (init : a)
         trd.trd_items
     | TopType _ | TopEffect _ | TopExternType _ | TopExternFn _ -> ()
   in
-  List.iter go_top prog.prog_decls;
+  List.iter go_top prog.prog_decls
+
+let fold_calls (type a) (f : a -> int -> expr -> a) (init : a)
+    (prog : program) : a =
+  let acc = ref init in
+  let next = ref 0 in
+  visit_program
+    (fun call ->
+      let ord = !next in
+      incr next;
+      acc := f !acc ord call)
+    prog;
   !acc
+
+(** [exists_call pred e] — is there a call site within [e] (any depth)
+    for which [pred] holds? Uses the SAME pre-order traversal as
+    [fold_calls], so a sub-expression scan can never miss a call shape
+    the numbering counts. *)
+let exists_call (pred : expr -> bool) (e : expr) : bool =
+  let found = ref false in
+  visit_expr (fun call -> if pred call then found := true) e;
+  !found
 
 (** Total number of call sites ([ExprApp] nodes) in [prog]. *)
 let count (prog : program) : int =

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -1794,6 +1794,32 @@ let populate_call_effects (ctx : context) (prog : Ast.program) : unit =
     | Ast.ExprSpan (e, _) -> callee_name e
     | _ -> None
   in
+  (* The local `fd_eff` map only covers callees declared in *this*
+     unit's `prog_decls`. On WasmGC, imported async primitives
+     (`http_request_thenable`, …) and any cross-module callee are NOT
+     in `prog_decls` (the backend does not flatten imports) — their
+     resolved effect row lives in the callee's scheme in
+     `ctx.name_types` (populated by resolve, incl. imports). Fall back
+     to that: union the effect components along the arrow spine (the
+     declared row is among them; a superset is sound for the
+     boundary predicate "row ⊇ Async"). Without this the side-table
+     was silently empty for imported async primitives — masked by S3's
+     structural disjunct and exposed when S4 retires it. *)
+  let rec eff_of_ty (t : ty) : eff =
+    match t with
+    | TArrow (_, _, b, e) ->
+      (match e with
+       | EPure -> eff_of_ty b
+       | _ -> (match eff_of_ty b with
+               | EPure -> e
+               | e2 -> EUnion [ e; e2 ]))
+    | _ -> EPure
+  in
+  let scheme_eff (n : string) : eff =
+    match Hashtbl.find_opt ctx.name_types n with
+    | Some sc -> (try eff_of_ty (instantiate ctx.level sc) with _ -> EPure)
+    | None -> EPure
+  in
   Effect_sites.iter
     (fun ord call ->
       let row =
@@ -1802,8 +1828,8 @@ let populate_call_effects (ctx : context) (prog : Ast.program) : unit =
           (match callee_name head with
            | Some n ->
              (match Hashtbl.find_opt fn_eff n with
-              | Some e -> e
-              | None -> EPure)
+              | Some e when e <> EPure -> e
+              | _ -> scheme_eff n)
            | None -> EPure)
         | _ -> EPure
       in


### PR DESCRIPTION
## #234 S4 — retire the hardcoded `async_primitives` (ADR-016 complete)

Final ADR-016 slice: async-boundary detection is now decided **purely** from the effect side-table; the structural name list is gone.

- **codegen.ml**: deleted `async_primitives=["http_request_thenable"]`. `is_async_prim_call e = Effect_sites.is_async_call e`. `mentions_async_prim` → `Effect_sites.exists_call Effect_sites.is_async_call e` (effect-driven, same shared traversal as the numbering — can't miss a shape the detector counts). The ADR "table-miss fallback" is the oracle being empty/count-mismatched (⇒ pre-#234 behaviour), not a name list.
- **effect_sites.ml**: factored the traversal into shared `visit_expr/visit_block/visit_program`; `fold_calls` + new `exists_call` both use it (single source, no drift). Dead legacy body removed.
- **typecheck.ml — root-cause fix for the cross-module gap S4 exposed**: `populate_call_effects` only scanned the local `prog_decls`; imported async primitives (`http_request_thenable`, resolved as a wasm import, **not** in `prog_decls`) got `EPure` → once the structural mask was removed the transform stopped firing for them. Now falls back to the callee's resolved scheme in `ctx.name_types` (incl. imports), unioning the arrow-spine effect components (declared row ⊆ that; superset is sound for "row ⊇ Async").

### Verification
Full `tools/run_codegen_wasm_tests.sh` green — `http_cps_base/capture/chain` + `http_response_reader` (imported `http_request_thenable`, now via scheme-eff) **and** `effect_async_boundary` (user `/{Async}` fn) all pass with **no** structural list. `dune test --force` **290/290**. Zero regression.

**#234 fully delivered**: S1 ADR-016 (#270) · S2a numbering (#275) · S2b table (#276) · S3 codegen switch (#277) · S4 (this).

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
