### PR TITLE
licence(#7): PMPL-1.0 -> PMPL-1.0-or-later (owner carve-out, SPDX-only)

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # governance.yml — single wrapper calling the shared estate governance bundle
 # in hyperpolymath/standards. Replaces ~8 duplicated per-repo governance
 # workflows (verisimiser#59 estate rollout). Load-bearing build/security

--- a/.github/workflows/spark-theatre-gate.yml
+++ b/.github/workflows/spark-theatre-gate.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Estate SPARK Theatre Gate — thin caller of the reusable workflow in
 # hyperpolymath/standards (#135 / #141). Pinned by commit SHA per the
 # estate action-pinning policy. Regenerate the pin only when the reusable

--- a/LICENSING-GUIDE.md
+++ b/LICENSING-GUIDE.md
@@ -168,7 +168,7 @@ graph TD
 
 **File Header:**
 ```rust
-// SPDX-License-Identifier: PMPL-1.0
+// SPDX-License-Identifier: PMPL-1.0-or-later
 // SPDX-License-Identifier: MPL-2.0
 // SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell
 //

--- a/stdlib/effects.affine
+++ b/stdlib/effects.affine
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0
+// SPDX-License-Identifier: PMPL-1.0-or-later
 // AffineScript Standard Library - Effect Declarations
 
 // Core IO effect - file and console operations


### PR DESCRIPTION
4 files, SPDX-value-only. NOT a relicence. Owner-sanctioned, standards LICENCE-POLICY A8(1). Refs LICENCE-DEBT-LEDGER-2026-05-18. 🤖 Generated with [Claude Code](https://claude.com/claude-code)