### PR TITLE
fix(governance): rename CLAUDE.md TypeScript exemptions heading to match workflow regex

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,7 +83,7 @@ Both are FOSS with independent governance (no Big Tech).
 7. **No Kotlin/Swift for mobile** - Use Tauri 2.0+ or Dioxus.
 8. **MPL-1.0 / MPL-1.0-or-later are non-conforming** - Rewrite to MPL-2.0 in SPDX headers and LICENSE files when encountered (Hypatia's `validate_license` flags both).
 
-### TypeScript / JavaScript Exemptions (Approved)
+### TypeScript Exemptions (Approved)
 
 The "no new TypeScript" / "no new JavaScript" rules have approved exemptions in this repo. These paths are *not* policy violations — they are documented carve-outs because the file format or downstream consumer requires the source language. They are honoured by Hypatia's scanner via path-based exemption + the per-repo CLAUDE.md exemption tables.
 


### PR DESCRIPTION
## Summary

The `governance / Language / package anti-pattern policy` job in the reusable [governance-reusable.yml](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/governance-reusable.yml) scans `.claude/CLAUDE.md` for a section heading matching the regex `TypeScript [Ee]xemptions` to find the exemption table.

This repo's heading was `### TypeScript / JavaScript Exemptions (Approved)`. The `/ JavaScript ` between the two words prevents the regex from matching.

The parser then falls through to the next mention of the phrase ("the TypeScript exemptions above") in the **Runtime Exemptions** section's prose, and parses the **Runtime Exemptions** table — picking up 2 JS entries (`packages/affinescript-cli/mod.js`, `editors/vscode/test/**/*.js`) instead of the 3 TypeScript entries (including `affinescript-deno-test/*.ts`).

Result: `affinescript-deno-test/{cli,example/smoke_driver,lib/{compile,discover,runner}}.ts` were reported as forbidden TypeScript files on every PR — blocking the check estate-wide for weeks.

## Fix

Rename `### TypeScript / JavaScript Exemptions (Approved)` → `### TypeScript Exemptions (Approved)`.

JavaScript exemptions already live in their own `### Runtime Exemptions (Approved)` section immediately below, so the original heading's `/ JavaScript` was misleading anyway.

## Verification

Simulated the workflow's Python parser locally on the post-fix `.claude/CLAUDE.md`:

```
Parsed 3 exemption(s)
✅ No TypeScript files outside allowlist (3 per-repo exemption(s) parsed).
```

(Pre-fix: parsed 2 exemptions — the wrong table — and 5 `affinescript-deno-test/*.ts` files were reported bad.)

## Test plan

- [x] Local Python simulation of the workflow parser
- [ ] CI: `governance / Language / package anti-pattern policy` green on this PR
- [ ] Downstream: re-run CI on #370, #371, #372, #373 — same check should turn green after merge

Refs gitbot-fleet#148 (unblocks affinescript #370/#371/#372/#373 et al)

🤖 Generated with [Claude Code](https://claude.com/claude-code)