### PR TITLE
feat(lexer): underscore-prefix idents `_key`/`_unused` (Refs gitbot-fleet#148)

### DIFF
--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -98,7 +98,15 @@ let upper = [%sedlex.regexp? 'A'..'Z']
 let alpha = [%sedlex.regexp? lower | upper]
 let alphanum = [%sedlex.regexp? alpha | digit | '_']
 
-let lower_ident = [%sedlex.regexp? lower, Star alphanum]
+(* `lower_ident_start` accepts the conventional Rust-idiom underscore-prefix
+   form `_unused` for parameters and bindings that are intentionally unused.
+   The two-alternative form `lower | ('_', alphanum)` (a lowercase letter, OR
+   underscore-then-at-least-one-alphanum) ensures bare `_` (the wildcard
+   pattern) still lexes as the distinct UNDERSCORE token under sedlex's
+   maximal-munch rule. Added 2026-05-26 (Refs gitbot-fleet#148 sustainabot
+   hand-port: `_key`, `_value` cache stubs in GitHubApp.affine). *)
+let lower_ident_start = [%sedlex.regexp? lower | ('_', alphanum)]
+let lower_ident = [%sedlex.regexp? lower_ident_start, Star alphanum]
 let upper_ident = [%sedlex.regexp? upper, Star alphanum]
 
 let int_lit = [%sedlex.regexp? Opt '-', Plus digit]

--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -23,11 +23,17 @@ let test_keywords () =
     tokens
 
 let test_identifiers () =
-  let tokens = lex_all "foo Bar _test test123" in
+  (* Underscore-prefix policy (Refs 2026-05-26 gitbot-fleet#148 sustainabot
+     hand-port): `_test` (and `_anything`) is the conventional Rust-idiom
+     unused-binding spelling; the lexer treats it as a single LOWER_IDENT.
+     Bare `_` is still tokenised as the distinct UNDERSCORE (wildcard) token
+     — sedlex applies maximal munch and the underscore branch of
+     `lower_ident_start` requires at least one trailing alphanum. *)
+  let tokens = lex_all "foo Bar _test test123 _" in
   Alcotest.(check (list token_testable)) "identifiers"
     [Token.LOWER_IDENT "foo"; Token.UPPER_IDENT "Bar";
-     Token.UNDERSCORE; Token.LOWER_IDENT "test";
-     Token.LOWER_IDENT "test123"; Token.EOF]
+     Token.LOWER_IDENT "_test"; Token.LOWER_IDENT "test123";
+     Token.UNDERSCORE; Token.EOF]
     tokens
 
 let test_literals () =


### PR DESCRIPTION
## Summary

Extends \`lower_ident_start\` from a single \`lower\` to \`lower | ('_', alphanum)\` — a lowercase letter, OR underscore followed by at least one alphanum. This is the conventional Rust-idiom spelling for "intentionally unused" bindings and parameters.

Bare \`_\` (the wildcard pattern) is preserved as the distinct \`UNDERSCORE\` token: sedlex applies maximal munch, and the underscore branch of \`lower_ident_start\` requires at least one trailing alphanum, so \`_\` standalone falls through to the existing UNDERSCORE rule.

## Test changes

\`test/test_lexer.ml::test_identifiers\` now asserts the new tokenisation:

- \`_test\` is a single \`LOWER_IDENT "_test"\` (was \`UNDERSCORE; LOWER_IDENT "test"\`).
- Bare \`_\` still emits \`UNDERSCORE\`.

327/327 tests pass.

## Why

Required by sustainabot hand-port (gitbot-fleet#148) — \`GitHubApp.affine\` declares unused cache-stub bindings as \`let _key = ...; let _value = ...;\`. Without this, every \`_x\` parses as wildcard + binding-name and breaks downstream pattern resolution.

## Test plan

- [x] \`dune build\` green
- [x] \`dune test\` green (327/327)
- [ ] CI green
- [ ] Smoke: \`let _key = json::encode(x);\` parses

## Companion PRs (gitbot-fleet#148 spine)

1. trailing-comma in fn params + expr lists (#370)
2. fn-type with effect arrow in type position (#371)
3. builtin/lowercase qualified paths + TOTAL field name (#372)
4. **this PR** — lexer \`_\`-prefix idents
5. (hypatia) Levenshtein perf fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)