### PR TITLE
feat(shim): close INT-10 — pin v0.1.1 (full coverage), bump shim 0.1.2

### DIFF
--- a/packages/affinescript-cli/deno.json
+++ b/packages/affinescript-cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperpolymath/affinescript",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": {
     ".": "./mod.js"
   },

--- a/packages/affinescript-cli/pins.js
+++ b/packages/affinescript-cli/pins.js
@@ -21,25 +21,22 @@ function assetUrl(version, target) {
   return `${REPO}/releases/download/${version}/affinescript-${target}`;
 }
 
-export const VERSION = "v0.1.0";
+export const VERSION = "v0.1.1";
 
 export const PINS = {
   version: VERSION,
   targets: {
     "linux-x64": {
       url: assetUrl(VERSION, "linux-x64"),
-      sha256: "c1ce65308bace96669d2a178732cd5ee180845d85a5775e119a221b98fe2a5da",
+      sha256: "b8f2cab7380306ca07b9599d7fe2470328236e7287a51c78c3bbb5e973fef5dc",
     },
     "macos-x64": {
-      // v0.1.0 macos-13 build was stuck in the runner queue at tag time;
-      // left fail-closed (empty sha256 ⇒ resolveCompiler refuses) until
-      // a follow-up release re-attempts the macos-x64 leg.
       url: assetUrl(VERSION, "macos-x64"),
-      sha256: "",
+      sha256: "6bc3837ef94f9b56a8bb63cec84c3f0ddf2d7e1092f49aa1d389da389b28b5e2",
     },
     "macos-arm64": {
       url: assetUrl(VERSION, "macos-arm64"),
-      sha256: "2cac3ba54ae7778d31d1bd780d11b56a5cf78b5d5ee6c1d33edd3f8e753943d5",
+      sha256: "7f7cb5ee6b7ef37818498813891a2cd636300da7cb4a59e938031c78c0ee3589",
     },
   },
 };

--- a/tools/affinescript-lsp/src/compiler.rs
+++ b/tools/affinescript-lsp/src/compiler.rs
@@ -28,7 +28,7 @@
 
 /// Pinned ADR-019 shim spec.  Must track `packages/affinescript-cli/deno.json`
 /// `version` (and therefore the `pins.js` `VERSION`).  Do not float this.
-pub const SHIM_SPEC: &str = "jsr:@hyperpolymath/affinescript@0.1.1";
+pub const SHIM_SPEC: &str = "jsr:@hyperpolymath/affinescript@0.1.2";
 
 /// Environment variable naming an explicit compiler binary (precedence 1).
 pub const COMPILER_ENV: &str = "AFFINESCRIPT_COMPILER";


### PR DESCRIPTION
## Summary
- Final wiring for INT-10 (#282). The v0.1.1 Release (cut after #292 swapped the retired macos-13 runner) produced all three platform binaries — the `macos-x64` leg picked up a `macos-15-intel` runner this time and built cleanly. This PR pins all three:
  - `linux-x64`: `b8f2cab7380306ca07b9599d7fe2470328236e7287a51c78c3bbb5e973fef5dc`
  - `macos-x64`: `6bc3837ef94f9b56a8bb63cec84c3f0ddf2d7e1092f49aa1d389da389b28b5e2`
  - `macos-arm64`: `7f7cb5ee6b7ef37818498813891a2cd636300da7cb4a59e938031c78c0ee3589`
- `pins.js` `VERSION` `v0.1.0` → `v0.1.1`, all three sha256 fields filled, interim "macos-x64 stuck" comment dropped.
- Shim `@hyperpolymath/affinescript` bumped `0.1.1` → `0.1.2` in lockstep (pins.js header rule); LSP-side `SHIM_SPEC` tracks it.

## Aside
The canonical `SHA256SUMS` on the v0.1.1 Release was uploaded by me manually because `release.yml`'s `checksums` job has no `actions/checkout` and `gh release download` failed on the missing `.git`. That bug was hidden on v0.1.0 by the macos-13 stall (the `checksums` job never even started). Fix in #294.

## Verification
- `deno test` (`packages/affinescript-cli`): **6/6 green**
- `cargo test` (`tools/affinescript-lsp`): **26/26 green**
- Real end-to-end smoke (host = linux-x64) against the live v0.1.1 Release:
  ```
  resolved: /tmp/affs-cache-v011/affinescript/v0.1.1/affinescript-linux-x64
  exit: 0
  ```
  `resolveCompiler()` downloaded the new binary, SHA-verified against the new pin, cached, execed `--version`. macOS legs not smoked from this host but the same code path is covered by the shim tests.

Closes #282. Refs #260, #181. ADR-019 in `docs/specs/SETTLED-DECISIONS.adoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)