### PR TITLE
fix(interp): `eval_decl` handles `FnExtern` (#328 build-failure root cause)

### DIFF
--- a/lib/interp.ml
+++ b/lib/interp.ml
@@ -1027,14 +1027,25 @@ let create_initial_env () : env =
 let eval_decl (env : env) (decl : top_level) : env result =
   match decl with
   | TopFn fd ->
-    let closure = VClosure {
-      cl_params = fd.fd_params;
-      cl_body = (match fd.fd_body with
-        | FnBlock blk -> ExprBlock blk
-        | FnExpr e -> e);
-      cl_env = env;
-    } in
-    Ok (extend_env fd.fd_name.name closure env)
+    (match fd.fd_body with
+     | FnExtern ->
+       (* Externs have no AST body to evaluate. Their runtime binding is
+          provided by [create_initial_env]'s builtin table (panic, error,
+          make_ref, …). Skip here so an inline `extern fn` declaration in
+          a test source (e.g. the STDLIB-04a Mut round-trip tests) doesn't
+          blow up the [FnBlock|FnExpr] match below.
+          Refs #328 root-cause for the interp pattern-match-failure. *)
+       Ok env
+     | FnBlock _ | FnExpr _ ->
+       let closure = VClosure {
+         cl_params = fd.fd_params;
+         cl_body = (match fd.fd_body with
+           | FnBlock blk -> ExprBlock blk
+           | FnExpr e -> e
+           | FnExtern -> assert false (* unreachable: outer match guards *));
+         cl_env = env;
+       } in
+       Ok (extend_env fd.fd_name.name closure env))
 
   | TopConst tc ->
     let* v = eval env tc.tc_value in


### PR DESCRIPTION
## Summary

Unbreaks main's `dune runtest` gate — root cause of the 2-test failure baseline that's been red since #334 merged.

## Root cause

`eval_decl`'s `TopFn fd` arm matched `fd.fd_body` against only `FnBlock` and `FnExpr`, leaving `FnExtern` unmatched. Every prior interp test imported externs via `use effects::{…}` so this case never fired — the bug was latent.

The STDLIB-04a (#328) hermetic tests are the **first** to include an inline `extern fn make_ref<T>(x: T) -> Ref<T> / Mut;` declaration in the source they hand to `Interp.eval_program`. That triggers the missing arm and raises:

```
File "lib/interp.ml", line 1010, characters 16-21: Pattern matching failed
  Raised at Affinescript__Interp.eval_decl
```

Reproduces the `2 failures! in 0.088s. 298 tests run.` line from every PR's `build` log since #334.

## Fix

Wrap the body lowering in an outer `match fd.fd_body with`:

- `FnExtern` → `Ok env` (externs are runtime-bound via `create_initial_env`'s `VBuiltin` table — `panic` / `error` / `make_ref` / `get` / `set` / etc., not via the AST).
- `FnBlock _ | FnExpr _` → existing closure construction.

The inner inner-match's `FnExtern` arm is `assert false` with a comment — it's unreachable per the outer guard and the assert makes that explicit for the next reader.

## Verification

The two failing tests (`#328 make_ref/set/get round-trip (Int)` and `(String)`) now have a defined evaluation path. The third 04a test (Deno codegen `__cell` shape) already passed — it bypasses interp.

## Test plan

- [ ] CI `build` job: `2 failures!` → `298 tests run` clean
- [ ] CI `lint`: should also clear (was likely propagating from the same root)
- [ ] Hypatia DOC-FORMAT: no `.md` introduced

Refs #328.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUHL3MH3yKKQAEhSZn4Thu)_