### PR TITLE
fix: io+math STAGE-A resolution (ADR-011 use + trunc builtin seed)

### DIFF
--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -64,6 +64,7 @@ let create_context () : context =
   (* Numeric coercions and math *)
   def "int"; def "float";
   def "sqrt"; def "cbrt"; def "pow_float"; def "floor"; def "ceil"; def "round";
+  def "trunc";
   def "abs"; def "max"; def "min";
   def "sin"; def "cos"; def "tan"; def "atan"; def "atan2";
   def "exp"; def "log"; def "log10"; def "log2";

--- a/stdlib/io.affine
+++ b/stdlib/io.affine
@@ -20,6 +20,9 @@
 //   show(value)             -> String
 //   time_now()              -> Float              (CPU time in seconds)
 
+// Cross-module imports (ADR-011: explicit `use module::{...}`)
+use string::{ split };
+
 // ============================================================================
 // Console Output
 // ============================================================================

--- a/stdlib/string.affine
+++ b/stdlib/string.affine
@@ -116,7 +116,7 @@ fn repeat(s: String, n: Int) -> String {
 }
 
 /// Split string by a delimiter
-fn split(s: String, delimiter: String) -> [String] {
+pub fn split(s: String, delimiter: String) -> [String] {
   let slen = len(s);
   let dlen = len(delimiter);
 


### PR DESCRIPTION
io.affine: split() is cross-module (defined in string.affine). Per the ruled ADR-011 model (explicit `use module::{...}`), make `split` pub in string.affine and add `use string::{ split };` to io.affine.

math.affine: `trunc` is a genuine runtime builtin (interp.ml:674, kernel_sublang.ml:128) but was missing from the resolver builtin-seed list (siblings floor/ceil/round are seeded). Add `def "trunc"`. (pow/to_float/fract are defined locally in math.affine — not builtins.)

Base 651cc12 (post #166/#168/#169). Refs #128