### PR TITLE
chore(gitignore): ignore packages/affine-js/deno.lock (sibling rule)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ htmlcov/
 # Local-only build workaround (see file header); never committed.
 /dune-workspace
 packages/affinescript-cli/deno.lock
+packages/affine-js/deno.lock
 
 # ADR-015 S3: fetch-pinned WASI adapter (provisioned, not committed)
 tools/vendor/


### PR DESCRIPTION
## Summary

- Mirrors the existing `packages/affinescript-cli/deno.lock` line on .gitignore:100. Running \`deno\` against \`packages/affine-js/\` otherwise leaves an unstaged \`deno.lock\` on every session — same artefact, same disposition.

## Scope

- 1-line .gitignore addition. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)