### PR TITLE
feat(componentize): #180 ADR-015 S3 — preview2 component on-ramp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ htmlcov/
 # Local-only build workaround (see file header); never committed.
 /dune-workspace
 packages/affinescript-cli/deno.lock
+
+# ADR-015 S3: fetch-pinned WASI adapter (provisioned, not committed)
+tools/vendor/

--- a/docs/ECOSYSTEM.adoc
+++ b/docs/ECOSYSTEM.adoc
@@ -206,10 +206,15 @@ satellite shell is downstream.
 |INT-03 |WASI preview2 / host I/O beyond stdout |#180 |S1, ADR-015
 ACCEPTED (owner-chosen full WASM Component-Model re-target). Staged
 S1..S6; legacy preview1 stdout path is the default until S6
-(reversible-in-progress). **S2 toolchain provisioned (#251 closed):
-`tools/provision-component-toolchain.sh` — pinned wasm-tools 1.249.0 /
-wasm-component-ld 0.5.22 / wac-cli 0.10.0. S3 (componentize on-ramp)
-now UNBLOCKED.** WIT world of record: `wit/affinescript.wit`
+(reversible-in-progress). S2 toolchain provisioned (#251). **S3
+DONE: `tools/componentize.sh` wraps the emitted core module into a
+valid WASI-0.2 component via the fetch-pinned preview1→preview2
+*reactor* adapter (wasmtime v44.0.1, sha256-verified); the
+`affinescript.ownership` section is proven to SURVIVE the wrap;
+`tests/componentize/smoke.sh` gates it (SKIP-safe without the
+toolchain). Codegen UNCHANGED — core preview1 stays the default
+(reversible).** Next: S4 native clocks/env/argv. WIT world of
+record: `wit/affinescript.wit`
 |INT-04 |Publish compiler + runtime to JSR (then npm) |#181 |runtime
 packaging READY (affine-js + affinescript-tea JSR dry-run green;
 manual-only `publish-jsr.yml`; docs/PACKAGING.adoc). INT-01 dep

--- a/docs/TECH-DEBT.adoc
+++ b/docs/TECH-DEBT.adoc
@@ -185,10 +185,12 @@ follow-up
 multi-ns import object, ownership accessor); 14 unit tests via pinned
 `deno task test` + `tests/modules/loader-bridge/` e2e on real
 compiler-emitted xmod wasm (closes INT-01↔INT-02). Unblocks INT-05/08/11
-|INT-03 |WASI preview2 / host I/O |S1→S2 |#180 ADR-015 (full
-Component-Model re-target, S1..S6); **S2 toolchain provisioned —
-#251 closed (`tools/provision-component-toolchain.sh`, pinned
-wasm-tools/wasm-component-ld/wac); S3 componentize on-ramp unblocked**
+|INT-03 |WASI preview2 / host I/O |S1→S3 |#180 ADR-015 (full
+Component-Model re-target, S1..S6); S2 toolchain #251 closed;
+**S3 DONE — `tools/componentize.sh` (pinned reactor adapter) →
+valid WASI-0.2 component, ownership section survives,
+`tests/componentize/smoke.sh` gates it; codegen unchanged. Next S4
+(native clocks/env/argv)**
 |INT-04 |Publish to JSR/npm |S2 |#181 packaging READY (dry-run green,
 manual workflow); JSR publish authorised + dispatched (owner go
 2026-05-19); compiler-binary distribution decided = **ADR-019**

--- a/tests/componentize/smoke.sh
+++ b/tests/componentize/smoke.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: PMPL-1.0-or-later
+#
+# ADR-015 S3 gated smoke: compile a core module that carries the
+# `affinescript.ownership` section, run it through the componentize
+# on-ramp, and assert the result is a valid WASI-0.2 component with the
+# ownership section intact (and that wasmtime can load it).
+#
+# SKIPs cleanly (exit 0) when the component toolchain is not provisioned
+# — it is opt-in (run tools/provision-component-toolchain.sh first /
+# the toolchain-bearing CI lane), so it never breaks the base gate.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if ! command -v wasm-tools >/dev/null \
+   || [ ! -f tools/vendor/wasi_snapshot_preview1.reactor.wasm ]; then
+  echo "SKIP: component toolchain not provisioned (tools/provision-component-toolchain.sh)"
+  exit 0
+fi
+
+COMPILER="${AFFINESCRIPT:-$ROOT/_build/default/bin/main.exe}"
+[ -x "$COMPILER" ] || COMPILER="dune exec affinescript --"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Known-good ownership fixture (emits the affinescript.ownership
+# section) + a main so the module is non-trivial.
+cp test/e2e/fixtures/verify_ownership_clean.affine "$work/cz.affine"
+printf '\nfn main() -> Int { add(2, 3) }\n' >> "$work/cz.affine"
+
+# `grep -c | … || true`: read all input (no early-close SIGPIPE that
+# `set -o pipefail` would mis-report — the `grep -q` footgun).
+has_section() {
+  [ "$(wasm-tools print "$1" 2>/dev/null | grep -c 'affinescript.ownership' || true)" -gt 0 ]
+}
+
+$COMPILER compile "$work/cz.affine" -o "$work/cz.wasm"
+has_section "$work/cz.wasm" \
+  || { echo "FAIL: fixture did not emit the ownership section"; exit 1; }
+
+tools/componentize.sh "$work/cz.wasm" "$work/cz.component.wasm"
+wasm-tools validate --features component-model "$work/cz.component.wasm"
+has_section "$work/cz.component.wasm" \
+  || { echo "FAIL: ownership section lost through componentization"; exit 1; }
+
+if command -v wasmtime >/dev/null; then
+  # Reactor component: no command entrypoint, so a successful
+  # instantiate (no trap) is the smoke. `--invoke` a missing export
+  # would error; instead just validate it loads as a component.
+  wasmtime compile "$work/cz.component.wasm" -o "$work/cz.cwasm" >/dev/null 2>&1 \
+    && echo "wasmtime: component compiles/loads ✓" \
+    || { echo "FAIL: wasmtime could not compile the component"; exit 1; }
+fi
+
+echo "ADR-015 S3 componentize smoke: PASSED ✓"

--- a/tools/componentize.sh
+++ b/tools/componentize.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: PMPL-1.0-or-later
+#
+# ADR-015 S3 — the componentize on-ramp. POST-codegen, codegen
+# UNCHANGED: the compiler still emits a core `wasi_snapshot_preview1`
+# module (the legacy default, ADR-015 reversible-in-progress); this
+# wraps that core module into a WASI-0.2 (preview2) WASM *component*
+# via the official preview1->preview2 reactor adapter (reactor, not
+# command: AffineScript modules export functions, not a WASI `_start`).
+#
+# The `affinescript.ownership` custom section (the typed-wasm contract
+# carrier, multi-producer ABI) MUST survive the wrap — asserted here.
+#
+# Usage:  tools/componentize.sh <core.wasm> <out.component.wasm>
+# Adapter: tools/vendor/wasi_snapshot_preview1.reactor.wasm
+#   (fetch-pinned + checksum-verified by provision-component-toolchain.sh;
+#    override with AFFINESCRIPT_WASI_ADAPTER=/path).
+set -euo pipefail
+
+core="${1:?usage: componentize.sh <core.wasm> <out.component.wasm>}"
+out="${2:?usage: componentize.sh <core.wasm> <out.component.wasm>}"
+adapter="${AFFINESCRIPT_WASI_ADAPTER:-$(cd "$(dirname "$0")" && pwd)/vendor/wasi_snapshot_preview1.reactor.wasm}"
+
+[ -f "$core" ]    || { echo "componentize: no core module: $core" >&2; exit 2; }
+[ -f "$adapter" ] || { echo "componentize: adapter missing ($adapter) — run tools/provision-component-toolchain.sh" >&2; exit 2; }
+command -v wasm-tools >/dev/null || { echo "componentize: wasm-tools not on PATH — run tools/provision-component-toolchain.sh" >&2; exit 2; }
+
+# Count with `grep -c` (reads ALL input, so no early-close SIGPIPE that
+# `set -o pipefail` would mis-report as a failure — the `grep -q`
+# footgun). `|| true` neutralises grep's no-match exit 1.
+section_count() {
+  wasm-tools print "$1" 2>/dev/null | grep -c 'affinescript.ownership' || true
+}
+
+# Does the core carry the typed-wasm ownership section? (only assert
+# survival if it was there to begin with.)
+had_ownership=0
+[ "$(section_count "$core")" -gt 0 ] && had_ownership=1
+
+wasm-tools component new "$core" --adapt "wasi_snapshot_preview1=$adapter" -o "$out"
+wasm-tools validate --features component-model "$out"
+
+if [ "$had_ownership" = 1 ]; then
+  if [ "$(section_count "$out")" -eq 0 ]; then
+    echo "FATAL: affinescript.ownership section did NOT survive componentization" >&2
+    rm -f "$out"
+    exit 1
+  fi
+  echo "ownership section: preserved through componentization ✓"
+fi
+
+echo "componentized -> $out (valid WASI-0.2 component)"

--- a/tools/provision-component-toolchain.sh
+++ b/tools/provision-component-toolchain.sh
@@ -21,14 +21,45 @@ WASM_TOOLS_VERSION="1.249.0"
 WASM_COMPONENT_LD_VERSION="0.5.22"
 WAC_CLI_VERSION="0.10.0"
 
+# The official `wasi_snapshot_preview1` -> preview2 *reactor* adapter
+# (ADR-015 S3). AffineScript modules export functions (`main`, …), not
+# a WASI command `_start`, so the REACTOR adapter is the correct one
+# (the command adapter requires `_start`). Fetch-pinned (provenance +
+# sha256 recorded here; verified fail-closed) rather than vendored as a
+# binary blob in the source tree. Source: bytecodealliance/wasmtime
+# release v44.0.1 (matches the pinned wasmtime in this estate).
+ADAPTER_WASMTIME_TAG="v44.0.1"
+ADAPTER_URL="https://github.com/bytecodealliance/wasmtime/releases/download/${ADAPTER_WASMTIME_TAG}/wasi_snapshot_preview1.reactor.wasm"
+ADAPTER_SHA256="e352bf5b74aec62d8e7da7e0536ede4b3d1ccdb4d9a1767031f4d6f007d22e85"
+ADAPTER_DIR="$(cd "$(dirname "$0")" && pwd)/vendor"
+ADAPTER_PATH="${ADAPTER_DIR}/wasi_snapshot_preview1.reactor.wasm"
+
 echo "Provisioning component-model toolchain (pinned, --locked)…"
 cargo install --locked --version "${WASM_TOOLS_VERSION}"        wasm-tools
 cargo install --locked --version "${WASM_COMPONENT_LD_VERSION}" wasm-component-ld
 cargo install --locked --version "${WAC_CLI_VERSION}"           wac-cli
+
+echo "Fetch-pinning the preview1->preview2 reactor adapter…"
+mkdir -p "${ADAPTER_DIR}"
+if [ -f "${ADAPTER_PATH}" ] && \
+   [ "$(sha256sum "${ADAPTER_PATH}" | cut -d' ' -f1)" = "${ADAPTER_SHA256}" ]; then
+  echo "adapter already present and verified"
+else
+  curl -fsSL -o "${ADAPTER_PATH}.tmp" "${ADAPTER_URL}"
+  got="$(sha256sum "${ADAPTER_PATH}.tmp" | cut -d' ' -f1)"
+  if [ "${got}" != "${ADAPTER_SHA256}" ]; then
+    rm -f "${ADAPTER_PATH}.tmp"
+    echo "FATAL: adapter checksum mismatch (expected ${ADAPTER_SHA256}, got ${got})" >&2
+    exit 1
+  fi
+  mv "${ADAPTER_PATH}.tmp" "${ADAPTER_PATH}"
+  echo "adapter verified + pinned -> ${ADAPTER_PATH}"
+fi
 
 echo
 echo "Installed:"
 wasm-tools --version
 wasm-component-ld --version
 wac --version
+echo "adapter: ${ADAPTER_WASMTIME_TAG} (${ADAPTER_SHA256})"
 echo "OK — ADR-015 S3 (componentize on-ramp) is now unblocked."


### PR DESCRIPTION
## #180 ADR-015 S3 — preview2 component on-ramp

Post-codegen; **codegen unchanged** (core `wasi_snapshot_preview1` stays the default — ADR-015 reversible-in-progress).

- **`provision-component-toolchain.sh`** (extends #251): fetch-pins the official preview1→preview2 **reactor** adapter (wasmtime `v44.0.1`, sha256 `e352bf5b…`, verified fail-closed → `tools/vendor/`, gitignored). Reactor not command — AffineScript modules export `main`, not WASI `_start` (the command adapter rejects them; proven empirically).
- **`tools/componentize.sh CORE OUT`**: `wasm-tools component new --adapt` → `validate --features component-model` → asserts the `affinescript.ownership` section (typed-wasm multi-producer carrier) **survives the wrap** (it does). Fail-closed.
- **`tests/componentize/smoke.sh`**: compile L10-clean ownership fixture → componentize → assert valid WASI-0.2 component + section survival + wasmtime loads it. **SKIP-safe** without the toolchain (never breaks the base gate; opt-in / toolchain lane).

Finding: `set -o pipefail` + `grep -q` on `wasm-tools print` is a SIGPIPE footgun (grep early-closes → wasm-tools dies 141 → pipefail mis-reports). Fixed with `grep -c | … || true`. The section genuinely survives — the transient "did NOT survive" was this footgun, not a real loss.

`dune test --force` **295/295** (no compiler change — S3 is post-codegen tooling; zero regression). S3 smoke **PASSED** (component valid, section preserved, wasmtime loads).

Refs #180 — S3 done; S4 (native wasi:clocks/env/argv) next, S5 filesystem (unblocks INT-06), S6 flip default. Not Closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
