### PR TITLE
chore(affine-vscode): finish PMPL→MPL sweep + truth-up Status paragraph (Refs #104)

### DIFF
--- a/packages/affine-vscode/README.adoc
+++ b/packages/affine-vscode/README.adoc
@@ -113,6 +113,7 @@ ABI lands.
 
 Phase 2 — bindings landed. The pilot affinescript port (issue #63) and
 external-extension ports (issue #64: my-lang, rsr-certifier) consume
-this adapter; the long-term plan is to publish it to npm so consumers
-do not have to vendor `mod.js`. Phase 4 (rattlescript-face sweep) still
-to do.
+this adapter. npm publish wiring is in place (issue #104:
+`affine-vscode-publish.yml` ships the package on `affine-vscode-v*`
+tag pushes); the first publish + downstream un-vendoring is gated on
+that issue. Phase 4 (rattlescript-face sweep) still to do.

--- a/packages/affine-vscode/deno.json
+++ b/packages/affine-vscode/deno.json
@@ -4,5 +4,5 @@
   "exports": {
     ".": "./mod.js"
   },
-  "license": "PMPL-1.0-or-later"
+  "license": "MPL-2.0"
 }

--- a/packages/affine-vscode/package.json
+++ b/packages/affine-vscode/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "JS-side adapter for AffineScript's stdlib/Vscode.affine + stdlib/VscodeLanguageClient.affine binding modules. Resolves each extern fn to a real vscode / vscode-languageclient call and maintains the FFI handle table.",
   "main": "./mod.js",
-  "license": "PMPL-1.0-or-later",
+  "license": "MPL-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/hyperpolymath/affinescript.git",


### PR DESCRIPTION
## Summary

- `packages/affine-vscode/package.json` line 6 and `packages/affine-vscode/deno.json` line 7 still read `PMPL-1.0-or-later`; commit `3170a6b` (Closes #301) swept this everywhere else. This finishes the sweep.
- Refresh the README "Status" paragraph so it reflects current state — `affine-vscode-publish.yml` is already in place, so the "long-term plan is to publish to npm so consumers do not have to vendor `mod.js`" framing is stale.

No JS / OCaml / dune changes — manifests + one doc paragraph.

## Why this is not a full #104 closer

Issue #104's acceptance criteria are 4 bullets. After this PR:

| AC | Status |
|---|---|
| `package.json` exists with `name`/`main`/`peerDependencies`/`repository.directory` | ✅ already on `main` |
| CI publishes on tag push | ✅ `affine-vscode-publish.yml` already on `main` (trigger: `affine-vscode-v*`) |
| README documents npm-install as primary | ✅ already on `main` (Install + Usage), tightened here |
| `@hyperpolymath/affine-vscode` resolvable via `npm view` | ❌ first publish gated on owner action (NPM_TOKEN secret + scope decision from issue body §3 — the `@hyperpolymath` org doesn't yet exist on npm) |
| my-lang + standards rsr-certifier un-vendored | ❌ blocked on first publish |

So #104 stays open until the first tag push + downstream un-vendoring.

## Test plan

- [ ] `gh pr view` shows green CI (manifest+doc-only changes; the heavy OCaml jobs in `ci.yml` are unaffected)
- [ ] `cat packages/affine-vscode/package.json | jq -r .license` returns `MPL-2.0`
- [ ] `cat packages/affine-vscode/deno.json    | jq -r .license` returns `MPL-2.0`

Refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)