### PR TITLE
test: inline-extern shape coverage (Refs #346)

### DIFF
--- a/test/e2e/fixtures/inline_extern_effectful.affine
+++ b/test/e2e/fixtures/inline_extern_effectful.affine
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// Inline-extern fixture (effectful): an `extern fn` declaration
+// whose return type carries an effect row.  Exercises the same path
+// as inline_extern_pure plus the effect-row resolution branch in
+// typecheck.  Pinned against the gate so a regression to the
+// pre-#346 silent-failure shape would fail loudly.
+//
+// See .claude/CLAUDE.md §"Test-fixture hygiene for latent bug
+// surfaces".
+
+effect IO;
+
+extern fn host_log(msg: String) -> Unit / IO;
+
+pub fn main() -> Int {
+  return 0;
+}

--- a/test/e2e/fixtures/inline_extern_polymorphic.affine
+++ b/test/e2e/fixtures/inline_extern_polymorphic.affine
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// Inline-extern fixture (polymorphic): an `extern fn` declaration
+// with type parameters.  Exercises the polymorphic-scheme registration
+// path that the FnExtern special case in typecheck handles
+// (see lib/typecheck.ml `check_fn_decl` `FnExtern` arm).
+//
+// See .claude/CLAUDE.md §"Test-fixture hygiene for latent bug
+// surfaces".
+
+extern fn host_identity[T](x: T) -> T;
+
+pub fn main() -> Int {
+  return 0;
+}

--- a/test/e2e/fixtures/inline_extern_pure.affine
+++ b/test/e2e/fixtures/inline_extern_pure.affine
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// Inline-extern fixture (pure): an `extern fn` declaration with no
+// effect row, fed to the full pipeline (parse → resolve → typecheck
+// → interp).  Counterpart to the missing `FnExtern` arm in
+// Interp.eval_decl that PR #346 fixed; this fixture pins the
+// "no-effect inline extern" shape against the gate so a regression
+// to the silent-pattern-match-failure path of the kind that broke
+// main between #334 and #346 would fail loudly here instead.
+//
+// See .claude/CLAUDE.md §"Test-fixture hygiene for latent bug
+// surfaces" and the comment on PR #346 for the rationale.
+
+extern fn host_pure_identity(x: Int) -> Int;
+
+pub fn main() -> Int {
+  // The call itself doesn't have to succeed at runtime — the
+  // interpreter's VBuiltin table doesn't know about
+  // host_pure_identity — but parse + resolve + typecheck + the
+  // eval_decl arm for FnExtern MUST all return Ok.  The check_program
+  // test driver asserts that, not the runtime value.
+  return 0;
+}

--- a/test/e2e/fixtures/inline_extern_type_consumed.affine
+++ b/test/e2e/fixtures/inline_extern_type_consumed.affine
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// Inline-extern fixture (extern type + extern fn together):
+// an opaque host type declared inline and consumed by an extern
+// function in the same unit.  Exercises both TyExtern registration
+// and the FnExtern path that consumes the resulting type.
+//
+// See .claude/CLAUDE.md §"Test-fixture hygiene for latent bug
+// surfaces".
+
+extern type Handle;
+
+extern fn host_use(h: Handle) -> Int;
+
+pub fn main() -> Int {
+  return 0;
+}

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -3834,6 +3834,80 @@ let qualified_value_tests = [
   Alcotest.test_case "use Mod as M; M::fn(x) resolves (#178 follow-up)" `Quick test_qualval_coloncolon_alias_call;
 ]
 
+(* ---- Inline `extern fn` / `extern type` shape-coverage fixtures ----
+   Class-level coverage for the "first user of an inline extern shape
+   feeds it to every downstream consumer" surface that produced the
+   PR #346 FnExtern interp bug (eval_decl missing match arm — survived
+   since the interpreter was written, fired the moment STDLIB-04a's
+   tests became the first to hand an inline extern fn to
+   Interp.eval_program).
+
+   See .claude/CLAUDE.md §"Test-fixture hygiene for latent bug
+   surfaces" for the rationale. Each fixture is fed through
+   parse → resolve → typecheck → interp; the assertion is that ALL
+   four return Ok. A regression that re-introduces the silent
+   pattern-match-failure path of the kind that broke main between
+   #334 and #346 would fail loudly here. *)
+
+let inline_extern_pipeline_ok path : bool =
+  let loader = Module_loader.create {
+    Module_loader.stdlib_path = "stdlib";
+    search_paths = [];
+    current_dir = fixture_dir;
+  } in
+  match parse_fixture path with
+  | Error _ -> false
+  | Ok raw ->
+    let prog = Resolve.lower_qualified_value_paths raw in
+    (match Resolve.resolve_program_with_loader prog loader with
+     | Error _ -> false
+     | Ok (resolve_ctx, import_type_ctx) ->
+       (match Typecheck.check_program
+                ~import_types:import_type_ctx.Typecheck.name_types
+                resolve_ctx.symbols prog with
+        | Error _ -> false
+        | Ok _ ->
+          (* The PR #346 root cause was here: Interp.eval_decl's TopFn
+             arm didn't match FnExtern, raising Match_failure. The
+             fixtures don't *call* the extern at runtime (the host
+             impl isn't registered), but eval_program walks every
+             TopFn through eval_decl as part of building the initial
+             env — that's the path that fired the missing arm. *)
+          (match Interp.eval_program prog with
+           | Ok _ -> true
+           | Error _ -> false)))
+
+let test_inline_extern_pure () =
+  Alcotest.(check bool)
+    "inline `extern fn host_pure_identity(x: Int) -> Int;` passes the pipeline"
+    true
+    (inline_extern_pipeline_ok (fixture "inline_extern_pure.affine"))
+
+let test_inline_extern_effectful () =
+  Alcotest.(check bool)
+    "inline `extern fn host_log(msg) -> Unit / IO;` passes the pipeline"
+    true
+    (inline_extern_pipeline_ok (fixture "inline_extern_effectful.affine"))
+
+let test_inline_extern_polymorphic () =
+  Alcotest.(check bool)
+    "inline `extern fn host_identity[T](x: T) -> T;` passes the pipeline"
+    true
+    (inline_extern_pipeline_ok (fixture "inline_extern_polymorphic.affine"))
+
+let test_inline_extern_type_consumed () =
+  Alcotest.(check bool)
+    "inline `extern type Handle; extern fn host_use(h: Handle) -> Int;` passes the pipeline"
+    true
+    (inline_extern_pipeline_ok (fixture "inline_extern_type_consumed.affine"))
+
+let inline_extern_shape_tests = [
+  Alcotest.test_case "pure (no effects)"           `Quick test_inline_extern_pure;
+  Alcotest.test_case "effectful (effect row)"      `Quick test_inline_extern_effectful;
+  Alcotest.test_case "polymorphic (type params)"   `Quick test_inline_extern_polymorphic;
+  Alcotest.test_case "extern type + consuming fn"  `Quick test_inline_extern_type_consumed;
+]
+
 (* ---- Type-syntax sugars: fn(...) -> T, Option<T>, (A, B) -> C ---- *)
 
 let parse_check_passes src : bool =
@@ -4304,6 +4378,7 @@ let tests =
     ("E2E Array Type Sugar",     array_type_tests);
     ("E2E Qualified Paths #228",  qualified_path_tests);
     ("E2E Qualified Value #178",  qualified_value_tests);
+    ("E2E Inline Extern Shapes (Refs #346)", inline_extern_shape_tests);
     ("E2E WasmGC PatCon Destructure", wasm_gc_patcon_tests);
     ("E2E Type Syntax Sugar",         type_syntax_sugar_tests);
   ]


### PR DESCRIPTION
## Summary

Adds **class-level coverage** for the "inline extern fed to every downstream consumer" surface that produced the PR #346 `FnExtern` interp bug (`Interp.eval_decl`'s `TopFn` arm missing the `FnExtern` match arm — silent pattern-match failure since the interpreter was written; fired the moment STDLIB-04a's tests became the first to hand an inline `extern fn` to `Interp.eval_program`).

Queued as a [comment on PR #346](https://github.com/hyperpolymath/affinescript/pull/346#issuecomment-4529343653) in the previous session; this is the follow-up.

## What this PR adds

Four fixtures under `test/e2e/fixtures/`:

| Fixture | Shape |
|---------|-------|
| `inline_extern_pure.affine` | `extern fn host_pure_identity(x: Int) -> Int;` (no effects) |
| `inline_extern_effectful.affine` | `extern fn host_log(msg: String) -> Unit / IO;` (effect row) |
| `inline_extern_polymorphic.affine` | `extern fn host_identity[T](x: T) -> T;` (type params) |
| `inline_extern_type_consumed.affine` | `extern type Handle; extern fn host_use(h: Handle) -> Int;` |

Each fed through **parse → resolve → typecheck → interp** via the new `inline_extern_pipeline_ok` helper in `test/test_e2e.ml`. Assertion: all four phases return `Ok`. A regression that re-introduces the silent pattern-match-failure path that broke main between #334 and #346 would fail loudly here instead.

Suite registered as `"E2E Inline Extern Shapes (Refs #346)"`.

## Why this matters

Per the `.claude/CLAUDE.md` §"Test-fixture hygiene for latent bug surfaces" rule landed this session: when adding a stdlib `extern fn` (or any other new declaration shape), test it against **every downstream consumer** (parse / resolve / typecheck / interp / codegen). PR #346 fixed *one* instance of this class; this PR pins the *class* against the gate so the next latent gap of the same shape (an `extern type` consumed by an `extern fn` in a module that other modules import, etc.) surfaces against CI rather than against the next agent.

## Test plan

- [ ] CI `build` job clean
- [ ] CI `dune runtest` — four new alcotest cases pass; existing suite unchanged
- [ ] No new lints

Refs #346, Refs `.claude/CLAUDE.md` §"Test-fixture hygiene for latent bug surfaces"

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHUYQEPKgQU6jBgUj4snYU)_