### PR TITLE
fix(release): scope checksums-job gh calls with --repo to avoid the git probe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           tag="${GITHUB_REF_NAME}"
           mkdir -p dl
-          gh release download "$tag" --dir dl --pattern 'affinescript-*'
+          gh release download "$tag" --repo "$GITHUB_REPOSITORY" --dir dl --pattern 'affinescript-*'
           ( cd dl && sha256sum affinescript-* | sort -k2 > SHA256SUMS )
           cat dl/SHA256SUMS
-          gh release upload "$tag" dl/SHA256SUMS --clobber
+          gh release upload "$tag" --repo "$GITHUB_REPOSITORY" dl/SHA256SUMS --clobber


### PR DESCRIPTION
## Summary
- The `checksums` job in `release.yml` has no `actions/checkout` step, so the runner has no `.git` directory. `gh release download` / `upload` without `--repo` falls back to probing the local git remote, which fails on a checkout-less runner: `failed to run git: fatal: not a git repository`.
- Observed on v0.1.1 release run [26145492160](https://github.com/hyperpolymath/affinescript/actions/runs/26145492160): all three build legs (which DO `checkout`) uploaded their binaries successfully, but the `checksums` job died before publishing SHA256SUMS. I uploaded SHA256SUMS to the v0.1.1 Release manually as a one-off, but the bug would silently re-bottle on every future release.
- This bug was hidden on v0.1.0: the macos-13 leg never completed (retired runner — fixed in #292), so the `checksums` job — gated by `needs: build` — never ran at all.
- Fix: pass `--repo "$GITHUB_REPOSITORY"` explicitly on both calls. Two-character change to two lines, matches gh CLI guidance for CI ("prefer `--repo` over relying on git auto-detection in non-clone contexts"). No behaviour change beyond losing the git probe.

## Test plan
- [ ] Next `v*` tag push exercises the patched checksums job. Expected: download + sha256sum + upload all succeed, SHA256SUMS lands on the Release automatically.
- [ ] Reviewer to confirm `--repo` flag is the right shape (could alternatively add `actions/checkout`, but that's heavier and pointless for a job that only needs to talk to the Release API).

Refs #282 (the v0.1.1 release was cut as part of that issue's closure path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)