### PR TITLE
feat(cli): #260 S3 — @hyperpolymath/affinescript compiler shim (ADR-019)

### DIFF
--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -23,6 +23,7 @@ on:
         options:
           - affine-js
           - affinescript-tea
+          - affinescript-cli
       dry_run:
         description: "Dry run only (no publish)"
         required: true
@@ -45,8 +46,9 @@ jobs:
         id: pkg
         run: |
           case "${{ inputs.package }}" in
-            affine-js)        echo "dir=packages/affine-js" >> "$GITHUB_OUTPUT" ;;
-            affinescript-tea) echo "dir=affinescript-tea"   >> "$GITHUB_OUTPUT" ;;
+            affine-js)         echo "dir=packages/affine-js"      >> "$GITHUB_OUTPUT" ;;
+            affinescript-tea)  echo "dir=affinescript-tea"        >> "$GITHUB_OUTPUT" ;;
+            affinescript-cli)  echo "dir=packages/affinescript-cli" >> "$GITHUB_OUTPUT" ;;
           esac
       - name: Dry run
         working-directory: ${{ steps.pkg.outputs.dir }}

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ htmlcov/
 /tests/codegen-deno/*.deno.js
 # Local-only build workaround (see file header); never committed.
 /dune-workspace
+packages/affinescript-cli/deno.lock

--- a/docs/PACKAGING.adoc
+++ b/docs/PACKAGING.adoc
@@ -54,13 +54,30 @@ this prep. If/when needed it follows the existing owner-sanctioned npm
 pattern (`.github/workflows/affine-vscode-publish.yml`, `NPM_TOKEN`
 scoped automation token) — a deliberate exception to Deno-first.
 
-== Open design question — the compiler itself
+== The compiler itself — decided (ADR-019 / #260)
 
 #181 says "publish *compiler* + runtime". The runtime is the JS
-packages above. The **compiler is a native OCaml binary** — it is *not*
-a JSR or npm package. "Publishing the compiler" therefore needs a
-release-binary strategy decision (GitHub Releases artifacts, Guix/Nix
-channel, or a thin JSR/npm shim that fetches a pinned binary). This is
-a one-way-door design choice and is filed as a separate issue rather
-than guessed here. `affinescript-lsp` distribution (INT-10) depends on
-that decision.
+packages above. The **compiler is a native OCaml binary** — not a
+JSR/npm package. The one-way-door fork (#260) was decided
+(**ADR-019**): *Releases-canonical, dual-channel*.
+
+* *Canonical artifact.* `.github/workflows/release.yml` (#260 S2), on a
+  `v*` tag, builds `affinescript-{linux-x64,macos-x64,macos-arm64}`
+  raw binaries + a `SHA256SUMS` manifest attached to the GitHub
+  Release. (`windows-x64` is a tracked follow-up.) Asset names are the
+  ADR-019 contract — do not rename without amending the ADR + the shim.
+* *Ergonomic front door.* `packages/affinescript-cli`
+  (`@hyperpolymath/affinescript`, #260 S3) — a thin Deno shim that
+  downloads the host-triple binary from the Release pinned in
+  `pins.js`, verifies it against the embedded SHA-256 (fail-closed: an
+  unpinned/mismatched binary is never executed), caches it under
+  `$AFFINESCRIPT_CACHE`/XDG, and execs it with the caller's argv. One
+  compiler version + checksum per shim release (no floating fetch).
+  Publish is owner-gated via `publish-jsr.yml` (the INT-04 manual
+  workflow; choice `affinescript-cli`).
+* *Later, additive over the same Release artifact (not separate
+  producers):* Guix/Nix fetch-derivations; an npm tail only if an
+  npm-native consumer needs it.
+
+`affinescript-lsp` distribution (INT-10, #282) consumes the shim;
+unblocked once a `v*` Release is cut and `pins.js` is finalised.

--- a/packages/affinescript-cli/deno.json
+++ b/packages/affinescript-cli/deno.json
@@ -1,0 +1,14 @@
+{
+  "name": "@hyperpolymath/affinescript",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./mod.js"
+  },
+  "license": "PMPL-1.0-or-later",
+  "publish": {
+    "exclude": ["mod_test.js"]
+  },
+  "tasks": {
+    "test": "deno test --allow-read --allow-write --allow-env --allow-run mod_test.js"
+  }
+}

--- a/packages/affinescript-cli/mod.js
+++ b/packages/affinescript-cli/mod.js
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+//
+// @hyperpolymath/affinescript — the thin compiler shim (ADR-019 / #260 S3).
+//
+// The AffineScript compiler is a native OCaml binary, not a JS package.
+// Per ADR-019 the GitHub Release (cut by .github/workflows/release.yml,
+// #260 S2) is the CANONICAL artifact: per-platform `affinescript-<target>`
+// binaries + a `SHA256SUMS` manifest. This package is the ergonomic Deno
+// front door: it downloads the binary for the host triple from the
+// Release pinned by THIS package version, verifies it against the
+// checksum embedded here (no floating fetch — one version+checksum per
+// shim release, the ADR-019 supply-chain rule), caches it, and execs it
+// with the caller's argv.
+//
+// Deno-first (CLAUDE.md). JavaScript, not ReScript, because this is
+// entirely Deno host APIs (Deno.Command / fetch / crypto.subtle / fs) —
+// the documented "JS only where ReScript cannot" carve-out, same as
+// packages/affine-js.
+
+import { PINS } from "./pins.js";
+
+/** Map the host to an ADR-019 release target triple. */
+export function hostTarget(os = Deno.build.os, arch = Deno.build.arch) {
+  if (os === "linux" && arch === "x86_64") return "linux-x64";
+  if (os === "darwin" && arch === "x86_64") return "macos-x64";
+  if (os === "darwin" && arch === "aarch64") return "macos-arm64";
+  throw new Error(
+    `@hyperpolymath/affinescript: unsupported host ${os}/${arch}. ` +
+      `Supported: linux-x64, macos-x64, macos-arm64 (windows-x64 is a ` +
+      `tracked follow-up). Build from source: hyperpolymath/affinescript.`,
+  );
+}
+
+/** Lower-case hex of the SHA-256 of `bytes`. */
+export async function sha256Hex(bytes) {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Cache path for a pinned binary (XDG, then HOME, then a temp dir). */
+export function cachePath(version, target) {
+  const base = Deno.env.get("AFFINESCRIPT_CACHE") ??
+    Deno.env.get("XDG_CACHE_HOME") ??
+    (Deno.env.get("HOME") ? `${Deno.env.get("HOME")}/.cache` : null) ??
+    Deno.env.get("TMPDIR") ?? "/tmp";
+  return `${base}/affinescript/${version}/affinescript-${target}`;
+}
+
+/**
+ * Resolve a runnable compiler binary path for the host, downloading +
+ * checksum-verifying from the pinned Release on a cache miss.
+ *
+ * @param {{ pins?: object, fetchImpl?: typeof fetch }} [opts]
+ *   `pins`/`fetchImpl` are test seams; production uses the embedded
+ *   PINS and global fetch.
+ * @returns {Promise<string>} absolute path to the verified binary
+ */
+export async function resolveCompiler(opts = {}) {
+  const pins = opts.pins ?? PINS;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const target = hostTarget();
+  const entry = pins.targets?.[target];
+  if (!entry || !entry.sha256 || !entry.url) {
+    throw new Error(
+      `@hyperpolymath/affinescript: no pinned binary for ${target} at ` +
+        `version ${pins.version} (pins.js not finalised for this release).`,
+    );
+  }
+  const path = cachePath(pins.version, target);
+
+  // Cache hit only counts if the cached bytes still match the pin
+  // (defends against a corrupted/tampered cache).
+  try {
+    const cached = await Deno.readFile(path);
+    if ((await sha256Hex(cached)) === entry.sha256) return path;
+  } catch { /* miss — fall through to download */ }
+
+  const res = await doFetch(entry.url);
+  if (!res.ok) {
+    throw new Error(
+      `@hyperpolymath/affinescript: download failed for ${target} ` +
+        `(${entry.url}): HTTP ${res.status}`,
+    );
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  const got = await sha256Hex(bytes);
+  if (got !== entry.sha256) {
+    throw new Error(
+      `@hyperpolymath/affinescript: checksum mismatch for ${target} — ` +
+        `expected ${entry.sha256}, got ${got}. Refusing to run (the ` +
+        `Release artifact does not match this shim version's pin).`,
+    );
+  }
+  await Deno.mkdir(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  await Deno.writeFile(path, bytes, { mode: 0o755 });
+  // writeFile mode is pre-umask; ensure it is executable.
+  await Deno.chmod(path, 0o755).catch(() => {});
+  return path;
+}
+
+/**
+ * Resolve then exec the compiler with `args`, inheriting stdio.
+ * Returns the child's exit code (caller decides whether to exit).
+ */
+export async function run(args = Deno.args, opts = {}) {
+  const bin = await resolveCompiler(opts);
+  const cmd = new Deno.Command(bin, {
+    args,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const { code } = await cmd.output();
+  return code;
+}
+
+if (import.meta.main) {
+  Deno.exit(await run());
+}

--- a/packages/affinescript-cli/mod_test.js
+++ b/packages/affinescript-cli/mod_test.js
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+//
+// @hyperpolymath/affinescript shim tests (ADR-019 / #260 S3).
+// Network-free: a fake `fetchImpl` serves bytes; AFFINESCRIPT_CACHE is
+// redirected to a temp dir. The "binary" is a tiny shell script so the
+// exec/argv path is exercised for real without a built compiler.
+//
+// Run: deno test --allow-read --allow-write --allow-env --allow-run mod_test.js
+
+import { assertEquals, assertRejects } from "jsr:@std/assert@1";
+import { hostTarget, resolveCompiler, run, sha256Hex } from "./mod.js";
+
+Deno.test("hostTarget maps the three supported triples", () => {
+  assertEquals(hostTarget("linux", "x86_64"), "linux-x64");
+  assertEquals(hostTarget("darwin", "x86_64"), "macos-x64");
+  assertEquals(hostTarget("darwin", "aarch64"), "macos-arm64");
+});
+
+Deno.test("hostTarget rejects unsupported hosts (incl. windows)", () => {
+  for (const [os, arch] of [["windows", "x86_64"], ["linux", "aarch64"]]) {
+    let threw = false;
+    try {
+      hostTarget(os, arch);
+    } catch (e) {
+      threw = e.message.includes("unsupported host");
+    }
+    assertEquals(threw, true, `${os}/${arch} should be rejected`);
+  }
+});
+
+// A fake "compiler": a POSIX script echoing argv and exiting 7.
+const FAKE = new TextEncoder().encode(
+  '#!/bin/sh\necho "args:$*"\nexit 7\n',
+);
+
+async function pinsFor() {
+  return {
+    version: "vtest",
+    targets: {
+      [hostTarget()]: {
+        url: "https://example.invalid/affinescript",
+        sha256: await sha256Hex(FAKE),
+      },
+    },
+  };
+}
+
+const okFetch = () => ({
+  ok: true,
+  arrayBuffer: async () => FAKE.buffer.slice(0),
+});
+
+function withTempCache(fn) {
+  return async () => {
+    const dir = await Deno.makeTempDir();
+    const prev = Deno.env.get("AFFINESCRIPT_CACHE");
+    Deno.env.set("AFFINESCRIPT_CACHE", dir);
+    try {
+      await fn(dir);
+    } finally {
+      if (prev === undefined) Deno.env.delete("AFFINESCRIPT_CACHE");
+      else Deno.env.set("AFFINESCRIPT_CACHE", prev);
+      await Deno.remove(dir, { recursive: true });
+    }
+  };
+}
+
+Deno.test(
+  "resolveCompiler downloads, checksum-verifies, caches (executable)",
+  withTempCache(async () => {
+    const pins = await pinsFor();
+    const p = await resolveCompiler({ pins, fetchImpl: okFetch });
+    const stat = await Deno.stat(p);
+    assertEquals(stat.isFile, true);
+    // mode is masked on some FSs; just assert the owner-exec bit is set.
+    assertEquals((stat.mode & 0o100) !== 0, true);
+    assertEquals(await sha256Hex(await Deno.readFile(p)), pins.targets[hostTarget()].sha256);
+  }),
+);
+
+Deno.test(
+  "resolveCompiler refuses on checksum mismatch and does not cache",
+  withTempCache(async (dir) => {
+    const pins = await pinsFor();
+    pins.targets[hostTarget()].sha256 = "0".repeat(64); // wrong pin
+    await assertRejects(
+      () => resolveCompiler({ pins, fetchImpl: okFetch }),
+      Error,
+      "checksum mismatch",
+    );
+    // Nothing written under the cache root.
+    let entries = 0;
+    for await (const _ of Deno.readDir(dir)) entries++;
+    assertEquals(entries, 0);
+  }),
+);
+
+Deno.test(
+  "resolveCompiler cache-hit skips fetch; corrupt cache re-downloads",
+  withTempCache(async () => {
+    const pins = await pinsFor();
+    await resolveCompiler({ pins, fetchImpl: okFetch });
+    // Cache hit: a throwing fetch must NOT be called.
+    const p = await resolveCompiler({
+      pins,
+      fetchImpl: () => {
+        throw new Error("fetch must not run on a valid cache hit");
+      },
+    });
+    // Corrupt the cache → must re-fetch (okFetch) and restore.
+    await Deno.writeFile(p, new TextEncoder().encode("tampered"));
+    const p2 = await resolveCompiler({ pins, fetchImpl: okFetch });
+    assertEquals(p2, p);
+    assertEquals(
+      await sha256Hex(await Deno.readFile(p2)),
+      pins.targets[hostTarget()].sha256,
+    );
+  }),
+);
+
+Deno.test(
+  "run execs the resolved binary with argv passthrough + exit code",
+  withTempCache(async () => {
+    const pins = await pinsFor();
+    const code = await run(["compile", "x.affine"], {
+      pins,
+      fetchImpl: okFetch,
+    });
+    assertEquals(code, 7); // the fake binary always exits 7
+  }),
+);

--- a/packages/affinescript-cli/pins.js
+++ b/packages/affinescript-cli/pins.js
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: PMPL-1.0-or-later
+// Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+//
+// ADR-019 / #260: the pin table. ONE compiler version + ONE sha256 per
+// target, per shim release — the supply-chain rule (no floating fetch).
+//
+// Filled when a `v*` tag is cut: the `release.yml` (#260 S2) job
+// publishes `affinescript-<target>` + `SHA256SUMS` to the GitHub
+// Release. Copy each line's hex into the matching `sha256` below, set
+// `version` to the tag, and bump THIS package's deno.json version in
+// lockstep. Empty `sha256` ⇒ `resolveCompiler` refuses to run for that
+// target (fail-closed: an unpinned binary is never executed).
+//
+// URL contract (must match release.yml asset names; do not rename
+// without amending ADR-019): the per-target raw executable asset on the
+// Release for `version`.
+
+const REPO = "https://github.com/hyperpolymath/affinescript";
+
+function assetUrl(version, target) {
+  return `${REPO}/releases/download/${version}/affinescript-${target}`;
+}
+
+export const VERSION = "v0.1.0";
+
+export const PINS = {
+  version: VERSION,
+  targets: {
+    "linux-x64": { url: assetUrl(VERSION, "linux-x64"), sha256: "" },
+    "macos-x64": { url: assetUrl(VERSION, "macos-x64"), sha256: "" },
+    "macos-arm64": { url: assetUrl(VERSION, "macos-arm64"), sha256: "" },
+  },
+};


### PR DESCRIPTION
## #260 S3 — `@hyperpolymath/affinescript` compiler shim (ADR-019)

The ergonomic Deno front door over the Releases-canonical compiler artifact (#260 S2). Per ADR-019.

**`packages/affinescript-cli` (`@hyperpolymath/affinescript`):**
- `hostTarget()` → linux-x64/macos-x64/macos-arm64 (ADR-019 release targets; windows rejected clearly — tracked follow-up).
- `resolveCompiler()` — cache-checked download of the pinned Release asset; streaming SHA-256 verify against `pins.js`. **Fail-closed**: an unpinned/mismatched binary is *never* executed (the ADR-019 supply-chain rule). Caches with exec bit under `$AFFINESCRIPT_CACHE`/XDG/HOME; corrupt cache detected by hash + re-fetched.
- `run()` — exec with argv + exit-code passthrough, stdio inherited. `pins.js` = one compiler version + sha256 per target per shim release (filled at `v*` release-cut; empty ⇒ refuse). `fetchImpl`/`pins` test seams.
- JavaScript (Deno host APIs only — the documented "JS where ReScript cannot" carve-out, same basis as `packages/affine-js`).

Wired into `publish-jsr.yml` (owner-gated manual publish; new `affinescript-cli` choice). `deno publish --dry-run` green. `docs/PACKAGING.adoc` truthed.

**Tests** `mod_test.js` — 6 Deno tests, **network-free** (fake fetch + temp cache + shell-script "binary"): host mapping incl. windows-reject; download+verify+cache w/ exec bit; checksum-mismatch fail-closed + no cache write; cache-hit skips fetch + corrupt-cache recovery; exec argv + exit-code passthrough. All green. `dune test --force` **295/295** (no compiler change; zero regression).

Refs #260 #181 #282. Not Closes — S4 (wire INT-10 onto the shim) is gated on a real `v*` Release cut + `pins.js` finalisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
