### PR TITLE
fix(borrow): escape `(*r` inside doc-comment examples (unblocks main …

### DIFF
--- a/lib/borrow.ml
+++ b/lib/borrow.ml
@@ -1112,7 +1112,7 @@ and check_block (ctx : context) (state : state) (symbols : Symbol.t) (blk : bloc
      statement we expire any ref-binding introduced in *this* block whose
      binder's last use has already passed, releasing the underlying
      borrow. This is the non-lexical-lifetimes win — patterns like
-     [let r = &x; print(*r); x = 2] now type-check, while the
+     [let r = &x; print( *r); x = 2] now type-check, while the
      anti-aliasing rules remain sound because the borrow is still live
      across statements that *do* use the binder. *)
   let last_use = compute_last_use_index symbols blk in
@@ -1335,7 +1335,7 @@ let check_program (symbols : Symbol.t) (program : program) : unit result =
    counts as the n-th statement); after each statement, check_block
    releases the underlying borrow of any in-block ref-binding whose
    binder is now dead. Unblocks the canonical NLL patterns
-   ([let r = &x; print(*r); x = 2] and [let m = &mut x; let y = *m; x]),
+   ([let r = &x; print( *r); x = 2] and [let m = &mut x; let y = *m; x]),
    while still rejecting real conflicts (the anti-aliasing rules fire
    against statements that *do* use the binder, before expiry).
    Outer-block ref-bindings are deliberately preserved — they expire


### PR DESCRIPTION
…gate)

Two `print(*r)` example fragments inside doc-comment blocks (lines 1115 and 1338) contained the literal substring `(*r`, which OCaml's lexer treats as a nested comment opener — bringing the outer comment to depth 2 with only one matching `*)` to close it. Result: "Comment not terminated" at EOF on every `dune build`. Marker count was 126 `(*` vs 124 `*)` (off by 2, one per offending example); after this patch it is 124 / 124.

This has blocked main's `dune build` since #335 (CORE-01 pt3 Slice A) merged, which is why every subsequent PR (#341, #344, the open #346) has shown `build` red regardless of its own changes. Tiny fix; high leverage.

Fix: insert a single space inside the parens — `print( *r)` — so the lexer sees `(` `*` `r` `)` rather than the comment-open token `(*` followed by `r`. Reader-friendly; the example still reads the same.

No behavioural change. No code touched. Comment text only.

Diagnosed by parallel claude (INT-03 / S5 thread). Refs #335