### PR TITLE
ci(release): swap retired macos-13 runner for macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x64
-          - os: macos-13
+          - os: macos-15-intel
             target: macos-x64
           - os: macos-14
             target: macos-arm64


### PR DESCRIPTION
## Summary
- `macos-13` GitHub-hosted runner image was deprecated 2025-09-22 and **fully unsupported from 2025-12-04** (actions/runner-images#13046, [#13402](https://github.com/actions/runner-images/issues/13402), [#13634](https://github.com/actions/runner-images/issues/13634)). Any matrix entry pinning `os: macos-13` now queues forever — there is no runner.
- Observed on the v0.1.0 Release run [26124042846](https://github.com/hyperpolymath/affinescript/actions/runs/26124042846): `linux-x64` ✓ in 2m, `macos-arm64` ✓ in 8m, **`macos-x64` queued ~10 h** before I cancelled it. The `checksums` job (`needs: build`) never ran, so no `SHA256SUMS` landed on the Release, which left INT-10 (#282) wedged — see #291 for the partial-pins workaround.
- Swap `os: macos-13` → `os: macos-15-intel` (current Intel x64 standard runner per the actions/runner-images README). macOS 15 is the safer of the two Intel-x64 options: stable GA image, vs `macos-26-intel` which only graduated from public beta in 2026-02 and had an arm-label regression in actions/runner-images#14112 as recently as 2026-05-19.
- Asset-name contract (`affinescript-macos-x64`) and target ID (`macos-x64`) are unchanged — only the build host moves.

## Effect
Next `v*` tag push produces all three binaries + the canonical `SHA256SUMS` in one run. After that the shim can ship a full-coverage pins.js (closing #282).

## Test plan
- [ ] Merge to main, then either cut a `v0.1.1` tag or wait for the next planned release. The workflow's structure is unchanged; the only signal that matters is that the macos-x64 leg now picks up a runner and completes the OCaml build.
- [ ] Verify the `checksums` job runs and `SHA256SUMS` appears on the Release with all three entries.
- [ ] Reviewer to spot-check that `macos-15-intel` is permitted under the project's runner-allowlist (if one exists in governance.yml).

Refs #282, #260. Unblocks #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)