### PR TITLE
docs: AffineScript↔Ephapax disambiguation hooks (README + CLAUDE.md + a2ml)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,30 @@
+## 🚨 Disambiguation (read first)
+
+**This repo is `hyperpolymath/affinescript`.** It is **NOT** `hyperpolymath/ephapax`.
+
+| | This repo | NOT this repo |
+|---|---|---|
+| Name | **AffineScript** | Ephapax |
+| Path | `hyperpolymath/affinescript` | `hyperpolymath/ephapax` |
+| File extension | `.affine` (plus face dialects) | `.eph` |
+| Build | `dune-project` at root | `Cargo.toml` at root |
+| Type checker | `lib/borrow.ml` (OCaml) | `ephapax-linear/src/{linear,affine}.rs` (Rust) |
+| Proofs | None mechanized; soundness arguments live in `lib/borrow.ml` + `docs/CAPABILITY-MATRIX.adoc` + issue #177 (CORE-01) | `formal/Semantics.v` (Coq), `src/abi/Ephapax/…` (Idris2) |
+
+**The trap.** Ephapax is internally dyadic — it contains `ephapax-linear` and `ephapax-affine` *sublanguages* inside one Rust crate. **The `ephapax-affine` sublanguage is NOT AffineScript.** The word `affine` is shared because both type systems happen to be substructural-logic-family — that's a logic-family fact, not a project relationship.
+
+**Rule for agents:** before applying any prior-session lesson, memory entry, or snippet, check whether it was about *AffineScript* or about *ephapax*. They share zero AST / typing / borrow-checker / codegen. The only shared surface is the compile target (`hyperpolymath/typed-wasm`) and the shared Rust verifier crate (`crates/typed-wasm-verify/` *in* that repo).
+
+When in doubt: state the context shift explicitly ("switching from ephapax context to AffineScript context") so the user sees the boundary respected.
+
+**Canonical disambiguation doc** (single source of truth):
+https://github.com/hyperpolymath/nextgen-languages/blob/main/docs/disambiguation/ephapax-vs-affinescript.md
+
+**Companion memory entry** (in user auto-memory):
+`feedback_affinescript_ephapax_siblings_not_impl_proof.md`
+
+---
+
 ## Machine-Readable Artefacts
 
 The following files in `.machine_readable/` contain structured project metadata:

--- a/.machine_readable/6a2/AGENTIC.a2ml
+++ b/.machine_readable/6a2/AGENTIC.a2ml
@@ -32,3 +32,22 @@ release-claim-requires-hard-pass = true
 # on-enter: Read 0-AI-MANIFEST.a2ml, then STATE.a2ml
 # on-exit: Update STATE.a2ml with session outcomes
 # on-commit: Run just validate-rsr
+
+# ── Disambiguation ────────────────────────────────────────────────────────
+# AI agents have repeatedly conflated this repo (AffineScript) with the
+# unrelated language Ephapax (hyperpolymath/ephapax). The two share exactly
+# one thing — both target hyperpolymath/typed-wasm — and otherwise have
+# different ASTs, type checkers, compilers, and proof stories. The shared
+# `affine` syllable names a substructural-logic property in BOTH cases
+# (it's a logic-family name), not a project relationship. Ephapax is itself
+# dyadic and contains an `ephapax-affine` *sublanguage* — that sublanguage
+# is NOT AffineScript.
+[disambiguation]
+this = "hyperpolymath/affinescript"
+canonical-name = "AffineScript"
+distinct-from = ["hyperpolymath/ephapax"]
+shared-with-distinct = ["hyperpolymath/typed-wasm"]
+ephapax-affine-sublanguage-is-not-affinescript = true
+canonical-doc = "https://github.com/hyperpolymath/nextgen-languages/blob/main/docs/disambiguation/ephapax-vs-affinescript.md"
+canonical-memory-entry = "feedback_affinescript_ephapax_siblings_not_impl_proof.md"
+do-not-apply-cross-repo-lessons-without-explicit-check = true

--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,30 @@
 :icons: font
 
 [IMPORTANT]
+.Not to be confused with Ephapax
+====
+This is **AffineScript**, a successor-to-JS/TS/ReScript application language
+at `hyperpolymath/affinescript`. It is *not*
+https://github.com/hyperpolymath/ephapax[Ephapax], a separate research language
+for WebAssembly memory safety at `hyperpolymath/ephapax`.
+
+The two share **exactly one thing**: both target
+https://github.com/hyperpolymath/typed-wasm[typed-wasm] (and interface with that
+repo's `crates/typed-wasm-verify/`). They have separate ASTs, separate type
+checkers, separate compilers, separate proof stories. The word `affine`
+overlaps in both names because it names a substructural-logic property —
+that's a logic-family fact, not a project relationship.
+
+Also: Ephapax is internally dyadic, containing both `ephapax-linear` and
+`ephapax-affine` sublanguages. **The `ephapax-affine` sublanguage is NOT
+AffineScript.** When ambiguous, write "ephapax-affine sublanguage (of ephapax)"
+vs "AffineScript language (this repo)".
+
+Canonical disambiguation:
+link:https://github.com/hyperpolymath/nextgen-languages/blob/main/docs/disambiguation/ephapax-vs-affinescript.md[nextgen-languages/docs/disambiguation/ephapax-vs-affinescript.md].
+====
+
+[IMPORTANT]
 ====
 *Authoritative status lives in link:docs/CAPABILITY-MATRIX.adoc[docs/CAPABILITY-MATRIX.adoc].*
 Where this README's prose implies broader maturity than that matrix states,


### PR DESCRIPTION
## Summary

Plants three thin pointers to the canonical disambiguation doc at [nextgen-languages/docs/disambiguation/ephapax-vs-affinescript.md](https://github.com/hyperpolymath/nextgen-languages/blob/main/docs/disambiguation/ephapax-vs-affinescript.md):

- **README.adoc** new top-of-file [IMPORTANT] admonition (before the existing CAPABILITY-MATRIX one).
- **.claude/CLAUDE.md** new "🚨 Disambiguation (read first)" block as first content.
- **.machine_readable/6a2/AGENTIC.a2ml** new [disambiguation] block.

All three explain: this is AffineScript not Ephapax; the two share only hyperpolymath/typed-wasm; the ephapax-affine sublanguage is NOT AffineScript; shared "affine" syllable is logic-family not project relationship.

## Why

AI agents have repeatedly conflated this repo with hyperpolymath/ephapax across sessions. The two share zero AST / typing / borrow-checker / codegen.

## Companion PR

hyperpolymath/ephapax#152 lands the symmetric hooks in ephapax. typed-wasm callout will follow.

## Test plan

- [ ] AsciiDoc renders cleanly on GitHub.
- [ ] AGENTIC.a2ml parses (manual review).
- [ ] .claude/CLAUDE.md picked up by Claude Code on next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)