### PR TITLE
chore(gitignore): match nested target/ for all crates, not just the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ Thumbs.db
 .vscode/
 
 # Build
-/target/
+target/
 /_build/
 /_opam/
 /build/


### PR DESCRIPTION
## Summary
- The repo has **7 Rust crates** besides the workspace root (`affinescriptiser/`, `runtime/`, `distributions/rattlescript/`, `tools/affine-doc/`, `tools/affine-pkg/`, `tools/affinescript-dap/`, `tools/affinescript-lsp/`). Each builds to its own sibling `target/`.
- The previous rule `/target/` was anchored to the repo root and only caught one of the seven. `git status` was showing e.g. `tools/affinescript-lsp/target/` as untracked across several sessions, one stray `git add .` away from committing ~100 MB of build output.
- Drop the leading slash so `target/` matches anywhere — the standard Rust convention.

## Why not unanchor the others too
Only the Rust `target/` has the nested-crate problem. `/_build/` stays anchored: there's exactly one OCaml dune build dir at the root, and an unanchored `_build/` could over-match user code that happens to live in a directory called `_build`. Same reasoning for the other anchored entries.

## Verification
After the fix, `git check-ignore` confirms the nested dirs are now ignored:
```
$ git check-ignore tools/affinescript-lsp/target/ runtime/target/ affinescriptiser/target/
tools/affinescript-lsp/target/
runtime/target/
affinescriptiser/target/
```

## Test plan
- [x] `git check-ignore` returns each nested `target/` path
- [ ] CI: no behavioural change expected (this only affects what `git status` shows and what `git add .` accidentally stages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)