### PR TITLE
fix(stdlib): wire env_at / arg_at surface — codegen lowers via gen_str_at_via_get (ADR-015 S5, #180)

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -29,8 +29,15 @@
 (executable
  (name bench_main)
  (libraries affinescript alcotest unix)
- (modules bench_main bench_fixtures bench_lex bench_parse bench_typecheck bench_codegen))
+ (modules
+  bench_main
+  bench_fixtures
+  bench_lex
+  bench_parse
+  bench_typecheck
+  bench_codegen))
 
 (rule
  (alias bench)
- (action (run %{exe:bench_main.exe})))
+ (action
+  (run %{exe:bench_main.exe})))

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -908,6 +908,17 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
         in
         Ok (ctx_with_heap, code)
 
+      | ExprVar id when id.name = "string_length" && List.length args = 1 ->
+        (* STDLIB-04e (#332) wasm-backend lowering. AS string layout is
+           `[len: i32][bytes...]` at the pointer the arg evaluates to —
+           reading the length is one i32.load at offset 0. The interp
+           binding (lib/interp.ml) was wired in #362; this handler is
+           the codegen sibling so tests/codegen/*.affine fixtures that
+           call string_length (env_at / arg_at / env_count_and_at) can
+           compile end-to-end. *)
+        let* (ctx_with_arg, arg_code) = gen_expr ctx (List.hd args) in
+        Ok (ctx_with_arg, arg_code @ [I32Load (2, 0)])
+
       | ExprVar id when (id.name = "env_at" || id.name = "arg_at")
                         && List.length args = 1 ->
         (* ADR-015 S5 (#180): env_at(i) / arg_at(i) — fetch the i-th

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -888,8 +888,7 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
            (added on-demand at module assembly; idx looked up in
            [ctx.wasi_func_indices]). The Unit arg satisfies the
            zero-param-fn collapse wart; it is evaluated but its value
-           is unused. String accessors (env_at/arg_at) need byte-level
-           wasm IR ops (currently absent) and are a tracked follow-up. *)
+           is unused. String accessors env_at/arg_at are below. *)
         let wasi_name =
           if id.name = "env_count" then "environ_sizes_get"
           else "args_sizes_get"
@@ -906,6 +905,49 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
           arg_code @ [Drop] @
           Wasi_runtime.gen_count_via_sizes_get
             heap_idx scratch_local sizes_func_idx
+        in
+        Ok (ctx_with_heap, code)
+
+      | ExprVar id when (id.name = "env_at" || id.name = "arg_at")
+                        && List.length args = 1 ->
+        (* ADR-015 S5 (#180): env_at(i) / arg_at(i) — fetch the i-th
+           entry from the WASI environ/argv vector and return as a
+           length-prefixed AS string. Lowers via [gen_str_at_via_get]
+           which needs 8 fresh locals + two WASI imports (sizes_get
+           paired with get). All locals are pre-allocated here and
+           passed by index; the helper does not modify the type/scope
+           context. The sizes_get import is shared with env_count /
+           arg_count when both are used in the same module; dedup is
+           done in the optional_wasi assembly below. *)
+        let (sizes_name, get_name) =
+          if id.name = "env_at"
+          then ("environ_sizes_get", "environ_get")
+          else ("args_sizes_get", "args_get")
+        in
+        let sizes_func_idx =
+          try List.assoc sizes_name ctx.wasi_func_indices
+          with Not_found -> 1
+        in
+        let get_func_idx =
+          try List.assoc get_name ctx.wasi_func_indices
+          with Not_found -> 1
+        in
+        let* (ctx_with_arg, arg_code) = gen_expr ctx (List.hd args) in
+        let (ctx1, scratch_local)  = alloc_local ctx_with_arg ("__" ^ id.name ^ "_scratch") in
+        let (ctx2, count_local)    = alloc_local ctx1 ("__" ^ id.name ^ "_count") in
+        let (ctx3, bufsize_local)  = alloc_local ctx2 ("__" ^ id.name ^ "_bufsize") in
+        let (ctx4, ptrvec_local)   = alloc_local ctx3 ("__" ^ id.name ^ "_ptrvec") in
+        let (ctx5, src_local)      = alloc_local ctx4 ("__" ^ id.name ^ "_src") in
+        let (ctx6, dst_local)      = alloc_local ctx5 ("__" ^ id.name ^ "_dst") in
+        let (ctx7, result_local)   = alloc_local ctx6 ("__" ^ id.name ^ "_result") in
+        let (ctx8, n_local)        = alloc_local ctx7 ("__" ^ id.name ^ "_n") in
+        let (ctx_with_heap, heap_idx) = ensure_heap_ptr ctx8 in
+        let code =
+          arg_code @
+          Wasi_runtime.gen_str_at_via_get
+            heap_idx n_local scratch_local count_local
+            bufsize_local ptrvec_local src_local dst_local result_local
+            sizes_func_idx get_func_idx
         in
         Ok (ctx_with_heap, code)
 
@@ -2564,14 +2606,34 @@ let generate_module ?loader (prog : program) : wasm_module result =
       false prog
   in
   let optional_wasi =
-    (* (guest_builtin_name, wasi_import_name, factory) — canonical order. *)
+    (* (guest_builtin_name, wasi_import_name, factory) — canonical order.
+       ADR-015 S5 (#180): env_at/arg_at each require TWO WASI imports
+       (sizes_get + get), so they appear as two rows. When env_count
+       and env_at are both used the sizes_get row is requested by
+       both — the dedup pass below collapses duplicates by wasi
+       import name (keep first occurrence) so the resulting module
+       has at most one import per WASI function. *)
     [ ("clock_now_ms", "clock_time_get",     Wasi_runtime.create_clock_time_get_import);
       ("env_count",    "environ_sizes_get",  Wasi_runtime.create_environ_sizes_get_import);
       ("arg_count",    "args_sizes_get",     Wasi_runtime.create_args_sizes_get_import);
+      ("env_at",       "environ_sizes_get",  Wasi_runtime.create_environ_sizes_get_import);
+      ("env_at",       "environ_get",        Wasi_runtime.create_environ_get_import);
+      ("arg_at",       "args_sizes_get",     Wasi_runtime.create_args_sizes_get_import);
+      ("arg_at",       "args_get",           Wasi_runtime.create_args_get_import);
       ("net_shutdown", "sock_shutdown",      Wasi_runtime.create_sock_shutdown_import);
     ]
     |> List.filter_map
          (fun (b, w, f) -> if uses b then Some (w, f ()) else None)
+    (* Dedup by wasi import name, keep first occurrence. Needed because
+       env_at + env_count both request environ_sizes_get; without dedup
+       the wasm would have two imports under the same name and
+       instantiation would fail. *)
+    |> List.fold_left (fun (seen, acc) (w, imp_ty) ->
+         if List.mem w seen then (seen, acc)
+         else (w :: seen, (w, imp_ty) :: acc)
+       ) ([], [])
+    |> snd
+    |> List.rev
     |> List.mapi (fun i (w, (imp, ty)) -> (i + 1, w, imp, ty))
   in
   let opt_types = List.map (fun (_, _, _, ty) -> ty) optional_wasi in

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -57,6 +57,10 @@ let seed_builtins (symbols : Symbol.t) : unit =
   def "clock_now_ms";
   (* WASI env / argv counts (ADR-015 S4b, #180) *)
   def "env_count"; def "arg_count";
+  (* WASI env / argv string accessors (ADR-015 S5, #180). Each lowers to
+     a `*_sizes_get` + `*_get` pair plus a byte-scan; codegen emits the
+     full helper inline via [Wasi_runtime.gen_str_at_via_get]. *)
+  def "env_at"; def "arg_at";
   (* WASI socket primitive (ADR-015 S6b, #180) *)
   def "net_shutdown";
   (* String / char builtins *)

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -1329,6 +1329,12 @@ let register_builtins (ctx : context) : unit =
      follow-up. Effect row `Time` (reserved). *)
   bind_var ctx "env_count" (TArrow (ty_unit, QOmega, ty_int, ESingleton "Time"));
   bind_var ctx "arg_count" (TArrow (ty_unit, QOmega, ty_int, ESingleton "Time"));
+  (* ADR-015 S5 (#180): env_at(i) / arg_at(i) -> String / Time.
+     Lowers via [Wasi_runtime.gen_str_at_via_get] (8-local scratch +
+     byte-scan + heap-allocated AS string). Effect row matches the
+     count siblings since they share the WASI environ/args surface. *)
+  bind_var ctx "env_at" (TArrow (ty_int, QOmega, ty_string, ESingleton "Time"));
+  bind_var ctx "arg_at" (TArrow (ty_int, QOmega, ty_string, ESingleton "Time"));
   (* ADR-015 S6b (#180): WASI socket primitive. `net_shutdown(fd, how)`
      -> Int errno (0 on success, ENOTSOCK on a non-socket fd, etc.).
      `how`: 1 = RD, 2 = WR, 3 = RDWR. Lowers to a


### PR DESCRIPTION
## Summary

4th baseline-rot iteration after #361 / #362 / the `.hypatia-ignore` format fix. The codegen-test fixtures `tests/codegen/{env_at,arg_at,env_count_and_at}.affine` all reference `env_at` / `arg_at`, but those surface names were **never wired** in `resolve.ml` or `typecheck.ml` — `dune runtest` hits `Resolve.UndefinedVariable` before codegen even fires.

The wasm IR + helper was added in commit `58f08b9` (ADR-015 S5) but the surface plumbing was left out. This PR completes the surface.

## What's wired

| Layer | File | Change |
|---|---|---|
| Resolver | `lib/resolve.ml` | `def "env_at"; def "arg_at"` |
| Typechecker | `lib/typecheck.ml` | `Int -> String / Time` for both (matches the effect row of `env_count` / `arg_count`) |
| Codegen — dispatch | `lib/codegen.ml` | New `ExprApp` handler right after `env_count`/`arg_count`. Allocates 8 fresh locals (n / scratch / count / bufsize / ptrvec / src / dst / result), looks up matching sizes_get + get WASI func indices, calls `Wasi_runtime.gen_str_at_via_get` (already present, just unreferenced). |
| Codegen — WASI imports | `lib/codegen.ml` `optional_wasi` table | Four new rows: `("env_at", "environ_sizes_get")`, `("env_at", "environ_get")`, `("arg_at", "args_sizes_get")`, `("arg_at", "args_get")`. |
| Codegen — dedup | `lib/codegen.ml` `optional_wasi` table | New dedup pass keyed by WASI import name (keep first occurrence). Required because `env_count + env_at` both want `environ_sizes_get`; without dedup the wasm carries two imports under the same name and instantiation fails. |

## Regression coverage

`tests/codegen/env_count_and_at.affine` is the dedup regression — its docstring already documented the invariant. The `dune runtest` invocation in CI compiles all three fixtures end-to-end.

## What this does NOT cover

`Interp.eval_program` does not gain `env_at` / `arg_at`. Same posture as `env_count` / `arg_count` (also absent from interp). These are WASI-only surfaces; interp would need a synthetic environ table to simulate them. Out of scope for the baseline-rot fix.

## How this was found

`#361`'s `build` job remained red after the bench/dune + `.hypatia-ignore` + `string_length` fixes cleared the other reds. The failure was `Resolution error: UndefinedVariable arg_at` at `tests/codegen/arg_at.affine:7`. Same root-cause class as `string_length` (#362): a stdlib surface declared in test fixtures but never wired in resolve+typecheck.

## Test plan

- [ ] `dune build` succeeds (no OCaml compile error from the codegen dispatch or dedup pass).
- [ ] `dune runtest` clears the codegen-test compile loop (env_at, arg_at, env_count_and_at all produce valid wasm).
- [ ] No regression in the wider STDLIB-04* E2E suites (env_at / arg_at don't appear in them, but `string_length` does — make sure the existing #362 wiring still works).

Refs #180 (ADR-015 parent), Refs #339 (the IR-only commit), Closes-Refs #361 (originating queue-clearance incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)