### PR TITLE
docs: README internal-drift fix + DOC-04/05/06 done-in-tree (Refs #176, Refs #175)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ Write software where the compiler helps enforce resource lifecycles, protocol st
 
 [NOTE]
 ====
-Honest status sync (2026-04-12): affine/QTT and borrow checking are wired into the standard CLI paths today (`check`, `compile`, `eval`) and gate user programs. Dependent/refinement features are still parse-first in places, and some backend features remain incomplete, especially around effect-handler lowering in Wasm targets. See `.machine_readable/6a2/STATE.a2ml` for the authoritative per-feature status.
+Honest status sync (2026-04-12): affine/QTT and borrow checking are wired into the standard CLI paths today (`check`, `compile`, `eval`) and gate user programs. Dependent/refinement features are still parse-first in places, and some backend features remain incomplete, especially around effect-handler lowering in Wasm targets. See link:docs/CAPABILITY-MATRIX.adoc[docs/CAPABILITY-MATRIX.adoc] for the authoritative per-feature status (`.machine_readable/6a2/STATE.a2ml` mirrors that matrix; it does not lead).
 ====
 
 == What AffineScript Is
@@ -611,7 +611,10 @@ ____
 == Documentation
 
 - `docs/` — language and architecture documentation
-- `.machine_readable/6a2/STATE.a2ml` — authoritative feature status
+- `docs/CAPABILITY-MATRIX.adoc` — authoritative per-feature status (overrides everything else)
+- `docs/TECH-DEBT.adoc` — coordination ledger (DOC/CORE/STDLIB/INT/SAT)
+- `docs/ECOSYSTEM.adoc` — spine, AS↔typed-wasm contract, satellite registry, INT-01..12
+- `.machine_readable/6a2/STATE.a2ml` — machine-readable mirror of CAPABILITY-MATRIX (does not lead)
 - `examples/` — example programs
 - `tools/affinescript-lsp/` — language tooling
 - `editors/` — editor integrations

--- a/docs/TECH-DEBT.adoc
+++ b/docs/TECH-DEBT.adoc
@@ -60,11 +60,18 @@ from re-drifting.
 INT-01..12 |*DONE 2026-05-19* (this PR)
 |DOC-03 |`TECH-DEBT.adoc` — this ledger |*DONE 2026-05-19* (this PR)
 |DOC-04 |Authoritative banners on README/BACKEND-IMPLEMENTATION/
-COMPILER-CAPABILITIES/ALPHA-1-RELEASE-NOTES |open (this PR adds where
-touched; full sweep tracked here)
-|DOC-05 |`STATE.a2ml` drift flagged (it mirrors, does not lead) |open
+COMPILER-CAPABILITIES/ALPHA-1-RELEASE-NOTES |*DONE in tree*
+2026-05-21 (banners present on all four; README internal drift on
+lines 25/614 also fixed — pointed both at CAPABILITY-MATRIX). MONITOR
+posture stays live via DOC-08/09
+|DOC-05 |`STATE.a2ml` drift flagged (it mirrors, does not lead) |*DONE
+in tree* 2026-05-21 (`authoritative-status-doc` + `drift-flag` keys
+present in `.machine_readable/6a2/STATE.a2ml`; README "Documentation"
+section now also labels STATE.a2ml as the mirror)
 |DOC-06 |`ROADMAP.adoc` Ecosystem Integration Track (INT-01..12) cross-links
-this ledger |open
+this ledger |*DONE in tree* 2026-05-21 (ROADMAP.adoc §"Status &
+contract" cross-links CAPABILITY-MATRIX + TECH-DEBT + ECOSYSTEM and
+names the INT-01..12 track)
 |DOC-07 |Stage A–E definitions authoritative (were never committed) |
 *DONE 2026-05-19* (ECOSYSTEM.adoc §The spine)
 |DOC-08 |MONITOR rule: reject backend-breadth over-claims |DONE (Hypatia/


### PR DESCRIPTION
## Summary

- Fix two leftover lines in `README.adoc` (25, 614) that called `STATE.a2ml` "authoritative" — directly contradicting the line-10 banner pointing at `docs/CAPABILITY-MATRIX.adoc`, and at odds with `STATE.a2ml`'s own `authoritative-status-doc` + `drift-flag` keys declaring it a mirror. Both lines now point at `CAPABILITY-MATRIX` and label `STATE.a2ml` as the mirror.
- Bump `docs/TECH-DEBT.adoc` DOC-04 / DOC-05 / DOC-06 from "open" to "DONE in tree" to match reality: banners exist on all four target docs, the `STATE.a2ml` drift-flag is in place, and `ROADMAP.adoc` already cross-links `CAPABILITY-MATRIX` + `TECH-DEBT` + `ECOSYSTEM` and names the INT-01..12 track. MONITOR posture (DOC-08/09 — Hypatia/gitbot DOC-FORMAT) is unchanged; this PR demonstrates it by being the kind of small drift-correction PR that posture exists to encourage.

## Scope

- 2 files changed: `README.adoc`, `docs/TECH-DEBT.adoc` (+16 / -6).
- No source, no build, no machine-readable artefacts touched. `STATE.a2ml` is a deliberate non-target — this PR doesn't make it lead, it makes the prose stop pretending it does.

## Not closing

`Refs #176, Refs #175` — never `Closes`. #175 is `requirements-target` (only closes on mutual agreement); #176 is the long-lived MONITOR. DOC-04 stays a live MONITOR item even though the snapshot is now clean.

## Test plan

- [ ] `gh pr diff` shows exactly the two files above.
- [ ] `grep -nE "authoritative" README.adoc` shows no remaining line that calls `STATE.a2ml` authoritative.
- [ ] `docs/TECH-DEBT.adoc` Section A renders cleanly (asciidoctor `|` table not broken by the new multi-line cells — same pattern DOC-02 already uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)