### PR TITLE
chore(stdlib): STDLIB-04c — remove dead `string_concat` extern (Closes #330)

### DIFF
--- a/docs/TECH-DEBT.adoc
+++ b/docs/TECH-DEBT.adoc
@@ -183,9 +183,12 @@ round-trips + Deno codegen __cell-shape assertion) |S3 |DONE
 (`lib/interp.ml`, `lib/js_codegen.ml`, `lib/codegen_deno.ml`); sibling
 `panic` is wired and `error` should mirror it (divergent `T`) |S3 |open
 — issue #329
-|STDLIB-04c |`string_concat` extern — no direct wiring found; `++`
-operator independently lowered. Decide: remove (operator-only) or wire
-to mirror `++` |S3 |open — issue #330
+|STDLIB-04c |`string_concat` extern — *REMOVED* (Refs #330): the
+canonical surface is the `++` operator (lowered in `Value.binop_string`
+and `__as_concat`); the extern was declared but never wired in any
+backend nor called from any stdlib/test/fixture — dead surface. The
+contract is now operator-only and one-source-of-truth. |S3 |DONE
+2026-05-24 (Refs #330)
 |STDLIB-04d |IO externs (`print`/`println`/`read_line`/`read_file`/
 `write_file`) — wired on all backends but no dedicated hermetic e2e
 tests; test-debt, not impl-debt |S3 |open — issue #331

--- a/stdlib/effects.affine
+++ b/stdlib/effects.affine
@@ -32,4 +32,8 @@ extern fn error<T>(msg: String) -> T / Throws;
 extern fn int_to_string(n: Int) -> String;
 extern fn string_to_int(s: String) -> Option<Int>;
 extern fn string_length(s: String) -> Int;
-extern fn string_concat(s1: String, s2: String) -> String;
+// `string_concat` removed (STDLIB-04c, Refs #330): the canonical surface
+// for string concatenation is the `++` operator, lowered directly in
+// `Value.binop_string` (interp) and `__as_concat` (Deno codegen). The
+// extern was declared but never wired in any backend nor called from
+// any stdlib/test/fixture file — dead surface.


### PR DESCRIPTION
## Summary

The `extern fn string_concat(s1: String, s2: String) -> String;` declared in `stdlib/effects.affine:35` was dead surface:

- Never wired in any backend (no entry in `lib/interp.ml` builtins or `lib/codegen_deno.ml` `deno_builtins` table).
- Never called from any stdlib, test, or fixture file (verified by `grep -rn string_concat`).

The canonical surface for string concatenation is the `++` operator, lowered in `Value.binop_string` (interp) and `__as_concat` (Deno codegen) — one source of truth.

Removing the dead extern eliminates the runtime trap where a caller could `use effects::{string_concat}`, get a clean compile, and then fail at run with `string_concat is not defined`.

## Test plan

- [x] `grep -rn string_concat stdlib/ lib/ test/` shows no callers
- [ ] CI: `dune runtest` — stdlib AOT gate must stay green (no fewer tests; this is pure removal)
- [ ] Hypatia DOC-FORMAT: no `.md` introduced

Updates `docs/TECH-DEBT.adoc` row 04c → DONE per the audit-split contract from #333.

Closes #330. Refs #175.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUHL3MH3yKKQAEhSZn4Thu)_