### PR TITLE
ci(migration-assistant): fix smoke-parse for tree-sitter-cli 0.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,14 @@ jobs:
         # ReScript source. Picks the existing res-to-affine test fixture
         # so any drift in the pinned commit's syntactic surface area
         # surfaces here rather than at walker-rule writing time.
+        #
+        # NOTE: tree-sitter-cli >= 0.25 repurposed `--paths` to mean "a
+        # file listing input source paths", not "a directory containing
+        # a grammar". Grammar lookup is now driven by the current
+        # working directory (the CLI walks up looking for grammar.js /
+        # src/parser.c), so we cd into the vendored grammar tree and
+        # pass an absolute path to the fixture. Without this, the step
+        # fails with `Failed to read paths file ... Is a directory`.
         run: |
           shopt -s nullglob
           fixtures=(tools/res-to-affine/test/fixtures/*.res)
@@ -190,9 +198,7 @@ jobs:
             echo "no .res fixtures to smoke-parse; skipping"
             exit 0
           fi
-          tree-sitter parse \
-            --quiet \
-            "${fixtures[0]}" \
-            --paths tools/vendor/tree-sitter-rescript \
-            > /dev/null
+          fixture_abs="$(realpath "${fixtures[0]}")"
+          ( cd tools/vendor/tree-sitter-rescript \
+              && tree-sitter parse --quiet "${fixture_abs}" > /dev/null )
           echo "smoke-parsed: ${fixtures[0]}"


### PR DESCRIPTION
## Summary

- `migration-assistant` has been failing on `main` and every PR (incl. docs-only #333, #336) at the "Smoke-parse a sample .res file" step with `Failed to read paths file tools/vendor/tree-sitter-rescript / Caused by: Is a directory (os error 21)`.
- Root cause: tree-sitter-cli >= 0.25 repurposed `--paths` to mean "a file listing input source paths", not "a directory containing the grammar". The `^0.25.0` range in `editors/tree-sitter-rescript/package.json` resolves to 0.25.10, where the flag's strict file requirement breaks the invocation introduced in #321.
- Fix: cd into the vendored grammar tree (the documented 0.25.x grammar-lookup mechanism) and pass an absolute path to the fixture. Drops the misused `--paths` flag entirely.

The pinned grammar commit `990214a` is unchanged, the install script is unchanged, and the failure is not diff-induced.

## Test plan

- [x] Reproduced the failure locally with tree-sitter-cli 0.25.10 + the pinned grammar commit.
- [x] Verified the new invocation exits 0 on the existing `tools/res-to-affine/test/fixtures/sample.res` fixture.
- [ ] CI run on this PR turns the `migration-assistant` job green.

Strict scope per request: only `.github/workflows/ci.yml` migration-assistant block touched. No changes to `editors/tree-sitter-rescript/` or `tools/res-to-affine/vendor/` were required.

https://claude.ai/code/session_01HZ3i2wX5R5rbY8Ycmug4Ao

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ3i2wX5R5rbY8Ycmug4Ao)_