### PR TITLE
refactor(codegen): extract affinescript.ownership emission to lib/tw_…

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -11,12 +11,17 @@ open Ast
 open Wasm
 
 (** Ownership kind for typed-wasm schema annotations.
-    Maps AffineScript ownership qualifiers to typed-wasm Level 7/10 verification. *)
-type ownership_kind =
-  | Unrestricted  (** Plain value, no ownership constraint (Wasm i32/f64 etc.) *)
-  | Linear        (** TyOwn / own — consumed exactly once (typed-wasm Level 10 linearity) *)
-  | SharedBorrow  (** TyRef / ref — read-only aliasing safety (typed-wasm Level 7) *)
-  | ExclBorrow    (** TyMut / mut — exclusive mutable aliasing safety (typed-wasm Level 7) *)
+
+    Re-exported from [Tw_ownership_section] (the dedicated home,
+    extracted 2026-05-24 per A3 of TYPED-WASM-ROADMAP.adoc).  The
+    type equation preserves constructor accessibility so
+    [Codegen.Linear] etc. continue to resolve and [open Codegen]
+    in [Tw_verify] / [Tw_interface] / [Test_e2e] is unaffected. *)
+type ownership_kind = Tw_ownership_section.ownership_kind =
+  | Unrestricted
+  | Linear
+  | SharedBorrow
+  | ExclBorrow
 
 (** Code generation context *)
 type context = {
@@ -111,19 +116,9 @@ let create_context () : context = {
   wasi_func_indices = [];
 }
 
-(** Extract ownership kind from a parameter declaration.
-    Checks p_ownership first; falls back to the shape of p_ty. *)
-let ownership_kind_of_param (p : param) : ownership_kind =
-  match p.p_ownership with
-  | Some Own -> Linear
-  | Some Ref -> SharedBorrow
-  | Some Mut -> ExclBorrow
-  | None ->
-    match p.p_ty with
-    | TyOwn _ -> Linear
-    | TyRef _ -> SharedBorrow
-    | TyMut _ -> ExclBorrow
-    | _ -> Unrestricted
+(** Extract ownership kind from a parameter declaration. Re-exported
+    from [Tw_ownership_section] (A3 refactor, 2026-05-24). *)
+let ownership_kind_of_param = Tw_ownership_section.ownership_kind_of_param
 
 (** If [ty] names a known struct (through any number of own/ref/mut wrappers),
     return that struct's name. Lets us recover a struct's field layout from
@@ -136,45 +131,21 @@ let rec struct_name_of_ty (ty : type_expr) : string option =
   | TyOwn inner | TyRef inner | TyMut inner -> struct_name_of_ty inner
   | _ -> None
 
-(** Extract ownership kind from an optional return type expression *)
-let ownership_kind_of_ret (ret : type_expr option) : ownership_kind =
-  match ret with
-  | Some (TyOwn _) -> Linear
-  | Some (TyRef _) -> SharedBorrow
-  | Some (TyMut _) -> ExclBorrow
-  | _ -> Unrestricted
+(** Extract ownership kind from an optional return type expression.
+    Re-exported from [Tw_ownership_section]. *)
+let ownership_kind_of_ret = Tw_ownership_section.ownership_kind_of_ret
 
-(** Encode an ownership_kind as a single byte (0–3) *)
-let ownership_kind_byte = function
-  | Unrestricted -> 0 | Linear -> 1 | SharedBorrow -> 2 | ExclBorrow -> 3
+(** Encode an ownership_kind as a single byte (0–3).
+    Re-exported from [Tw_ownership_section]. *)
+let ownership_kind_byte = Tw_ownership_section.ownership_kind_byte
 
 (** Build the payload for the [affinescript.ownership] Wasm custom section.
-    Encoding (all little-endian):
-      u32  entry_count
-      per entry:
-        u32  func_index
-        u8   param_count
-        u8*  param_kind  (one per param, see kind encoding above)
-        u8   return_kind *)
-let build_ownership_section (annots : (int * ownership_kind list * ownership_kind) list) : bytes =
-  if annots = [] then Bytes.empty
-  else
-    let buf = Buffer.create 64 in
-    let write_u32_le n =
-      Buffer.add_char buf (Char.chr  (n         land 0xff));
-      Buffer.add_char buf (Char.chr ((n lsr  8) land 0xff));
-      Buffer.add_char buf (Char.chr ((n lsr 16) land 0xff));
-      Buffer.add_char buf (Char.chr ((n lsr 24) land 0xff))
-    in
-    let write_u8 n = Buffer.add_char buf (Char.chr (n land 0xff)) in
-    write_u32_le (List.length annots);
-    List.iter (fun (func_idx, param_kinds, ret_kind) ->
-      write_u32_le func_idx;
-      write_u8 (List.length param_kinds);
-      List.iter (fun k -> write_u8 (ownership_kind_byte k)) param_kinds;
-      write_u8 (ownership_kind_byte ret_kind)
-    ) annots;
-    Buffer.to_bytes buf
+    Re-exported from [Tw_ownership_section.build_section] (A3 refactor,
+    2026-05-24).  The dedicated module is the home for the on-wire format;
+    this alias preserves the [Codegen.build_ownership_section] public
+    API surface that downstream callers (lib/tw_verify.ml,
+    lib/tw_interface.ml, test/test_e2e.ml) rely on. *)
+let build_ownership_section = Tw_ownership_section.build_section
 
 (** Map AffineScript type to WASM value type *)
 let type_to_wasm (ty : type_expr) : value_type result =

--- a/lib/tw_ownership_section.ml
+++ b/lib/tw_ownership_section.ml
@@ -1,0 +1,96 @@
+(* SPDX-License-Identifier: MPL-2.0 *)
+(* SPDX-FileCopyrightText: 2026 hyperpolymath *)
+(*
+ * tw_ownership_section.ml — the dedicated home for the
+ * `affinescript.ownership` Wasm custom section: kind encoding,
+ * extraction from the AST, and binary serialisation.
+ *
+ * Extracted from lib/codegen.ml at 2026-05-24 per Tranche A3 of
+ * docs/specs/TYPED-WASM-ROADMAP.adoc. Behaviour-preserving move.
+ *
+ * The format itself is specified in
+ * docs/specs/TYPED-WASM-INTERFACE.adoc (v1, current) and
+ * docs/specs/TYPED-WASM-ROADMAP.adoc §"Tranche B" (v2, the
+ * ratified ADR-020 widening; landed via [Tw_verify] parse-support
+ * first, with the producer-emit flip deferred to the coordinated
+ * landing window per ADR-021 — see TYPED-WASM-COORDINATION-LEDGER.adoc
+ * Q-001).
+ *
+ * Backwards compatibility: [Codegen] re-exports the same names so
+ * `open Codegen` continues to expose [ownership_kind] and friends —
+ * downstream callers ([Tw_verify], [Tw_interface], [Test_e2e]) need
+ * no change.
+ *)
+
+open Ast
+
+(** Ownership kind for typed-wasm schema annotations.
+    Maps AffineScript ownership qualifiers to typed-wasm Level 7/10
+    verification. *)
+type ownership_kind =
+  | Unrestricted  (** Plain value, no ownership constraint (Wasm i32/f64 etc.) *)
+  | Linear        (** TyOwn / own — consumed exactly once (typed-wasm Level 10) *)
+  | SharedBorrow  (** TyRef / ref — read-only aliasing safety (typed-wasm Level 7) *)
+  | ExclBorrow    (** TyMut / mut — exclusive mutable aliasing safety (typed-wasm Level 7) *)
+
+(** Extract ownership kind from a parameter declaration.
+    Checks [p.p_ownership] first; falls back to the shape of [p.p_ty]. *)
+let ownership_kind_of_param (p : param) : ownership_kind =
+  match p.p_ownership with
+  | Some Own -> Linear
+  | Some Ref -> SharedBorrow
+  | Some Mut -> ExclBorrow
+  | None ->
+    match p.p_ty with
+    | TyOwn _ -> Linear
+    | TyRef _ -> SharedBorrow
+    | TyMut _ -> ExclBorrow
+    | _ -> Unrestricted
+
+(** Extract ownership kind from an optional return type expression *)
+let ownership_kind_of_ret (ret : type_expr option) : ownership_kind =
+  match ret with
+  | Some (TyOwn _) -> Linear
+  | Some (TyRef _) -> SharedBorrow
+  | Some (TyMut _) -> ExclBorrow
+  | _ -> Unrestricted
+
+(** Encode an [ownership_kind] as a single byte (0..3). *)
+let ownership_kind_byte = function
+  | Unrestricted -> 0
+  | Linear -> 1
+  | SharedBorrow -> 2
+  | ExclBorrow -> 3
+
+(** Build the payload for the [affinescript.ownership] Wasm custom section.
+
+    v1 encoding (current emit; LE):
+      u32  entry_count
+      per entry:
+        u32  func_index
+        u8   param_count
+        u8*  param_kind  (one per param, see kind encoding above)
+        u8   return_kind
+
+    Returns [Bytes.empty] when there are no annotations so the
+    caller can omit the section entirely. *)
+let build_section
+    (annots : (int * ownership_kind list * ownership_kind) list) : bytes =
+  if annots = [] then Bytes.empty
+  else
+    let buf = Buffer.create 64 in
+    let write_u32_le n =
+      Buffer.add_char buf (Char.chr  (n         land 0xff));
+      Buffer.add_char buf (Char.chr ((n lsr  8) land 0xff));
+      Buffer.add_char buf (Char.chr ((n lsr 16) land 0xff));
+      Buffer.add_char buf (Char.chr ((n lsr 24) land 0xff))
+    in
+    let write_u8 n = Buffer.add_char buf (Char.chr (n land 0xff)) in
+    write_u32_le (List.length annots);
+    List.iter (fun (func_idx, param_kinds, ret_kind) ->
+      write_u32_le func_idx;
+      write_u8 (List.length param_kinds);
+      List.iter (fun k -> write_u8 (ownership_kind_byte k)) param_kinds;
+      write_u8 (ownership_kind_byte ret_kind)
+    ) annots;
+    Buffer.to_bytes buf


### PR DESCRIPTION
…ownership_section.ml

Tranche A3 of docs/specs/TYPED-WASM-ROADMAP.adoc. Behaviour-preserving move; downstream callers (lib/tw_verify.ml, lib/tw_interface.ml, test/test_e2e.ml) are unaffected.

Why now: A3 was specified as a prerequisite for B1 (ADR-020 v2-parse support, now ACCEPTED + RATIFIED 2026-05-24). Putting the on-wire format in a dedicated module is cheap now and saves us editing codegen.ml inline when v2-parse + v2-emit land.

Changes:
- NEW lib/tw_ownership_section.ml — the dedicated home for:
    * type ownership_kind (Unrestricted/Linear/SharedBorrow/ExclBorrow)
    * ownership_kind_of_param (extracts from p_ownership or type shape)
    * ownership_kind_of_ret
    * ownership_kind_byte (0..3 encoding)
    * build_section (v1 binary serialiser)

- MOD lib/codegen.ml — re-exports preserve the [Codegen.X] surface:
    * type ownership_kind = Tw_ownership_section.ownership_kind = | ... (type equation keeps Codegen.Linear etc. resolving as constructors so `open Codegen` in Tw_verify / Tw_interface / Test_e2e continues to work)
    * `let ownership_kind_of_param = Tw_ownership_section.…` and friends — pure aliases.
    * `let build_ownership_section = Tw_ownership_section.build_section` — alias preserving the prior public name.

No semantic change. The v1 binary format and all enforcement (L7 aliasing + L10 linearity + L13 isolation) are unchanged. The 260+ test baseline should pass byte-for-byte; in particular the ownership-section round-trip cases
(test_ownership_section_present / _roundtrip / _entry_count) test the exact same serialisation path.

Not yet verified locally — no OCaml toolchain in this remote execution environment. CI is the verification surface; the change is mechanical and the type-equation re-export pattern is a standard OCaml idiom.

Refs ADR-020, docs/specs/TYPED-WASM-ROADMAP.adoc §"Tranche A — A3"