### PR TITLE
fix(codegen): register struct_layouts for record-type aliases

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -2452,6 +2452,15 @@ let gen_decl (ctx : context) (decl : top_level) : context result =
            ExprRecord store path which writes fields in declaration order. *)
         let layout = List.mapi (fun i sf -> (sf.sf_name.name, i * 4)) fields in
         Ok { ctx with struct_layouts = (td.td_name.name, layout) :: ctx.struct_layouts }
+      | TyAlias (TyRecord (rfs, _)) ->
+        (* `type X = { a: T, b: U, ... }` is parsed as an alias to TyRecord.
+           Without this branch, the alias falls through to the catch-all
+           below and never registers a layout, causing every parameter /
+           return of type X to read all fields at offset 0 (silent
+           miscompile, not a crash). Mirrors the TyStruct branch above
+           but unpacks the alias. *)
+        let layout = List.mapi (fun i rf -> (rf.rf_name.name, i * 4)) rfs in
+        Ok { ctx with struct_layouts = (td.td_name.name, layout) :: ctx.struct_layouts }
       | TyAlias _ ->
         Ok ctx
     end

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -644,6 +644,46 @@ let test_wasm_lambda () =
   | Error msg -> Alcotest.fail msg
   | Ok _wasm_mod -> ()
 
+(* ----------------------------------------------------------------------------
+   Regression: `type X = { ... }` (a TyAlias wrapping a TyRecord) must
+   register a struct_layouts entry just like `struct X { ... }` (TyStruct).
+   Without that, every parameter / return of type X reads all fields at
+   offset 0 — a silent miscompile, not a crash. See lib/codegen.ml
+   `gen_decl` TopType branch. *)
+
+let codegen_decl_for src =
+  let prog = Parse_driver.parse_string ~file:"<regression>" src in
+  match prog.prog_decls with
+  | decl :: _ -> decl
+  | [] -> Alcotest.fail "expected at least one top-level decl"
+
+let test_codegen_record_alias_registers_struct_layout () =
+  let decl = codegen_decl_for "type State = { health: Int, score: Int };" in
+  match Codegen.gen_decl (Codegen.create_context ()) decl with
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "gen_decl errored: %s"
+                     (Codegen.show_codegen_error e))
+  | Ok ctx ->
+    let layout = List.assoc_opt "State" ctx.struct_layouts in
+    Alcotest.(check (option (list (pair string int))))
+      "State alias registers field layout"
+      (Some [("health", 0); ("score", 4)])
+      layout
+
+let test_codegen_plain_alias_does_not_register_layout () =
+  (* Sanity: the new pattern must not over-broaden — `type X = Int`
+     should still hit the catch-all and leave struct_layouts empty. *)
+  let decl = codegen_decl_for "type Plain = Int;" in
+  match Codegen.gen_decl (Codegen.create_context ()) decl with
+  | Error e ->
+    Alcotest.fail (Printf.sprintf "gen_decl errored: %s"
+                     (Codegen.show_codegen_error e))
+  | Ok ctx ->
+    Alcotest.(check (option (list (pair string int))))
+      "non-record alias registers no layout"
+      None
+      (List.assoc_opt "Plain" ctx.struct_layouts)
+
 let wasm_tests = [
   Alcotest.test_case "bitwise codegen"    `Quick test_wasm_bitwise;
   Alcotest.test_case "arithmetic codegen" `Quick test_wasm_arithmetic;
@@ -651,6 +691,10 @@ let wasm_tests = [
   Alcotest.test_case "write binary" `Quick test_wasm_write_binary;
   Alcotest.test_case "full pipeline" `Quick test_wasm_full_pipeline;
   Alcotest.test_case "lambda codegen" `Quick test_wasm_lambda;
+  Alcotest.test_case "record-alias registers struct_layouts" `Quick
+    test_codegen_record_alias_registers_struct_layout;
+  Alcotest.test_case "non-record alias leaves struct_layouts alone" `Quick
+    test_codegen_plain_alias_does_not_register_layout;
 ]
 
 (* ============================================================================


### PR DESCRIPTION
## Summary

Record-type aliases (`type X = { ... }`) silently miscompiled when used as function parameters or return types: every field access on such a value resolved to offset 0.

### Root cause

`type X = { a: T, b: U }` parses to `TopType { td_body = TyAlias (TyRecord (rfs, _)) }` (parser.mly:431). The TopType branch in `gen_decl` (codegen.ml:2439) handled the analogous `TyStruct` case by registering a 4-byte-stride layout in `ctx.struct_layouts`, but the TyAlias branch caught everything with `TyAlias _ -> Ok ctx`. With no layout registered, every `.field_N` access fell back to offset 0 — a silent runtime miscompile, not a validation error or compile failure.

The fix adds a `TyAlias (TyRecord (rfs, _))` branch immediately before the catch-all, mirroring the TyStruct case but unpacking the alias.

## Regression coverage

Two new tests in the `E2E WASM` group:

- **`record-alias registers struct_layouts`** — parses `type State = { health: Int, score: Int };`, calls `gen_decl` directly, asserts `(\"State\", [(\"health\", 0); (\"score\", 4)])` appears in `ctx.struct_layouts`. Verified to fail on main without the fix (stash-revert reproduces `expected Some [...] but got None`); passes with it.
- **`non-record alias leaves struct_layouts alone`** — guards against accidental over-broadening: `type Plain = Int` must still hit the catch-all and add no layout entry.

## Verification

\`\`\`
$ dune build && dune runtest
…
Test Successful in 0.082s. 329 tests run.
\`\`\`

Was 327, now 329 with the two new tests. Full suite green.

## Discovered during

Field trial taking `airborne-submarine-squadron` (a 29-field state record stepped at 60 fps over WASM) from \"compiles\" to \"runs to conclusion\". The product currently ships via the linear backend with flat-record boundaries; this fix removes the flatness constraint at the per-record-alias level. WasmGC-backend record/tuple layout has a separate, independent defect — out of scope here.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` → 329/329 green
- [x] New regression test verified to fail on main without the fix
- [x] Catch-all `TyAlias _` still reached for non-record aliases
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)