### PR TITLE
fix(shim): relicense the JSR shim package to MPL-2.0

### DIFF
--- a/packages/affinescript-cli/deno.json
+++ b/packages/affinescript-cli/deno.json
@@ -4,7 +4,7 @@
   "exports": {
     ".": "./mod.js"
   },
-  "license": "PMPL-1.0-or-later",
+  "license": "MPL-2.0",
   "publish": {
     "exclude": ["mod_test.js"]
   },

--- a/packages/affinescript-cli/mod.d.ts
+++ b/packages/affinescript-cli/mod.d.ts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 //
 // Type declarations for mod.js — the @hyperpolymath/affinescript shim.

--- a/packages/affinescript-cli/mod.js
+++ b/packages/affinescript-cli/mod.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 //
 // @hyperpolymath/affinescript — the thin compiler shim (ADR-019 / #260 S3).

--- a/packages/affinescript-cli/mod_test.js
+++ b/packages/affinescript-cli/mod_test.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 //
 // @hyperpolymath/affinescript shim tests (ADR-019 / #260 S3).

--- a/packages/affinescript-cli/pins.js
+++ b/packages/affinescript-cli/pins.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 //
 // ADR-019 / #260: the pin table. ONE compiler version + ONE sha256 per


### PR DESCRIPTION
## Summary
- JSR validates the `license` field in `deno.json` against the SPDX list and rejects unrecognised identifiers. The repo's house licence `PMPL-1.0-or-later` is custom (Polymath Public License) — not on the SPDX list — so the v0.1.2 publish failed:
  ```
  Failed to publish @hyperpolymath/affinescript at 0.1.2:
    The license specified in the "license" field of your configuration file, or in the LICENSE file was not recognized.
  ```
- Relicense the shim package to **MPL-2.0** (Mozilla Public License 2.0): SPDX-recognised, OSI-approved, and the direction the estate has been moving (per the wider PMPL-vs-MPL-2.0 discussion).

## Scope is deliberately narrow
Only 5 files under `packages/affinescript-cli/`:
- `deno.json` — `"license": "MPL-2.0"`
- `mod.js`, `mod.d.ts`, `pins.js`, `mod_test.js` — SPDX-License-Identifier header

**Out of scope** (separate decision):
- Repo-wide PMPL → MPL-2.0 sweep across `bin/`, `lib/`, `runtime/`, `affinescriptiser/`, `tools/*/`, …
- The code generators in OCaml + Rust that emit PMPL headers when scaffolding new files
- Adding `LICENSE-MPL-2.0` to `LICENSES/`

The wider sweep needs explicit owner approval; flagged for follow-up.

## Verification
- `deno publish --dry-run` → clean, 4 files, no warnings.
- `deno test mod_test.js` → **6/6 green**.
- SPDX validator accepts `MPL-2.0`.

## After merge
Last blocker for the v0.1.2 JSR publish: package exists ✓, OIDC trusted publisher is wired ✓, types are typed ✓, license is now SPDX ✓. Re-dispatch `publish-jsr.yml` after merge and `0.1.2` should finally land on `https://jsr.io/@hyperpolymath/affinescript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)