### PR TITLE
feat(parser): record-update spread at start `#{ ..base, f: v }` (Refs gitbot-fleet#148)

### DIFF
--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -928,6 +928,18 @@ expr_record_body:
   (* spread-only: { ..var } or { ..expr } *)
   | sp = expr_record_spread
     { ([], Some sp) }
+  (* Rust-style record-update: spread first, then comma-separated fields:
+     `Record #{ ..base, field: x, other: y }`. Required by sustainabot
+     hand-port (gitbot-fleet#148) — `Model #{ ..model, totalProcessed: n }`
+     in Oikos.affine and `Router #{ ..router, routes: rs }` in Router.affine.
+     The leading spread captures the source-of-defaults; subsequent fields
+     override. Mirrors the existing trailing-spread form below (`{ f: v,
+     ..s }`) but in the opposite order. LR(1)-safe: after parsing
+     `expr_record_spread`, the lookahead is either RBRACE (existing
+     spread-only rule already reduces) or COMMA (this rule shifts);
+     the choice is unambiguous on one-token lookahead. Added 2026-05-26. *)
+  | sp = expr_record_spread COMMA field = record_field rest = expr_record_rest
+    { (field :: fst rest, Some sp) }
   (* field possibly followed by more: { f: v, ... } *)
   | field = record_field rest = expr_record_rest
     { (field :: fst rest, snd rest) }


### PR DESCRIPTION
## Summary

Adds the Rust-style record-update form to `expr_record_body`: a leading `..spread` followed by COMMA and one or more fields, all inside `#{ ... }`.

The existing grammar accepted:
- empty record `#{}`
- spread-only `#{ ..s }`
- fields with optional trailing spread `#{ f: v, ..s }`

But the Rust-style `Record #{ ..base, override: x }` was a parse error. Required by sustainabot hand-port (gitbot-fleet#148):
- `Model #{ ..model, totalProcessed: n }` in Oikos.affine
- `Router #{ ..router, routes: rs }` in Router.affine

## Conflict cost

Zero. LR(1)-safe: after parsing `expr_record_spread`, the lookahead is either RBRACE (the existing spread-only rule reduces) or COMMA (this new rule shifts); the choice is unambiguous on one-token lookahead. Parser builds with 21 shift/reduce + 1 reduce/reduce, identical to the pre-patch baseline.

## Test plan
- [x] `dune build bin/main.exe` — clean
- [x] `menhir --explain` — 21 S/R + 1 R/R (unchanged)
- [x] Validation oracle: with this + #370/#371/#372/#373, all 13 sustainabot `.affine` files reach Resolution (no parse errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)