### PR TITLE
feat(shim): #260 S4 — finalise pins.js for v0.1.0 (partial), bump shim 0.1.1

### DIFF
--- a/packages/affinescript-cli/deno.json
+++ b/packages/affinescript-cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperpolymath/affinescript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": {
     ".": "./mod.js"
   },

--- a/packages/affinescript-cli/pins.js
+++ b/packages/affinescript-cli/pins.js
@@ -26,8 +26,20 @@ export const VERSION = "v0.1.0";
 export const PINS = {
   version: VERSION,
   targets: {
-    "linux-x64": { url: assetUrl(VERSION, "linux-x64"), sha256: "" },
-    "macos-x64": { url: assetUrl(VERSION, "macos-x64"), sha256: "" },
-    "macos-arm64": { url: assetUrl(VERSION, "macos-arm64"), sha256: "" },
+    "linux-x64": {
+      url: assetUrl(VERSION, "linux-x64"),
+      sha256: "c1ce65308bace96669d2a178732cd5ee180845d85a5775e119a221b98fe2a5da",
+    },
+    "macos-x64": {
+      // v0.1.0 macos-13 build was stuck in the runner queue at tag time;
+      // left fail-closed (empty sha256 ⇒ resolveCompiler refuses) until
+      // a follow-up release re-attempts the macos-x64 leg.
+      url: assetUrl(VERSION, "macos-x64"),
+      sha256: "",
+    },
+    "macos-arm64": {
+      url: assetUrl(VERSION, "macos-arm64"),
+      sha256: "2cac3ba54ae7778d31d1bd780d11b56a5cf78b5d5ee6c1d33edd3f8e753943d5",
+    },
   },
 };

--- a/tools/affinescript-lsp/src/compiler.rs
+++ b/tools/affinescript-lsp/src/compiler.rs
@@ -28,7 +28,7 @@
 
 /// Pinned ADR-019 shim spec.  Must track `packages/affinescript-cli/deno.json`
 /// `version` (and therefore the `pins.js` `VERSION`).  Do not float this.
-pub const SHIM_SPEC: &str = "jsr:@hyperpolymath/affinescript@0.1.0";
+pub const SHIM_SPEC: &str = "jsr:@hyperpolymath/affinescript@0.1.1";
 
 /// Environment variable naming an explicit compiler binary (precedence 1).
 pub const COMPILER_ENV: &str = "AFFINESCRIPT_COMPILER";


### PR DESCRIPTION
## Summary
- Fills `packages/affinescript-cli/pins.js` with the real sha256 for the two v0.1.0 binaries that the Release workflow actually produced (`linux-x64`, `macos-arm64`); `macos-x64` stays fail-closed (empty sha256 ⇒ `resolveCompiler` refuses), per the rule at the top of pins.js. SHAs were computed directly from the published binaries because the canonical `SHA256SUMS` manifest isn't on the Release yet — `release.yml`'s `checksums` job needs all three matrix legs to succeed, and `macos-13` has been queued in the runner pool since `2026-05-19T22:25Z` (estate CI concurrency-pool exhaustion).
- Bumps `@hyperpolymath/affinescript` 0.1.0 → 0.1.1 in lockstep (pins.js header rule), and tracks it on the LSP side via `SHIM_SPEC = "jsr:@hyperpolymath/affinescript@0.1.1"`. This finally activates the INT-10 wiring merged in #287 (which was code-complete but inert — the LSP could not actually exec a shim-fetched binary while every sha256 in pins was `""`).
- **Not `Closes #282`** — owner explicitly reopened #282 gating it on the v0.1.0 Release producing assets, and `macos-x64` is still owed. A follow-up release fills the last pin.

## Verification
- `deno test --allow-read --allow-write --allow-env --allow-run mod_test.js` in `packages/affinescript-cli`: **6/6 green** (network-free fake-binary tests still pass after the pins change).
- `cargo test` in `tools/affinescript-lsp`: **26/26 green** (including `compiler::tests::*` after the `SHIM_SPEC` bump).
- Real end-to-end smoke on this host (linux-x64) against the live v0.1.0 Release:
  ```
  resolved: /tmp/affs-cache/affinescript/v0.1.0/affinescript-linux-x64
  exit: 0
  stdout: 0.1.0
  ```
  i.e. `resolveCompiler()` downloaded `affinescript-linux-x64`, SHA256-verified it against the new pin, cached, execed `--version`. macOS arm64 not smoked from this host but the same pin path is exercised by the shim tests.

## Test plan
- [x] `deno test` (`packages/affinescript-cli`) green
- [x] `cargo test` (`tools/affinescript-lsp`) green
- [x] Real fetch+verify+exec smoke against the v0.1.0 Release (linux-x64)
- [ ] Reviewer to optionally repeat the smoke on a darwin/arm64 host
- [ ] After macos-x64 build clears CI: cut a follow-up tag, let `release.yml` write the full `SHA256SUMS`, fill the macos-x64 pin, bump shim 0.1.1 → 0.1.2, close #282

Refs #282, #260, #181. ADR-019 in `docs/specs/SETTLED-DECISIONS.adoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)