### PR TITLE
rename: affinescript.ownership → typedwasm.ownership (producer-neutral)

### DIFF
--- a/EXPLAINME.adoc
+++ b/EXPLAINME.adoc
@@ -18,7 +18,7 @@ The README makes claims. This file backs them up.
 
 *From README:* "TEA runtime targeting typed-wasm — dogfooded via IDApTIK. Affine TEA contract: `update : Msg ⊸ Model ⊸ (Model, Cmd Msg)` where Msg is consumed linearly."
 
-*Evidence:* `lib/tea_bridge.ml` generates a complete Wasm 1.0 binary (`titlescreen.wasm`) encoding the TitleScreen state machine. The `affinescript.ownership` custom section records the update function's `msg` parameter as kind=1 (Linear). `lib/dune` includes `tea_bridge` in the library; `bin/main.ml` exposes `affinescript tea-bridge -o OUTPUT` as a subcommand. The generated binary is checked in at `idaptik/public/assets/wasm/titlescreen.wasm` (512 bytes). Verified in Node.js: `WebAssembly.validate` → `true`; functional round-trip: `init → selected=0`, `update(0) → selected=1`, `update(3) → selected=4`, `setScreen(1920,1080) → screen_w=1920`. The IDApTIK `TitleScreen.res` `teaDrive` function calls `AffineTEA.update`, then reads `getSelected()` — navigation is determined by Wasm state, not button identity. Graceful fallback to direct ReScript navigation when the Wasm binary is unavailable. **Caveat:** The affine ownership guarantee is carried in the `affinescript.ownership` custom section; a typed-wasm multi-module verifier (Levels 7–10) is needed to enforce it at runtime — that is the Stage 6/7 work.
+*Evidence:* `lib/tea_bridge.ml` generates a complete Wasm 1.0 binary (`titlescreen.wasm`) encoding the TitleScreen state machine. The `typedwasm.ownership` custom section records the update function's `msg` parameter as kind=1 (Linear). `lib/dune` includes `tea_bridge` in the library; `bin/main.ml` exposes `affinescript tea-bridge -o OUTPUT` as a subcommand. The generated binary is checked in at `idaptik/public/assets/wasm/titlescreen.wasm` (512 bytes). Verified in Node.js: `WebAssembly.validate` → `true`; functional round-trip: `init → selected=0`, `update(0) → selected=1`, `update(3) → selected=4`, `setScreen(1920,1080) → screen_w=1920`. The IDApTIK `TitleScreen.res` `teaDrive` function calls `AffineTEA.update`, then reads `getSelected()` — navigation is determined by Wasm state, not button identity. Graceful fallback to direct ReScript navigation when the Wasm binary is unavailable. **Caveat:** The affine ownership guarantee is carried in the `typedwasm.ownership` custom section; a typed-wasm multi-module verifier (Levels 7–10) is needed to enforce it at runtime — that is the Stage 6/7 work.
 
 === Claim 3: 101 End-to-End Tests Covering the Full Compiler Pipeline
 
@@ -59,7 +59,7 @@ Run `dune runtest` to reproduce. All 101 pass. **Caveat:** Borrow-checker BUG-00
 AffineScript validates the hyperpolymath ecosystem:
 
 - **IDApTIK** — TitleScreen driven by AffineScript TEA Wasm binary; AffineTEA.js + AffineTEA.res bridge live in the game repo. Proves the stack at scale.
-- **typed-wasm** — AffineScript emits `affinescript.ownership` and `affinescript.tea_layout` custom sections that typed-wasm Levels 7–10 can verify. The paper angle: "Full-stack affine UI architecture from source to Wasm binary."
+- **typed-wasm** — AffineScript emits `typedwasm.ownership` and `affinescript.tea_layout` custom sections that typed-wasm Levels 7–10 can verify. The paper angle: "Full-stack affine UI architecture from source to Wasm binary."
 - **RattleScript** — Python-syntax face on AffineScript. Standalone repo at `hyperpolymath/rattlescript` with Deno ESM wrapper. Distributions live in `distributions/rattlescript/`.
 
 == Proof of Claimed Safety Properties

--- a/affinescript-tea/README.adoc
+++ b/affinescript-tea/README.adoc
@@ -17,7 +17,7 @@ conforming WASM module exposes: `affinescript_init()`,
 once per update cycle), optional `affinescript_get_*` getters /
 `affinescript_set_screen`, an exported `memory`, and two custom
 sections — `affinescript.tea_layout` (model field layout) and
-`affinescript.ownership` (the per-function ownership kinds, including
+`typedwasm.ownership` (the per-function ownership kinds, including
 the Linear `msg` proof).
 
 This package is the *generic* host runtime for any such module. It
@@ -50,7 +50,7 @@ await app.run({
 == Linear-msg invariant
 
 `affinescript_update`'s `msg` is annotated `Linear` in
-`affinescript.ownership` — a message is consumed exactly once per
+`typedwasm.ownership` — a message is consumed exactly once per
 update cycle. `dispatch()` enforces this host-side: `affinescript_update`
 is invoked exactly once, and the call is non-re-entrant — a message
 source or effect that tries to dispatch again *before the in-flight

--- a/affinescript-tea/mod.js
+++ b/affinescript-tea/mod.js
@@ -16,7 +16,7 @@
 //     memory
 //   custom sections:
 //     affinescript.tea_layout    model field layout (parsed here, generically)
-//     affinescript.ownership     per-fn ownership kinds (the Linear-msg proof)
+//     typedwasm.ownership     per-fn ownership kinds (the Linear-msg proof)
 //
 // This runtime is GENERIC: it discovers the model from `tea_layout` rather
 // than hard-coding any one model (the bridge's TitleModel was only a demo).
@@ -182,7 +182,7 @@ export class TeaApp {
    * invoked exactly once, and the call is non-re-entrant — dispatching
    * again from within a view/effect triggered by this cycle throws (that
    * would consume a second message inside one cycle, violating the
-   * linearity the `affinescript.ownership` section asserts).
+   * linearity the `typedwasm.ownership` section asserts).
    *
    * @param {number} msg
    * @returns {Record<string, number>} the model after the update

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -406,7 +406,7 @@ let tea_bridge_cmd_fn output =
   Format.printf "  affinescript_get_screen_w/h() -> i32    — current screen dimensions@.";
   Format.printf "  affinescript_set_screen(w: i32, h: i32) — handle resize events@.";
   Format.printf "  memory                                   — exported linear memory (model at offset 64)@.";
-  Format.printf "Custom sections: affinescript.ownership, affinescript.tea_layout@.";
+  Format.printf "Custom sections: typedwasm.ownership, affinescript.tea_layout@.";
   `Ok ()
 
 (** Generate the Cadre Router Wasm module.
@@ -438,7 +438,7 @@ let router_bridge_cmd_fn output =
   Format.printf "  affinescript_router_get_popup_tag() -> i32          — active popup (−1 if none)@.";
   Format.printf "Screen tags: 0=Title 1=CharacterSelect 2=WorldMap 3=Load 4=Game@.";
   Format.printf "Popup tags:  0=Settings 1=Inventory 2=Hacking@.";
-  Format.printf "Custom sections: affinescript.ownership, affinescript.tea_layout@.";
+  Format.printf "Custom sections: typedwasm.ownership, affinescript.tea_layout@.";
   `Ok ()
 
 (** Generate the CharacterSelect TEA Bridge Wasm module.
@@ -476,7 +476,7 @@ let cs_bridge_cmd_fn output =
   Format.printf "  affinescript_get_screen_w/h() -> i32    — current screen dimensions@.";
   Format.printf "  affinescript_set_screen(w: i32, h: i32) — handle resize events@.";
   Format.printf "  memory                                   — exported linear memory (model at offset 64)@.";
-  Format.printf "Custom sections: affinescript.ownership, affinescript.tea_layout@.";
+  Format.printf "Custom sections: typedwasm.ownership, affinescript.tea_layout@.";
   `Ok ()
 
 (** Start the REPL *)
@@ -1107,7 +1107,7 @@ let compile_to_wasm_module face path
 
     Runs the full frontend pipeline (parse → resolve → typecheck → borrow →
     quantity → codegen) and then passes the resulting Wasm module through
-    [Tw_verify.verify_from_module], which reads the [affinescript.ownership]
+    [Tw_verify.verify_from_module], which reads the [typedwasm.ownership]
     custom section and checks each function body for linearity (Level 10) and
     aliasing-safety (Level 7) violations.
 
@@ -1335,7 +1335,7 @@ let verify_cmd =
 (** Print the ownership-annotated export interface of a generated bridge module.
 
     Generates the selected module ([tea-bridge] or [router]) in-memory, extracts
-    its [affinescript.ownership] section, and prints the per-export ownership
+    its [typedwasm.ownership] section, and prints the per-export ownership
     contract: which parameters are [own] (Linear), [ref] (SharedBorrow), [mut]
     (ExclBorrow), or plain [val] (Unrestricted).
 
@@ -1442,7 +1442,7 @@ let verify_boundary_fn which =
 
     Compiles [callee_path] and [caller_path] through the full frontend
     pipeline, extracts [callee]'s ownership-annotated export interface from
-    its [affinescript.ownership] custom section, then checks that every
+    its [typedwasm.ownership] custom section, then checks that every
     function in [caller] invokes each Linear-param import with consistent
     per-path call counts:
       - max_calls > 1 on any path → LinearImportCalledMultiple
@@ -1491,7 +1491,7 @@ let interface_cmd =
   let doc = "Print the ownership-annotated export interface of a generated bridge module" in
   let man = [
     `S "DESCRIPTION";
-    `P "Extracts the $(b,affinescript.ownership) custom section from the selected \
+    `P "Extracts the $(b,typedwasm.ownership) custom section from the selected \
         generated Wasm module and prints the per-export ownership contract.";
     `P "Parameters are annotated: $(b,own) = Linear (consumed exactly once), \
         $(b,ref) = SharedBorrow (read-only), $(b,mut) = ExclBorrow (exclusive \
@@ -1541,7 +1541,7 @@ let verify_boundary_cmd =
     `S "DESCRIPTION";
     `P "Compiles $(b,CALLEE) and $(b,CALLER) through the full frontend pipeline, \
         extracts $(b,CALLEE)'s ownership-annotated export interface from its \
-        $(b,affinescript.ownership) custom section, and then checks every \
+        $(b,typedwasm.ownership) custom section, and then checks every \
         function body in $(b,CALLER) against that interface.";
     `P "For each import that corresponds to a callee export with at least one \
         $(b,own) (Linear) parameter, the verifier counts per-execution-path \

--- a/docs/CAPABILITY-MATRIX.adoc
+++ b/docs/CAPABILITY-MATRIX.adoc
@@ -164,7 +164,7 @@ silent-bad-codegen fallbacks eliminated. Mixed-arity matches need uniform
 variant rep; effects/try-catch/`call_ref` deferred (EH/CPS — #225 line).
 
 |typed-wasm |*contract, narrow* |Not a backend flag — a *discipline-bearing
-shape* over the WASM output: the `affinescript.ownership` custom section +
+shape* over the WASM output: the `typedwasm.ownership` custom section +
 `lib/tw_interface.ml` / `lib/tw_verify.ml` boundary verifier. Emitted-wasm
 enforcement covers *typed-wasm Level 7 (aliasing) + Level 10 (linearity)
 + Level 13 (module isolation, negative form)*.

--- a/docs/ECOSYSTEM.adoc
+++ b/docs/ECOSYSTEM.adoc
@@ -108,7 +108,7 @@ must stay so. Do not collapse "AffineScript" and "typed-wasm" in any doc.
 The contract is *narrower than older prose claimed* and is exactly this:
 
 . *Carrier.* AffineScript emits ordinary WASM/WASM-GC. The typed-wasm
-  discipline rides on it via the `affinescript.ownership` custom section
+  discipline rides on it via the `typedwasm.ownership` custom section
   (per-function param ownership kinds: `0`=Unrestricted, `1`=Linear,
   `2`=SharedBorrow, `3`=ExclBorrow) plus the `affinescript.tea_layout`
   section where a TEA bridge is involved.
@@ -134,7 +134,7 @@ The contract is *narrower than older prose claimed* and is exactly this:
   with `hyperpolymath/typed-wasm` + `ephapax` — not made unilaterally
   here. Further widening + INT-12 is the rest of Stage E.
 . *Other producers.* `ephapax` (`src/ephapax-wasm`) already emits the same
-  `affinescript.ownership` section and exposes the verifier via
+  `typedwasm.ownership` section and exposes the verifier via
   `ephapax compile --verify-ownership`. Any change to the section format is
   a multi-producer ABI change and must be coordinated with typed-wasm
   (Refs the typed-wasm repo), not made unilaterally here.
@@ -176,7 +176,7 @@ not part of the integration critical path.
 |`packages/affine-js` / `-ts` / `-res` / `-vscode` |works |
 `affine-js` SAT-02 fixed by INT-02 (#179): host-agnostic loader
 (`loader.js`) — Deno/Node/browser parity, multi-namespace import
-object, `affinescript.ownership` accessor.
+object, `typedwasm.ownership` accessor.
 |===
 
 == Integration roadmap — INT-01..12
@@ -210,7 +210,7 @@ S1..S6; legacy preview1 stdout path remains the default until S6c
 DONE: `tools/componentize.sh` wraps the emitted core module into a
 valid WASI-0.2 component via the fetch-pinned preview1→preview2
 *reactor* adapter (wasmtime v44.0.1, sha256-verified); the
-`affinescript.ownership` section is proven to SURVIVE the wrap;
+`typedwasm.ownership` section is proven to SURVIVE the wrap;
 `tests/componentize/smoke.sh` gates it (SKIP-safe without the
 toolchain). S4a (clock) + S4b (env_count, arg_count) DONE:
 builtins lower to on-demand `wasi_snapshot_preview1.*` imports

--- a/docs/specs/SETTLED-DECISIONS.adoc
+++ b/docs/specs/SETTLED-DECISIONS.adoc
@@ -287,7 +287,7 @@ Component Model with WASI 0.2 WIT worlds (`wit/affinescript.wit`, world
 `affinescript:cli/run`). *Staged and non-breaking per slice*; the legacy
 core-wasm + preview1 stdout path remains the default until the final
 slice, so the migration is reversible while in progress even though the
-end-state is one-way. The `affinescript.ownership` custom section is a
+end-state is one-way. The `typedwasm.ownership` custom section is a
 *multi-producer ABI* (shared with `hyperpolymath/ephapax`; the typed-wasm
 contract carrier) and must survive verbatim onto the component's embedded
 core module — its format must not change here; any change is coordinated

--- a/docs/specs/TYPED-WASM-COORDINATION-LEDGER.a2ml
+++ b/docs/specs/TYPED-WASM-COORDINATION-LEDGER.a2ml
@@ -72,7 +72,7 @@ mirror-typed-wasm = { repo = "hyperpolymath/typed-wasm", status = "to-be-filed" 
 mirror-ephapax = { repo = "hyperpolymath/ephapax", status = "to-be-filed" }
 
 [queue-entry.change]
-summary = "Move affinescript.ownership from v1 (unversioned) to v2 (0xAF sentinel + u8 version + entry_count + entries)"
+summary = "Move typedwasm.ownership from v1 (unversioned) to v2 (0xAF sentinel + u8 version + entry_count + entries)"
 v1-format = "u32 entry_count | entry*"
 v2-format = "u8 0xAF | u8 version (0x02) | u32 entry_count | entry*"
 v2-entry-shape = "identical to v1 (no new fields in v2.0)"

--- a/docs/specs/TYPED-WASM-COORDINATION-LEDGER.adoc
+++ b/docs/specs/TYPED-WASM-COORDINATION-LEDGER.adoc
@@ -76,7 +76,7 @@ verifier dispatches on sentinel.  `hyperpolymath/ephapax`: *to be
 filed* — second producer emits v2.
 |*State* |*verifier-parse-shipping* (in this repo, this session)
 |*Owner* |@hyperpolymath
-|*Change* |Move `affinescript.ownership` from v1 (unversioned) to
+|*Change* |Move `typedwasm.ownership` from v1 (unversioned) to
 v2 (`0xAF` sentinel + `u8` version + entry_count + entries).  v2.0
 entry shape identical to v1.
 |*Verifier work* |*This repo:* `lib/tw_verify.ml` accepts both v1

--- a/docs/specs/TYPED-WASM-INTERFACE.a2ml
+++ b/docs/specs/TYPED-WASM-INTERFACE.a2ml
@@ -116,11 +116,11 @@ status = "spec-level-only"
 blocked-on = ["new carrier section", "session-type codegen", "capability tracking", "multi-producer ABI"]
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Carrier — affinescript.ownership v1
+# Carrier — typedwasm.ownership v1
 # ──────────────────────────────────────────────────────────────────────────────
 
 [carrier]
-custom-section-name = "affinescript.ownership"
+custom-section-name = "typedwasm.ownership"
 endianness = "little-endian"
 version-field = false   # v1 is unversioned; ADR-020 (proposed) adds one
 omit-when-empty = true
@@ -291,7 +291,7 @@ verifier = "lib/tw_verify.ml + lib/tw_interface.ml"
 [[producer-party]]
 id = "ephapax"
 repo = "hyperpolymath/ephapax"
-role = "second producer; same affinescript.ownership format"
+role = "second producer; same typedwasm.ownership format"
 verifier-cli = "ephapax compile --verify-ownership"
 
 [[consumer-party]]
@@ -319,7 +319,7 @@ roadmap-anchor = "TYPED-WASM-ROADMAP.adoc"
 
 [[non-feature]]
 id = "NF-003"
-description = "Schema versioning on affinescript.ownership"
+description = "Schema versioning on typedwasm.ownership"
 reason = "v1 unversioned by accident-of-history; ADR-020 (proposed) adds backward-compat version prefix"
 roadmap-anchor = "ADR-020 (proposed)"
 

--- a/docs/specs/TYPED-WASM-INTERFACE.adoc
+++ b/docs/specs/TYPED-WASM-INTERFACE.adoc
@@ -88,10 +88,10 @@ link:TYPED-WASM-ROADMAP.adoc[TYPED-WASM-ROADMAP.adoc].
 |*Spec-level only.*  Same reason.
 |===
 
-== Carrier — the `affinescript.ownership` custom section
+== Carrier — the `typedwasm.ownership` custom section
 
 The L7+L10 discipline rides on a WebAssembly *custom section* named
-`affinescript.ownership`.  AffineScript emits it; AffineScript's own
+`typedwasm.ownership`.  AffineScript emits it; AffineScript's own
 verifier consumes it; `hyperpolymath/ephapax` *also* emits it
 (same format); the Rust verifier in `hyperpolymath/typed-wasm`
 consumes it as the cross-compat target.
@@ -289,7 +289,7 @@ until the cross-compat suite is supplemented with real AffineScript-
 emitted fixtures.
 
 |*ephapax* (`hyperpolymath/ephapax`)
-|Second producer.  Emits the same `affinescript.ownership` section.
+|Second producer.  Emits the same `typedwasm.ownership` section.
 Exposes the verifier via `ephapax compile --verify-ownership`.
 
 |*typed-wasm* (`hyperpolymath/typed-wasm`)
@@ -314,7 +314,7 @@ The following are *deliberate scope boundaries*, not oversights:
   session-protocol / agent-choreography carrier.  Multi-producer
   ABI change *and* compiler-side region/session-type inference
   (the latter blocked by CORE-01 Phase-3 NLL/Polonius).
-* *Schema versioning on `affinescript.ownership`.*  Currently
+* *Schema versioning on `typedwasm.ownership`.*  Currently
   unversioned; ADR-020 (proposed) adds a one-byte version prefix
   in a backward-compatible way.
 * *Automatic compile-time L7/L10 gating.*  Today `verify` is an

--- a/docs/specs/TYPED-WASM-ROADMAP.a2ml
+++ b/docs/specs/TYPED-WASM-ROADMAP.a2ml
@@ -57,7 +57,7 @@ blocked-on = []
 [[work-item]]
 id = "A3"
 tranche = "A"
-title = "Extract affinescript.ownership emission to lib/tw_ownership_section.ml"
+title = "Extract typedwasm.ownership emission to lib/tw_ownership_section.ml"
 status = "proposed"
 risk = "low"
 single-session = true

--- a/docs/specs/TYPED-WASM-ROADMAP.adoc
+++ b/docs/specs/TYPED-WASM-ROADMAP.adoc
@@ -60,7 +60,7 @@ Closes "no friction" without touching any sister repo.
 *Status: proposed.*
 
 Today `affinescript verify FILE` is opt-in.  The compile pipeline
-emits the `affinescript.ownership` section but does not run the
+emits the `typedwasm.ownership` section but does not run the
 verifier.  A user who wants the typed-wasm guarantee has to invoke
 two commands.
 
@@ -96,7 +96,7 @@ serialiser in `lib/json_output.ml`.
 
 *Test:* one E2E case asserting JSON shape on a known-good fixture.
 
-=== A3.  Extract `affinescript.ownership` emission to a dedicated module
+=== A3.  Extract `typedwasm.ownership` emission to a dedicated module
 
 *Status: proposed (housekeeping).*
 

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -54,7 +54,7 @@ type context = {
   datas : data list;                 (** data segments *)
   ownership_annots : (int * ownership_kind list * ownership_kind) list;
   (** Collected ownership annotations: (func_index, param_kinds, return_kind).
-      Emitted as the [affinescript.ownership] Wasm custom section for typed-wasm
+      Emitted as the [typedwasm.ownership] Wasm custom section for typed-wasm
       Level 7/10 verification. Kind encoding: 0=Unrestricted, 1=Linear, 2=SharedBorrow, 3=ExclBorrow. *)
   wasi_func_indices : (string * int) list;
   (** ADR-015 S4 (#180): WASI preview1 import name → wasm func index.
@@ -148,7 +148,7 @@ let ownership_kind_of_ret (ret : type_expr option) : ownership_kind =
 let ownership_kind_byte = function
   | Unrestricted -> 0 | Linear -> 1 | SharedBorrow -> 2 | ExclBorrow -> 3
 
-(** Build the payload for the [affinescript.ownership] Wasm custom section.
+(** Build the payload for the [typedwasm.ownership] Wasm custom section.
     Encoding (all little-endian):
       u32  entry_count
       per entry:
@@ -2377,7 +2377,7 @@ let gen_decl (ctx : context) (decl : top_level) : context result =
     (* Determine function index before generating *)
     let func_idx = import_func_count ctx_with_type + List.length ctx_with_type.funcs in
 
-    (* Stage 2: Extract ownership annotations for typed-wasm [affinescript.ownership] section *)
+    (* Stage 2: Extract ownership annotations for typed-wasm [typedwasm.ownership] section *)
     let param_kinds = List.map ownership_kind_of_param fd.fd_params in
     let ret_kind = ownership_kind_of_ret fd.fd_ret_ty in
 
@@ -2765,10 +2765,10 @@ let generate_module ?loader (prog : program) : wasm_module result =
     | _ -> (ctx'.types, all_funcs, exports_with_mem)
   in
 
-  (* Stage 2: Build [affinescript.ownership] custom section from collected annotations *)
+  (* Stage 2: Build [typedwasm.ownership] custom section from collected annotations *)
   let ownership_payload = build_ownership_section ctx'.ownership_annots in
   let custom_sections = if Bytes.length ownership_payload > 0 then
-    [("affinescript.ownership", ownership_payload)]
+    [("typedwasm.ownership", ownership_payload)]
   else
     []
   in

--- a/lib/tea_bridge.ml
+++ b/lib/tea_bridge.ml
@@ -60,7 +60,7 @@
 
     {2 Ownership annotations}
 
-    The [affinescript.ownership] custom section marks [update]'s [msg]
+    The [typedwasm.ownership] custom section marks [update]'s [msg]
     parameter as Linear (kind byte 1) — consumed exactly once per TEA
     update cycle — encoding the AffineScript linearity invariant for
     typed-wasm Level 10 verification.
@@ -190,7 +190,7 @@ let fn_set_screen : func = {
    Custom sections
    ------------------------------------------------------------------------- *)
 
-(** Build the [affinescript.ownership] custom section payload.
+(** Build the [typedwasm.ownership] custom section payload.
 
     Encoding (all little-endian):
       {v
@@ -290,7 +290,7 @@ let generate () : wasm_module = {
     { e_name = "memory";                       e_desc = ExportMemory 0 };
   ];
   custom_sections = [
-    ("affinescript.ownership",   build_ownership_section ());
+    ("typedwasm.ownership",   build_ownership_section ());
     ("affinescript.tea_layout",  build_tea_layout_section ());
   ];
 }

--- a/lib/tea_cs_bridge.ml
+++ b/lib/tea_cs_bridge.ml
@@ -69,7 +69,7 @@
 
     {2 Ownership annotations}
 
-    The [affinescript.ownership] custom section marks [update]'s [msg]
+    The [typedwasm.ownership] custom section marks [update]'s [msg]
     parameter as Linear (kind byte 1) — consumed exactly once per TEA
     update cycle — encoding the AffineScript linearity invariant for
     typed-wasm Level 10 verification.
@@ -207,7 +207,7 @@ let fn_set_screen : func = {
    Custom sections
    ------------------------------------------------------------------------- *)
 
-(** Build the [affinescript.ownership] custom section payload.
+(** Build the [typedwasm.ownership] custom section payload.
 
     Identical encoding to the TitleScreen bridge — only [fn_update]'s msg
     param is Linear; all other params and returns are Unrestricted. *)
@@ -305,7 +305,7 @@ let generate () : wasm_module = {
     { e_name = "memory";                       e_desc = ExportMemory 0 };
   ];
   custom_sections = [
-    ("affinescript.ownership",   build_ownership_section ());
+    ("typedwasm.ownership",   build_ownership_section ());
     ("affinescript.tea_layout",  build_tea_layout_section ());
   ];
 }

--- a/lib/tea_router.ml
+++ b/lib/tea_router.ml
@@ -49,7 +49,7 @@
 
     Each exported function corresponds to one RouterMsg variant.  The
     payload parameters are annotated Linear (kind byte = 1) in the
-    [affinescript.ownership] custom section, encoding that each message is
+    [typedwasm.ownership] custom section, encoding that each message is
     consumed exactly once per TEA update cycle:
 
     {v
@@ -339,7 +339,7 @@ let fn_get_popup_tag : func = {
    Custom sections
    ------------------------------------------------------------------------- *)
 
-(** Build the [affinescript.ownership] custom section payload.
+(** Build the [typedwasm.ownership] custom section payload.
 
     Encoding (all little-endian):
     {v
@@ -461,7 +461,7 @@ let generate () : wasm_module = {
     { e_name = "memory";                            e_desc = ExportMemory 0 };
   ];
   custom_sections = [
-    ("affinescript.ownership",  build_ownership_section ());
+    ("typedwasm.ownership",  build_ownership_section ());
     ("affinescript.tea_layout", build_tea_layout_section ());
   ];
 }

--- a/lib/tw_interface.ml
+++ b/lib/tw_interface.ml
@@ -6,7 +6,7 @@
     Implements two capabilities:
 
     1.  {b Interface extraction}: given any Wasm module that contains an
-        [affinescript.ownership] custom section, extract the
+        [typedwasm.ownership] custom section, extract the
         ownership-annotated signatures of all exported functions.  This is
         the machine-readable boundary contract that callers must honour.
         Printed by [affinescript interface FILE].
@@ -67,12 +67,12 @@ type cross_error =
    ============================================================================ *)
 
 (** Build a [(func_idx → (param_kinds, ret_kind))] lookup table from the
-    [affinescript.ownership] custom section of [wasm_mod].
+    [typedwasm.ownership] custom section of [wasm_mod].
     Returns an empty table if the section is absent. *)
 let ownership_index_of_module (wasm_mod : Wasm.wasm_module)
     : (int, ownership_kind list * ownership_kind) Hashtbl.t =
   let tbl = Hashtbl.create 16 in
-  (match List.assoc_opt "affinescript.ownership" wasm_mod.Wasm.custom_sections with
+  (match List.assoc_opt "typedwasm.ownership" wasm_mod.Wasm.custom_sections with
   | None -> ()
   | Some payload ->
     List.iter (fun (idx, param_kinds, ret_kind) ->

--- a/lib/tw_ownership_section.ml
+++ b/lib/tw_ownership_section.ml
@@ -2,7 +2,7 @@
 (* SPDX-FileCopyrightText: 2026 hyperpolymath *)
 (*
  * tw_ownership_section.ml — the dedicated home for the
- * `affinescript.ownership` Wasm custom section: kind encoding,
+ * `typedwasm.ownership` Wasm custom section: kind encoding,
  * extraction from the AST, and binary serialisation.
  *
  * Extracted from lib/codegen.ml at 2026-05-24 per Tranche A3 of
@@ -62,7 +62,7 @@ let ownership_kind_byte = function
   | SharedBorrow -> 2
   | ExclBorrow -> 3
 
-(** Build the payload for the [affinescript.ownership] Wasm custom section.
+(** Build the payload for the [typedwasm.ownership] Wasm custom section.
 
     v1 encoding (current emit; LE):
       u32  entry_count

--- a/lib/tw_verify.ml
+++ b/lib/tw_verify.ml
@@ -161,7 +161,7 @@ let verify_function
 
     [wasm_mod] is the compiled module.
     [annots] is the list of [(func_idx, param_kinds, ret_kind)] annotations
-    collected by codegen and stored in the [affinescript.ownership] custom
+    collected by codegen and stored in the [typedwasm.ownership] custom
     section (but here provided in structured form directly from [Codegen]).
 
     Imported functions have no body and are skipped.
@@ -184,7 +184,7 @@ let verify_module
    Pipeline integration — parse ownership section from the module
    ============================================================================ *)
 
-(** Parse the [affinescript.ownership] custom section payload into structured
+(** Parse the [typedwasm.ownership] custom section payload into structured
     [(func_idx, param_kinds, ret_kind)] annotations.
 
     Supports BOTH v1 (legacy, unversioned) and v2 (ADR-020, accepted
@@ -336,14 +336,14 @@ let verify_module_isolation
         | Wasm.ImportFunc _ -> None)
       wasm_mod.Wasm.imports
 
-(** Verify a Wasm module using the embedded [affinescript.ownership] custom
+(** Verify a Wasm module using the embedded [typedwasm.ownership] custom
     section.  This is the primary entry point for the pipeline and the CLI.
 
     Returns [Ok ()] if no violations are found, [Error errs] otherwise. *)
 let verify_from_module
     (wasm_mod : Wasm.wasm_module)
   : (unit, ownership_error list) Result.t =
-  match List.assoc_opt "affinescript.ownership" wasm_mod.Wasm.custom_sections with
+  match List.assoc_opt "typedwasm.ownership" wasm_mod.Wasm.custom_sections with
   | None ->
     (* No ownership section: nothing to verify.  This is not an error —
        modules compiled without ownership qualifiers have no constraints. *)

--- a/lib/wasm.ml
+++ b/lib/wasm.ml
@@ -259,7 +259,7 @@ type wasm_module = {
   start : int option;  (** optional start function index *)
   custom_sections : (string * bytes) list;
   (** Named custom sections (Wasm section ID 0).
-      Used for [affinescript.ownership] — carries ownership annotations
+      Used for [typedwasm.ownership] — carries ownership annotations
       (TyOwn/TyRef/TyMut) that survive to the binary for typed-wasm
       Level 7/10 verification. *)
 }

--- a/packages/affine-js/README.adoc
+++ b/packages/affine-js/README.adoc
@@ -110,7 +110,7 @@ const mod = await AffineModule.fromBytes(bytes, {
 
 == Ownership section (typed-wasm contract)
 
-The compiler embeds an `affinescript.ownership` custom section carrying
+The compiler embeds an `typedwasm.ownership` custom section carrying
 per-function parameter/return ownership kinds (the AffineScript ↔
 typed-wasm contract — see `docs/ECOSYSTEM.adoc`). Read it via:
 

--- a/packages/affine-js/loader.js
+++ b/packages/affine-js/loader.js
@@ -15,7 +15,7 @@
 //   2. a host-agnostic byte reader (Deno / Node / browser parity);
 //   3. a full import-object builder (multi-namespace, for the cross-module
 //      WASM imports INT-01/#178 emits — not `env`-only);
-//   4. an accessor for the `affinescript.ownership` custom section (the
+//   4. an accessor for the `typedwasm.ownership` custom section (the
 //      typed-wasm contract carrier — see docs/ECOSYSTEM.adoc).
 //
 // It has no dependency on `mod.js`; `mod.js` consumes it.
@@ -195,7 +195,7 @@ const OWNERSHIP_KINDS = /** @type {const} */ ([
  */
 
 /**
- * Parse the `affinescript.ownership` custom section.
+ * Parse the `typedwasm.ownership` custom section.
  *
  * Binary encoding (must match `Codegen.build_ownership_section` /
  * `Tw_verify.parse_ownership_section_payload` in the compiler):
@@ -213,7 +213,7 @@ const OWNERSHIP_KINDS = /** @type {const} */ ([
 export function parseOwnershipSection(wasmModule) {
   const sections = WebAssembly.Module.customSections(
     wasmModule,
-    "affinescript.ownership",
+    "typedwasm.ownership",
   );
   if (sections.length === 0) return [];
   const view = new DataView(sections[0]);

--- a/packages/affine-js/loader_test.js
+++ b/packages/affine-js/loader_test.js
@@ -7,7 +7,7 @@
 //
 // These cover the SAT-02 fix (no more `url.pathname` path mangling), host
 // detection, byte-reader parity, the multi-namespace import-object builder,
-// and the `affinescript.ownership` custom-section parser (whose binary format
+// and the `typedwasm.ownership` custom-section parser (whose binary format
 // must stay byte-identical to Codegen.build_ownership_section /
 // Tw_verify.parse_ownership_section_payload in the compiler).
 
@@ -157,7 +157,7 @@ Deno.test("parseOwnershipSection: round-trips the compiler's binary format", () 
     3,
     1, // ret_kind
   ];
-  const bytes = wasmWithCustomSection("affinescript.ownership", payload);
+  const bytes = wasmWithCustomSection("typedwasm.ownership", payload);
   const mod = new WebAssembly.Module(bytes);
   assertEquals(parseOwnershipSection(mod), [
     {

--- a/packages/affine-js/mod.js
+++ b/packages/affine-js/mod.js
@@ -218,7 +218,7 @@ export class AffineModule {
   }
 
   /**
-   * The parsed `affinescript.ownership` custom section: per-function
+   * The parsed `typedwasm.ownership` custom section: per-function
    * parameter/return ownership kinds carrying the typed-wasm discipline
    * (see docs/ECOSYSTEM.adoc — the AffineScript ↔ typed-wasm contract).
    * Empty when the module was compiled without ownership qualifiers.

--- a/packages/affine-js/types.d.ts
+++ b/packages/affine-js/types.d.ts
@@ -142,7 +142,7 @@ export declare class AffineModule {
   readonly instance: WebAssembly.Instance;
 
   /**
-   * Parsed `affinescript.ownership` custom section: per-function
+   * Parsed `typedwasm.ownership` custom section: per-function
    * parameter/return ownership kinds carrying the typed-wasm discipline.
    * Empty when the module was compiled without ownership qualifiers.
    */
@@ -171,7 +171,7 @@ export declare function buildImportObject(
   options?: Pick<LoadOptions, "imports" | "modules">,
 ): WebAssembly.Imports;
 
-/** Parse the `affinescript.ownership` custom section. */
+/** Parse the `typedwasm.ownership` custom section. */
 export declare function parseOwnershipSection(
   wasmModule: WebAssembly.Module,
 ): OwnershipEntry[];

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -1121,7 +1121,7 @@ let python_face_tests = [
    ============================================================================
 
    Verify that AffineScript ownership qualifiers (own/ref/mut) survive codegen
-   and appear in the [affinescript.ownership] Wasm custom section.
+   and appear in the [typedwasm.ownership] Wasm custom section.
 
    Kind encoding (matches Codegen.ownership_kind):
      0 = Unrestricted  (plain value)
@@ -1130,9 +1130,9 @@ let python_face_tests = [
      3 = ExclBorrow    (mut / TyMut — typed-wasm Level 7)
 *)
 
-(** Find the [affinescript.ownership] custom section payload, if present *)
+(** Find the [typedwasm.ownership] custom section payload, if present *)
 let find_ownership_section (wasm_mod : Wasm.wasm_module) : bytes option =
-  List.assoc_opt "affinescript.ownership" wasm_mod.Wasm.custom_sections
+  List.assoc_opt "typedwasm.ownership" wasm_mod.Wasm.custom_sections
 
 (** Parse the ownership section payload into structured entries.
     Returns a list of (func_index, param_kinds, return_kind) tuples. *)
@@ -1166,7 +1166,7 @@ let test_ownership_section_present () =
   | Ok wasm_mod ->
     match find_ownership_section wasm_mod with
     | None ->
-      Alcotest.fail "Expected [affinescript.ownership] custom section, none found"
+      Alcotest.fail "Expected [typedwasm.ownership] custom section, none found"
     | Some payload ->
       Alcotest.(check bool) "section payload is non-empty" true
         (Bytes.length payload > 0)
@@ -1183,7 +1183,7 @@ let test_ownership_roundtrip () =
   | Error msg -> Alcotest.fail msg
   | Ok wasm_mod ->
     match find_ownership_section wasm_mod with
-    | None -> Alcotest.fail "No [affinescript.ownership] section in compiled output"
+    | None -> Alcotest.fail "No [typedwasm.ownership] section in compiled output"
     | Some payload ->
       let entries = parse_ownership_section payload in
       (* At least one function must have a Linear (1) param — TyOwn survived *)
@@ -1283,11 +1283,11 @@ let ownership_schema_tests = [
    5. update branchless: selected = msg + 1 after affinescript_update(n).
 *)
 
-(** Parse the [affinescript.ownership] custom section from a Wasm binary
+(** Parse the [typedwasm.ownership] custom section from a Wasm binary
     and return (func_idx, param_kinds, return_kind) entries, or [] on failure. *)
 let parse_ownership_from_bytes (raw : bytes) : (int * int list * int) list =
-  (* Scan for the custom section with name "affinescript.ownership" *)
-  let target = "affinescript.ownership" in
+  (* Scan for the custom section with name "typedwasm.ownership" *)
+  let target = "typedwasm.ownership" in
   let rlen   = Bytes.length raw in
   let found  = ref [] in
   let i = ref 8 in  (* skip magic + version *)
@@ -1382,7 +1382,7 @@ let test_bridge_custom_sections () =
   Alcotest.(check int) "2 custom sections" 2 (List.length m.custom_sections);
   let names = List.map fst m.custom_sections in
   Alcotest.(check bool) "ownership section"   true
-    (List.mem "affinescript.ownership"  names);
+    (List.mem "typedwasm.ownership"  names);
   Alcotest.(check bool) "tea_layout section"  true
     (List.mem "affinescript.tea_layout" names)
 
@@ -1511,7 +1511,7 @@ let test_router_custom_sections () =
   Alcotest.(check int) "2 custom sections" 2 (List.length m.custom_sections);
   let names = List.map fst m.custom_sections in
   Alcotest.(check bool) "ownership section"  true
-    (List.mem "affinescript.ownership"  names);
+    (List.mem "typedwasm.ownership"  names);
   Alcotest.(check bool) "tea_layout section" true
     (List.mem "affinescript.tea_layout" names)
 
@@ -2417,7 +2417,7 @@ let test_cross_call_once_ok () =
     let annots = Codegen.build_ownership_section [(0, [Codegen.Linear], Codegen.Unrestricted)] in
     { m with
       Wasm.exports        = [export];
-      Wasm.custom_sections = [("affinescript.ownership", annots)];
+      Wasm.custom_sections = [("typedwasm.ownership", annots)];
     }
   in
   let iface = Tw_interface.extract_exports callee in
@@ -2447,7 +2447,7 @@ let test_cross_call_twice_violation () =
     let annots = Codegen.build_ownership_section [(0, [Codegen.Linear], Codegen.Unrestricted)] in
     { m with
       Wasm.exports        = [export];
-      Wasm.custom_sections = [("affinescript.ownership", annots)];
+      Wasm.custom_sections = [("typedwasm.ownership", annots)];
     }
   in
   let iface = Tw_interface.extract_exports callee in
@@ -2482,7 +2482,7 @@ let test_cross_call_partial_violation () =
     let annots = Codegen.build_ownership_section [(0, [Codegen.Linear], Codegen.Unrestricted)] in
     { m with
       Wasm.exports        = [export];
-      Wasm.custom_sections = [("affinescript.ownership", annots)];
+      Wasm.custom_sections = [("typedwasm.ownership", annots)];
     }
   in
   let iface = Tw_interface.extract_exports callee in

--- a/test/test_tw_isolation.ml
+++ b/test/test_tw_isolation.ml
@@ -13,7 +13,7 @@ let imp m n d : Wasm.import = { Wasm.i_module = m; i_name = n; i_desc = d }
 
 (* count=0 ownership payload (u32le 0) — present so verify_from_module
    does not short-circuit on "no ownership section ⇒ Ok". *)
-let own_section = ("affinescript.ownership", Bytes.make 4 '\000')
+let own_section = ("typedwasm.ownership", Bytes.make 4 '\000')
 
 let is_isolation_err = function
   | Tw_verify.ModuleNotIsolated _ -> true

--- a/tests/componentize/command_smoke.sh
+++ b/tests/componentize/command_smoke.sh
@@ -7,7 +7,7 @@
 #   (a) the resulting component is a valid WASI-0.2 component,
 #   (b) it exports `wasi:cli/run@0.2.x`,
 #   (c) `wasmtime run` can invoke it (exit 0), and
-#   (d) the `affinescript.ownership` custom section survives the wrap.
+#   (d) the `typedwasm.ownership` custom section survives the wrap.
 #
 # SKIPs cleanly (exit 0) when the component toolchain or wasmtime is
 # not provisioned — opt-in, mirroring tests/componentize/smoke.sh.
@@ -38,7 +38,7 @@ cp test/e2e/fixtures/verify_ownership_clean.affine "$work/cmd.affine"
 printf '\nfn main() -> Int { add(2, 3) }\n' >> "$work/cmd.affine"
 
 has_section() {
-  [ "$(wasm-tools print "$1" 2>/dev/null | grep -c 'affinescript.ownership' || true)" -gt 0 ]
+  [ "$(wasm-tools print "$1" 2>/dev/null | grep -c 'typedwasm.ownership' || true)" -gt 0 ]
 }
 
 $COMPILER compile "$work/cmd.affine" -o "$work/cmd.wasm"

--- a/tests/componentize/smoke.sh
+++ b/tests/componentize/smoke.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # ADR-015 S3 gated smoke: compile a core module that carries the
-# `affinescript.ownership` section, run it through the componentize
+# `typedwasm.ownership` section, run it through the componentize
 # on-ramp, and assert the result is a valid WASI-0.2 component with the
 # ownership section intact (and that wasmtime can load it).
 #
@@ -25,7 +25,7 @@ COMPILER="${AFFINESCRIPT:-$ROOT/_build/default/bin/main.exe}"
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-# Known-good ownership fixture (emits the affinescript.ownership
+# Known-good ownership fixture (emits the typedwasm.ownership
 # section) + a main so the module is non-trivial.
 cp test/e2e/fixtures/verify_ownership_clean.affine "$work/cz.affine"
 printf '\nfn main() -> Int { add(2, 3) }\n' >> "$work/cz.affine"
@@ -33,7 +33,7 @@ printf '\nfn main() -> Int { add(2, 3) }\n' >> "$work/cz.affine"
 # `grep -c | … || true`: read all input (no early-close SIGPIPE that
 # `set -o pipefail` would mis-report — the `grep -q` footgun).
 has_section() {
-  [ "$(wasm-tools print "$1" 2>/dev/null | grep -c 'affinescript.ownership' || true)" -gt 0 ]
+  [ "$(wasm-tools print "$1" 2>/dev/null | grep -c 'typedwasm.ownership' || true)" -gt 0 ]
 }
 
 $COMPILER compile "$work/cz.affine" -o "$work/cz.wasm"

--- a/tools/componentize.sh
+++ b/tools/componentize.sh
@@ -20,7 +20,7 @@
 #   exports a parameter-less `main`. The resulting component exports
 #   `wasi:cli/run@0.2.x` per `wit/affinescript.wit`.
 #
-# The `affinescript.ownership` custom section (the typed-wasm contract
+# The `typedwasm.ownership` custom section (the typed-wasm contract
 # carrier, multi-producer ABI) MUST survive the wrap — asserted here
 # in both modes.
 #
@@ -53,7 +53,7 @@ command -v wasm-tools >/dev/null || { echo "componentize: wasm-tools not on PATH
 # `set -o pipefail` would mis-report as a failure — the `grep -q`
 # footgun). `|| true` neutralises grep's no-match exit 1.
 section_count() {
-  wasm-tools print "$1" 2>/dev/null | grep -c 'affinescript.ownership' || true
+  wasm-tools print "$1" 2>/dev/null | grep -c 'typedwasm.ownership' || true
 }
 
 # Does the core carry the typed-wasm ownership section? (only assert
@@ -78,7 +78,7 @@ wasm-tools validate --features component-model "$out"
 
 if [ "$had_ownership" = 1 ]; then
   if [ "$(section_count "$out")" -eq 0 ]; then
-    echo "FATAL: affinescript.ownership section did NOT survive componentization" >&2
+    echo "FATAL: typedwasm.ownership section did NOT survive componentization" >&2
     rm -f "$out"
     exit 1
   fi


### PR DESCRIPTION
## Summary
- Renames the wasm custom section `affinescript.ownership` → `typedwasm.ownership` everywhere AffineScript emits, parses, or describes it.
- Producer-neutral name: the section is owned by the typed-wasm verifier, not by AffineScript-the-language. Ephapax is the second producer and bumps in lockstep.
- 31 files changed, all mechanical (88 insertions / 88 deletions).

## Sibling PRs (coordinated hard-flip)
- **typed-wasm#65**: source-of-truth `OWNERSHIP_SECTION_NAME` constant + verifier comments. **Must merge first.**
- **affinescript** (this PR): emitters, parsers, JS loader, TEA bridges, CLI, componentize tooling, docs.
- **ephapax** (next): bump `typed-wasm-verify` rev pin to typed-wasm#65 merge SHA + 6 comment updates.

## What changed
- **codegen / ownership section builder:** `lib/codegen.ml`, `lib/tw_ownership_section.ml`
- **intra/cross-module verifiers:** `lib/tw_verify.ml`, `lib/tw_interface.ml`
- **TEA bridges:** `lib/tea_router.ml`, `lib/tea_bridge.ml`, `lib/tea_cs_bridge.ml`
- **wasm carrier doc:** `lib/wasm.ml`
- **CLI strings + docstrings:** `bin/main.ml`
- **JS loader + types:** `packages/affine-js/{loader.js,types.d.ts,loader_test.js,mod.js,README.adoc}`
- **TEA satellite:** `affinescript-tea/{mod.js,README.adoc}`
- **componentize shell tools:** `tools/componentize.sh`, `tests/componentize/{smoke.sh,command_smoke.sh}`
- **tests:** `test/test_e2e.ml`, `test/test_tw_isolation.ml`
- **docs:** `docs/ECOSYSTEM.adoc`, `docs/CAPABILITY-MATRIX.adoc`, `docs/specs/TYPED-WASM-*`, `EXPLAINME.adoc`

`docs/history/` is intentionally untouched — dated snapshots preserve the original name as accurate to their period.

## Test plan
- [x] `dune build` clean (modulo ADR-012 disclosed parser conflicts)
- [x] `dune test --force` → **327/327 passing**
- [x] `deno task test` in `packages/affine-js` → **14/14 passing**
- [x] `rg 'affinescript\.ownership'` outside `docs/history/` and `CHANGELOG.md` → **0 hits**

## Why now
Estate disentangling: AffineScript and Ephapax must be independent languages; typed-wasm must be removable from either with no impact. The section name embedding one producer's brand was the first wire-format coupling to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)