### PR TITLE
chore(gitignore): ignore dune-generated *.install manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ target/
 /build/
 /dist/
 /out/
+# dune-generated package install manifests (sibling to *.opam — regenerated on build)
+*.install
 # Idris2 build artifacts (nested, e.g. under formal-verification dirs)
 **/solo-core/build/
 


### PR DESCRIPTION
## Summary
- `affinescript.install` (and any sibling `*.install` for future opam packages declared in `dune-project`) is regenerated by dune on every build. Was showing up as untracked across recent sessions, one stray `git add .` away from being committed.
- Add `*.install` to `.gitignore` — standard pattern; same shape as the `target/` glob fix (#296) so any future nested opam package's `.install` file is also covered.

## Verification
```
$ git check-ignore affinescript.install
affinescript.install
$ git status --short | grep '.install'
(no output)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)