### PR TITLE
feat(res-to-affine): walker parity for raw-js, untyped-exception, mutable-global (Phase 2c, Refs #57)

### DIFF
--- a/tools/res-to-affine/test/test_walker.ml
+++ b/tools/res-to-affine/test/test_walker.ml
@@ -105,6 +105,80 @@ let test_walker_only_module_toplevel () =
     "walker reports the line-8 import and only that one"
     [8] side_effect_lines
 
+let lines_for_kind ~k findings =
+  List.filter_map
+    (fun (f : Scanner.finding) ->
+      if f.kind = k then Some f.line else None)
+    findings
+
+let test_walker_raw_js () =
+  (* sample.res line 11: `let host = %raw(\`globalThis.location.host\`)` *)
+  skip_unless_ready ();
+  let source = read_file fixture in
+  let path = Filename.concat (Sys.getcwd ()) fixture in
+  let findings =
+    Walker.scan ~grammar_dir:(grammar_dir ()) ~path ~source
+  in
+  Alcotest.(check (list int))
+    "walker reports raw-js at line 11"
+    [11]
+    (lines_for_kind ~k:Scanner.Raw_js findings)
+
+let test_walker_untyped_exception () =
+  (* sample.res:
+       line 19  try { ... }
+       line 22  | Js.Exn.Error(_) => None     (Js.Exn in pattern position)
+       line 28  api->Promise.catch(...)        *)
+  skip_unless_ready ();
+  let source = read_file fixture in
+  let path = Filename.concat (Sys.getcwd ()) fixture in
+  let findings =
+    Walker.scan ~grammar_dir:(grammar_dir ()) ~path ~source
+  in
+  Alcotest.(check (list int))
+    "walker reports untyped-exception at lines 19, 22, 28"
+    [19; 22; 28]
+    (lines_for_kind ~k:Scanner.Untyped_exception findings)
+
+let test_walker_mutable_global () =
+  (* sample.res line 15: `currentUser := Some("alice")` — top-level
+     assignment via the := operator. The declaration on line 14
+     (`let currentUser = ref(None)`) is intentionally not flagged in
+     parity-port scope; it is a Phase-2 follow-up in CORPUS-RUN.md. *)
+  skip_unless_ready ();
+  let source = read_file fixture in
+  let path = Filename.concat (Sys.getcwd ()) fixture in
+  let findings =
+    Walker.scan ~grammar_dir:(grammar_dir ()) ~path ~source
+  in
+  Alcotest.(check (list int))
+    "walker reports mutable-global at line 15"
+    [15]
+    (lines_for_kind ~k:Scanner.Mutable_global findings)
+
+let test_walker_parity_with_scanner () =
+  (* The headline parity property of Phase 2c: walker and scanner
+     produce the same set of (kind, line) pairs on the synthetic
+     fixture. Both are expected to find 6 findings — see CORPUS-RUN.md
+     for the 491-file estate-scale numbers behind this design. *)
+  skip_unless_ready ();
+  let source = read_file fixture in
+  let path = Filename.concat (Sys.getcwd ()) fixture in
+  let walker_findings =
+    Walker.scan ~grammar_dir:(grammar_dir ()) ~path ~source
+  in
+  let scanner_findings = Scanner.scan source in
+  let summarise findings =
+    List.map
+      (fun (f : Scanner.finding) -> (Scanner.kind_to_label f.kind, f.line))
+      findings
+    |> List.sort compare
+  in
+  Alcotest.(check (list (pair string int)))
+    "walker and scanner emit the same (kind, line) pairs on sample.res"
+    (summarise scanner_findings)
+    (summarise walker_findings)
+
 (* ---- s-exp parser sanity (NOT gated; pure OCaml) ---------------------------
 
    The walker subprocess is shelled out in the gated tests above. The
@@ -123,5 +197,13 @@ let () =
             `Quick test_walker_finds_side_effect_import;
           Alcotest.test_case "module-toplevel-only, correct line"
             `Quick test_walker_only_module_toplevel;
+          Alcotest.test_case "raw-js detected on sample.res"
+            `Quick test_walker_raw_js;
+          Alcotest.test_case "untyped-exception detected at all expected lines"
+            `Quick test_walker_untyped_exception;
+          Alcotest.test_case "mutable-global detected at column-0 line"
+            `Quick test_walker_mutable_global;
+          Alcotest.test_case "walker / scanner parity on the synthetic fixture"
+            `Quick test_walker_parity_with_scanner;
         ] );
     ]

--- a/tools/res-to-affine/walker.ml
+++ b/tools/res-to-affine/walker.ml
@@ -267,6 +267,21 @@ let truncate s =
   if String.length s <= 80 then s
   else String.sub s 0 77 ^ "..."
 
+(* ---- finding-emission shared helpers --------------------------------------
+
+   The walker emits its findings sorted by line ascending in the final
+   pass; intermediate emission appends to a head-of-list accumulator
+   for O(1) cons. The [push] helper builds and conses a finding with
+   the standard truncate/trim of the slice around [n]. *)
+let push_finding ~source ~kind acc n =
+  let excerpt =
+    truncate (String.trim (slice ~source ~start:n.start ~stop:n.stop))
+  in
+  let finding : Scanner.finding =
+    { kind; line = n.start.row + 1; excerpt }
+  in
+  finding :: acc
+
 (* Is this node's source text exactly the underscore [_]? *)
 let is_underscore_pattern ~source n =
   if n.ntype <> "value_identifier" then false
@@ -320,48 +335,148 @@ let pattern_and_body ~lb =
   in
   pattern, body
 
-(* Walk with ancestor context. [ancestors] lists ancestor node types from
-   immediate parent outward; the head is the immediate parent. *)
+(* True when this [let_declaration] sits at module top level:
+   either its immediate parent is [source_file], or its parent is a
+   [block] that's the body of a [module_declaration]. *)
+let let_at_module_toplevel ancestors =
+  match ancestors with
+  | "source_file" :: _ -> true
+  | "block" :: "module_declaration" :: _ -> true
+  | _ -> false
+
+(* Detect side-effect-import findings for one [let_declaration] node
+   that's already known to live at module top level. *)
+let detect_side_effect_import ~source acc let_decl_node =
+  List.fold_left
+    (fun acc lb ->
+      if lb.ntype <> "let_binding" then acc
+      else
+        match pattern_and_body ~lb with
+        | Some pat, Some body
+          when is_underscore_pattern ~source pat
+            && body_has_module_access ~source body ->
+            push_finding ~source ~kind:Scanner.Side_effect_import acc lb
+        | _ -> acc)
+    acc let_decl_node.children
+
+(* ---- detection: raw-js ----------------------------------------------------
+
+   The grammar models `%raw(...)` as
+
+     (extension_expression
+       (extension_identifier "raw")
+       ...)
+
+   `[%bs.raw "..."]` (the older syntax) does not parse cleanly on the
+   pinned grammar — it lands under an `(ERROR ... (extension_expression
+   (extension_identifier "bs.raw")) ...)` subtree. We still detect the
+   inner extension_expression normally because the walker visits every
+   descendant of [source_file], including children of ERROR nodes. *)
+let raw_js_extension_id ~source ext_id_node =
+  let text = String.trim (slice ~source ~start:ext_id_node.start ~stop:ext_id_node.stop) in
+  text = "raw" || text = "bs.raw"
+
+let detect_raw_js ~source acc node =
+  if node.ntype <> "extension_expression" then acc
+  else
+    match node.children with
+    | head :: _ when head.ntype = "extension_identifier"
+                  && raw_js_extension_id ~source head ->
+        push_finding ~source ~kind:Scanner.Raw_js acc node
+    | _ -> acc
+
+(* ---- detection: untyped-exception ----------------------------------------
+
+   Three structural triggers, any one of which emits one finding per
+   occurrence:
+
+   1. [(try_expression ...)] — the literal `try ... catch { ... }`
+      form. ReScript's `try` is exactly the antipattern: an untyped
+      catch that throws away type information.
+
+   2. A [value_identifier_path] whose surface text begins with
+      `Js.Exn` or `Promise.catch`. The grammar represents both shapes
+      as a path with module identifiers + a value identifier; the
+      surface-text check is the cheapest reliable filter.
+
+   3. A [call_expression] whose function child is a bare
+      [value_identifier] with text `raise` — a `raise(MyExn)` call.
+
+   We deduplicate within a single node visit (a [call_expression]
+   that is itself a child of a [try_expression] would otherwise
+   double-count), but the same anti-pattern appearing on different
+   lines is reported separately. *)
+let starts_with prefix s =
+  let lp = String.length prefix in
+  let ls = String.length s in
+  ls >= lp && String.sub s 0 lp = prefix
+
+let path_matches_untyped_exn ~source path_node =
+  let text = String.trim (slice ~source ~start:path_node.start ~stop:path_node.stop) in
+  starts_with "Js.Exn" text || starts_with "Promise.catch" text
+
+let call_is_raise ~source call_node =
+  match List.find_opt (fun c -> c.field = Some "function") call_node.children with
+  | Some fn when fn.ntype = "value_identifier" ->
+      let text = String.trim (slice ~source ~start:fn.start ~stop:fn.stop) in
+      text = "raise"
+  | _ -> false
+
+let detect_untyped_exception ~source acc node =
+  if node.ntype = "try_expression" then
+    push_finding ~source ~kind:Scanner.Untyped_exception acc node
+  else if (node.ntype = "value_identifier_path"
+        || node.ntype = "module_identifier_path")
+       && path_matches_untyped_exn ~source node then
+    push_finding ~source ~kind:Scanner.Untyped_exception acc node
+  else if node.ntype = "call_expression" && call_is_raise ~source node then
+    push_finding ~source ~kind:Scanner.Untyped_exception acc node
+  else acc
+
+(* ---- detection: mutable-global -------------------------------------------
+
+   The grammar models a [name := value] statement as
+
+     (expression_statement (mutation_expression ...))
+
+   We flag [mutation_expression] only when an outer
+   [expression_statement] sits at module top level — i.e. its
+   ancestor chain is [expression_statement :: source_file :: _]
+   or [expression_statement :: block :: module_declaration :: _].
+   In-function `x := ...` against a local [ref] is a normal idiom
+   and is not flagged. *)
+let mutation_at_module_toplevel ancestors =
+  match ancestors with
+  | "expression_statement" :: "source_file" :: _ -> true
+  | "expression_statement" :: "block" :: "module_declaration" :: _ -> true
+  | _ -> false
+
+let detect_mutable_global ~source ancestors acc node =
+  if node.ntype = "mutation_expression"
+  && mutation_at_module_toplevel ancestors then
+    push_finding ~source ~kind:Scanner.Mutable_global acc node
+  else acc
+
+(* ---- unified visitor -----------------------------------------------------
+
+   One DFS over the AST. Each detector receives only what it needs.
+   The [side-effect-import] detector handles its own [let_binding]
+   recursion under one [let_declaration] node and is gated on
+   module-toplevel ancestors; we keep that compound check together
+   to avoid threading the ancestor list into a separate helper. *)
 let rec collect ~source ancestors acc node =
   let acc =
-    if node.ntype = "let_declaration" then
-      let at_module_toplevel =
-        match ancestors with
-        | "source_file" :: _ -> true
-        | "block" :: parent :: _ when parent = "module_declaration" -> true
-        | _ -> false
-      in
-      if at_module_toplevel then
-        List.fold_left
-          (fun acc c ->
-            if c.ntype = "let_binding" then check_binding ~source acc c
-            else acc)
-          acc node.children
-      else acc
+    if node.ntype = "let_declaration"
+    && let_at_module_toplevel ancestors then
+      detect_side_effect_import ~source acc node
     else acc
   in
+  let acc = detect_raw_js ~source acc node in
+  let acc = detect_untyped_exception ~source acc node in
+  let acc = detect_mutable_global ~source ancestors acc node in
   List.fold_left
     (fun acc c -> collect ~source (node.ntype :: ancestors) acc c)
     acc node.children
-
-and check_binding ~source acc lb =
-  match pattern_and_body ~lb with
-  | Some pat, Some body
-    when is_underscore_pattern ~source pat
-      && body_has_module_access ~source body ->
-      let excerpt =
-        truncate
-          (String.trim
-             (slice ~source ~start:lb.start ~stop:lb.stop))
-      in
-      let finding : Scanner.finding =
-        { kind = Scanner.Side_effect_import
-        ; line = lb.start.row + 1
-        ; excerpt
-        }
-      in
-      finding :: acc
-  | _ -> acc
 
 (* ---- public entry point --------------------------------------------------- *)
 

--- a/tools/res-to-affine/walker.mli
+++ b/tools/res-to-affine/walker.mli
@@ -8,14 +8,17 @@
     [editors/tree-sitter-rescript/] grammar. The two pipelines share
     [Scanner.kind] and [Scanner.finding] so the emitter is unchanged.
 
-    Phase 2b ports a single anti-pattern: [Side_effect_import]. Phase
-    2c ports the remaining three. The walker's discovery of an
-    anti-pattern is strictly stronger than the regex's: it requires
-    the [let _ = Mod.value] shape to live at *module top level* (the
-    actual anti-pattern's structural shape), not just to match a
-    column-0 prefix on any line. This eliminates the [let _ =
-    chained.call()] false-positive class that the Phase-1 regex
-    band-aided in #319. *)
+    Phase 2b (#322) ported [Side_effect_import]. Phase 2c (this file's
+    current state) ports the remaining three — [Raw_js],
+    [Untyped_exception], [Mutable_global] — to AST detection,
+    reaching parity with [Scanner.scan] on the synthetic
+    [test/fixtures/sample.res] corpus.
+
+    The walker's discovery of [Side_effect_import] and
+    [Mutable_global] is strictly stronger than the regex's: it
+    requires the anti-pattern to live at *module top level*. The
+    column-0 false-positive class that [#319] band-aided is
+    eliminated structurally rather than by regex anchor. *)
 
 val scan :
   grammar_dir:string ->


### PR DESCRIPTION
## Summary

Brings the tree-sitter AST walker (Phase 2b, #322) to feature parity with the Phase-1 line-regex scanner across all four anti-patterns. Walker and scanner now emit the same `(kind, line)` pairs on the synthetic fixture, locked in by a new alcotest.

| Pattern | Phase 1 (scanner) | Phase 2b | Phase 2c (this PR) |
|---|:---:|:---:|:---:|
| `side-effect-import` | ✅ regex | ✅ AST | ✅ |
| `raw-js` | ✅ regex | — | ✅ **AST (new)** |
| `untyped-exception` | ✅ regex | — | ✅ **AST (new)** |
| `mutable-global` | ✅ regex | — | ✅ **AST (new)** |

## New walker detectors

- **`raw_js`** — `extension_expression` whose `extension_identifier` is `raw` or `bs.raw`. Reaches inside ERROR subtrees so the older `[%bs.raw ...]` syntax (which the pinned grammar can't parse cleanly) is still flagged.

- **`untyped_exception`** — three structural triggers:
  1. any `try_expression` (try/catch block);
  2. `value_identifier_path` OR `module_identifier_path` whose surface text starts with `Js.Exn` or `Promise.catch` (catches the path in both expression and **pattern** position — line 22 of `sample.res` `| Js.Exn.Error(_) =>` is the latter);
  3. `call_expression` whose function child is the bare identifier `raise`.

- **`mutable_global`** — `mutation_expression` that lives directly inside an `expression_statement` at module top level (ancestor chain is `expression_statement :: source_file` or `expression_statement :: block :: module_declaration`). In-function `x := y` against a local ref is correctly **not** flagged — the structurally-stronger version of the column-0 regex anchor introduced in #319.

Shared helper `push_finding` consolidates the slice/trim/truncate/cons boilerplate that all four detectors now use. The DFS is one pass with all detectors invoked per node.

## Phase 2c follow-ups remaining (not in this PR)

- The two anti-patterns **deferred from Phase 1** (inline lambda callback records, oversized 4+ tuple matches) — both need new `Scanner.kind` variants and emitter guidance.
- Flipping the CLI default from `--engine=scanner` to `--engine=walker` — a behavior change deserving its own PR.
- The two precision-pass deferrals in `CORPUS-RUN.md` (module-block nested side effects, top-level `let x = ref(...)` declarations).

## Test plan

- [x] `dune build tools/res-to-affine` clean.
- [x] `dune test tools/res-to-affine/` — **9/9** (3 existing emitter + 6 walker cases, 4 new in this PR).
- [x] `dune build` + `dune test` clean repo-wide (**327/327** tests pass).
- [x] Spot-checked end-to-end against `tools/res-to-affine/test/fixtures/sample.res`:
      walker emits 6 findings, same `(kind, line)` set as scanner.
- [ ] CI on this PR.

Refs #57 (multi-phase; this is Phase 2c parity port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)