### PR TITLE
feat(parser): builtin/lowercase qualified paths + TOTAL field name (Refs gitbot-fleet#148)

### DIFF
--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -871,6 +871,52 @@ expr_primary:
   | modu = upper_ident COLONCOLON fname = lower_ident
     { ExprField (ExprVar (mk_ident modu $startpos(modu) $endpos(modu)),
                  mk_ident fname $startpos(fname) $endpos(fname)) }
+  /* Builtin-type-qualified value path: `Int::to_string(n)`, `String::len(s)`,
+     etc. The built-in type names are reserved keyword tokens (INT_T, STRING_T,
+     ...) rather than UPPER_IDENT, so the `upper_ident COLONCOLON lower_ident`
+     production above never fires for them. We replicate the same
+     `ExprField (ExprVar TypeName, lower_ident)` shape so [Resolve] sees a
+     uniform qualified-path AST. The lookahead after COLONCOLON (a lower_ident)
+     distinguishes this from any type-position use of the same keyword.
+     Added 2026-05-26 (Refs gitbot-fleet#148 sustainabot hand-port:
+     Int::to_string, Int::from_string, Float::to_string, etc.). */
+  | NAT COLONCOLON fname = lower_ident
+    { ExprField (ExprVar (mk_ident "Nat" $startpos($1) $endpos($1)),
+                 mk_ident fname $startpos(fname) $endpos(fname)) }
+  | INT_T COLONCOLON fname = lower_ident
+    { ExprField (ExprVar (mk_ident "Int" $startpos($1) $endpos($1)),
+                 mk_ident fname $startpos(fname) $endpos(fname)) }
+  | BOOL COLONCOLON fname = lower_ident
+    { ExprField (ExprVar (mk_ident "Bool" $startpos($1) $endpos($1)),
+                 mk_ident fname $startpos(fname) $endpos(fname)) }
+  | FLOAT_T COLONCOLON fname = lower_ident
+    { ExprField (ExprVar (mk_ident "Float" $startpos($1) $endpos($1)),
+                 mk_ident fname $startpos(fname) $endpos(fname)) }
+  | STRING_T COLONCOLON fname = lower_ident
+    { ExprField (ExprVar (mk_ident "String" $startpos($1) $endpos($1)),
+                 mk_ident fname $startpos(fname) $endpos(fname)) }
+  | CHAR_T COLONCOLON fname = lower_ident
+    { ExprField (ExprVar (mk_ident "Char" $startpos($1) $endpos($1)),
+                 mk_ident fname $startpos(fname) $endpos(fname)) }
+  /* Lowercase-module-qualified value path: `json::encode_string(s)`,
+     `string::join(xs, sep)`, etc. The stdlib already defines lowercase
+     modules (`stdlib/json.affine` declares `module json;`,
+     `stdlib/string.affine` declares `module string;`) and `use json::{...}`
+     parses because `module_path` is a list of `ident` (upper or lower).
+     The expression-position qualified path, however, only covered
+     `upper_ident COLONCOLON lower_ident`, leaving every call into a
+     lowercase stdlib module as a parse error. We mirror that rule for
+     lower-module values so [Resolve] sees the same canonical
+     `ExprField (ExprVar Mod, fname)` AST regardless of module casing.
+     LR(1)-safe: the only competing reduction for `lower_ident` at this
+     position is `name = lower_ident { ExprVar ... }`, and on a COLONCOLON
+     lookahead no rule starting from `expr_primary COLONCOLON` exists, so
+     the parser shifts unambiguously into this rule. Added 2026-05-26
+     (Refs gitbot-fleet#148 sustainabot hand-port: json::encode_object,
+     string::join, etc.). */
+  | modu = lower_ident COLONCOLON fname = lower_ident
+    { ExprField (ExprVar (mk_ident modu $startpos(modu) $endpos(modu)),
+                 mk_ident fname $startpos(fname) $endpos(fname)) }
 
   /* Grouping and tuples */
   | LPAREN RPAREN { ExprLit (LitUnit (mk_span $startpos $endpos)) }
@@ -1182,10 +1228,17 @@ ident:
    record field names.  Only keywords that do NOT introduce shift/reduce or
    reduce/reduce conflicts are listed here.  HANDLE is safe because it always
    requires `name COLON ty` in type-record context and `name: expr` in
-   expression-record context; the surrounding COLON disambiguates. *)
+   expression-record context; the surrounding COLON disambiguates.
+   TOTAL is safe by the same reasoning: as a function-decl modifier it always
+   appears between visibility? and FN (never after DOT, never before COLON in
+   a record body), and as a field name it always appears immediately before
+   COLON (record-field decl, record-literal field, dotted field access). The
+   surrounding COLON / DOT disambiguates. Added 2026-05-26 (Refs gitbot-fleet#148
+   sustainabot hand-port: HealthIndex.total, Recommendation.total, etc.). *)
 field_name:
   | id = ident { id }
   | HANDLE { mk_ident "handle" $startpos $endpos }
+  | TOTAL { mk_ident "total" $startpos $endpos }
 
 lower_ident:
   | name = LOWER_IDENT { name }


### PR DESCRIPTION
## Summary

Three closely-related \`expr_primary\` / \`field_name\` extensions, all driven by sustainabot hand-port shapes (gitbot-fleet#148):

### 1. Builtin-type-qualified value path

\`Int::to_string(n)\`, \`String::len(s)\`, \`Float::to_string(f)\`, etc. The built-in type names are reserved keyword tokens (NAT/INT_T/BOOL/FLOAT_T/STRING_T/CHAR_T), not UPPER_IDENT, so the existing \`upper_ident COLONCOLON lower_ident\` production never fired for them. Six new productions, one per builtin keyword, producing the canonical \`ExprField (ExprVar TypeName, fname)\` shape that [Resolve] already expects.

### 2. Lowercase-module-qualified value path

\`json::encode_string(s)\`, \`string::join(xs, sep)\`, etc. The stdlib already defines lowercase modules (\`module json;\`, \`module string;\`) and \`use json::{...}\` parses, but the expression-position qualified path only covered uppercase modules. The new \`lower_ident COLONCOLON lower_ident\` rule mirrors the upper-ident form.

LR(1)-safe: the only competing reduction for \`lower_ident\` at this position is \`name = lower_ident { ExprVar ... }\`, and on a COLONCOLON lookahead no rule starting from \`expr_primary COLONCOLON\` exists, so the parser shifts unambiguously.

### 3. \`total\` as a record-field name

Added to \`field_name\` alongside the existing \`handle\` contextual-keyword exception. Safe by the same reasoning HANDLE is safe: as a function-decl modifier TOTAL appears between \`visibility?\` and \`FN\`, never after DOT/before COLON in a record body; as a field name it appears between COLON / DOT and the field value. Surrounding token disambiguates. Used by sustainabot's \`HealthIndex.total\`, \`Recommendation.total\`, etc.

## Conflict-cost

Zero. Parser builds with **21 S/R + 1 R/R**, identical to the pre-patch baseline.

## Test plan

- [x] \`dune build\` green
- [x] Conflict count unchanged: 21 S/R + 1 R/R
- [ ] CI green
- [ ] Smoke: \`Int::to_string(42)\` parses
- [ ] Smoke: \`json::encode_string(\"x\")\` parses
- [ ] Smoke: \`r.total\` parses as field access; \`#{ total: 99 }\` parses as record literal

## Companion PRs (gitbot-fleet#148 spine)

1. trailing-comma in fn params + expr lists (#370)
2. fn-type with effect arrow in type position (#371)
3. **this PR** — builtin/lowercase qualified paths + TOTAL field name
4. lexer \`_\`-prefix idents
5. (hypatia) Levenshtein perf fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)