### PR TITLE
feat(borrow): CORE-01 ref-to-ref binding (#177 pt3) — let r2 = r / r = s alias the borrow-graph

### DIFF
--- a/lib/borrow.ml
+++ b/lib/borrow.ml
@@ -494,27 +494,64 @@ and expr_to_place (symbols : Symbol.t) (expr : expr) : place option =
     expr_to_place symbols e
   | _ -> None
 
-(** Record a borrow-graph edge for [let <pat> = &p] (or [&mut p]).
+(** Look up the live borrow that [expr] denotes, after the expression has
+    been checked. Handles three cases:
+      - [&p] / [&mut p]: find the borrow on [p] in [state.borrows];
+      - [r] where [r] is a ref-binder symbol: return its [state.ref_bindings]
+        entry (the same borrow it already aliases) — this is ref-to-ref
+        binding / reborrow through indirection;
+      - anything else: None.
+    Used by [record_ref_binding] (let path) and [StmtAssign] (assign path)
+    so [let r2 = r] and [r2 = r] both extend the borrow-graph correctly.
+    CORE-01 / #177 ref-to-ref. *)
+let rec ref_source_borrow (state : state) (symbols : Symbol.t)
+    (expr : expr) : borrow option =
+  match expr with
+  | ExprSpan (e, _) -> ref_source_borrow state symbols e
+  | ExprUnary ((OpRef | OpMutRef), _) ->
+    (match ref_target symbols expr with
+     | Some target ->
+       List.find_opt (fun b -> places_overlap b.b_place target) state.borrows
+     | None -> None)
+  | ExprVar id ->
+    (match lookup_symbol_by_name symbols id.name with
+     | Some sym -> List.assoc_opt sym.Symbol.sym_id state.ref_bindings
+     | None -> None)
+  | _ -> None
 
-    Call *after* the value expression has been checked, so the borrow it
-    created is already on [state.borrows]. Binds the let-bound symbol to
-    that borrow so block-exit validation can detect a reference outliving
-    a block-local owner. CORE-01 / #177. *)
+(** Cheap structural test: would [expr] supply a reborrow source on
+    [StmtAssign]? Used *before* the RHS check, so it does not consult
+    live borrow state — only the structural shape of [expr] and the
+    pre-existing [state.ref_bindings] (for the ref-var path). *)
+let rec is_reborrow_source (state : state) (symbols : Symbol.t)
+    (expr : expr) : bool =
+  match expr with
+  | ExprSpan (e, _) -> is_reborrow_source state symbols e
+  | ExprUnary ((OpRef | OpMutRef), _) -> true
+  | ExprVar id ->
+    (match lookup_symbol_by_name symbols id.name with
+     | Some sym -> List.mem_assoc sym.Symbol.sym_id state.ref_bindings
+     | None -> false)
+  | _ -> false
+
+(** Record a borrow-graph edge for [let <pat> = <ref-source>].
+
+    [<ref-source>] is either a direct [&p]/[&mut p] *or* another ref-binder
+    variable [r] (ref-to-ref binding). Call *after* the value expression has
+    been checked, so the underlying borrow is already on [state.borrows]
+    (or already aliased via [state.ref_bindings] for the ref-var path).
+    CORE-01 / #177. *)
 let record_ref_binding (state : state) (symbols : Symbol.t)
     (pat : pattern) (value : expr) : unit =
   match pat with
   | PatVar id ->
-    begin match ref_target symbols value with
-    | Some target ->
-      begin match
-        List.find_opt (fun b -> places_overlap b.b_place target) state.borrows,
-        lookup_symbol_by_name symbols id.name
-      with
-      | Some b, Some sym ->
-        state.ref_bindings <- (sym.Symbol.sym_id, b) :: state.ref_bindings
-      | _ -> ()
-      end
-    | None -> ()
+    begin match
+      ref_source_borrow state symbols value,
+      lookup_symbol_by_name symbols id.name
+    with
+    | Some b, Some sym ->
+      state.ref_bindings <- (sym.Symbol.sym_id, b) :: state.ref_bindings
+    | _ -> ()
     end
   | _ -> ()
 
@@ -1212,7 +1249,15 @@ and check_block (ctx : context) (state : state) (symbols : Symbol.t) (blk : bloc
         (not (is_outer_binding sym)) && last_use_of sym <= stmt_idx
       ) state.ref_bindings
     in
-    List.iter (fun (_sym, b) -> end_borrow state b) dying;
+    (* CORE-01 pt3 ref-to-ref / #177: only end a borrow if no surviving
+       ref-binding still aliases it.  Pre-fix, `let r = &x; let r2 = r;`
+       would end the borrow on x when r died, even though r2 still held
+       it — silently dropping x's protection.  Reference-count the
+       borrow by [b_id] across [still_live] before deciding. *)
+    List.iter (fun (_sym, b) ->
+      if not (List.exists (fun (_, b') -> b'.b_id = b.b_id) still_live)
+      then end_borrow state b
+    ) dying;
     state.ref_bindings <- still_live
   in
   let* () =
@@ -1329,9 +1374,10 @@ and check_stmt (ctx : context) (state : state) (symbols : Symbol.t) (stmt : stmt
              analyses see the *current* referent after re-assignment,
              not the stale original. *)
           let pre_release =
-            match root_var place, ref_target symbols rhs with
-            | Some binder_sym, Some _
-              when List.mem_assoc binder_sym state.ref_bindings ->
+            match root_var place with
+            | Some binder_sym
+              when is_reborrow_source state symbols rhs
+                && List.mem_assoc binder_sym state.ref_bindings ->
               let old_borrow = List.assoc binder_sym state.ref_bindings in
               end_borrow state old_borrow;
               state.ref_bindings <-
@@ -1340,15 +1386,14 @@ and check_stmt (ctx : context) (state : state) (symbols : Symbol.t) (stmt : stmt
             | _ -> None
           in
           let* () = check_expr ctx state symbols rhs in
-          (match pre_release, ref_target symbols rhs with
-           | Some binder_sym, Some new_target ->
-             (match List.find_opt (fun b ->
-                      places_overlap b.b_place new_target) state.borrows with
+          (match pre_release with
+           | Some binder_sym ->
+             (match ref_source_borrow state symbols rhs with
               | Some new_b ->
                 state.ref_bindings <-
                   (binder_sym, new_b) :: state.ref_bindings
               | None -> ())
-           | _ -> ());
+           | None -> ());
           Ok ()
         end
     | None ->
@@ -1480,12 +1525,18 @@ let check_program (symbols : Symbol.t) (program : program) : unit result =
    one helper so all CFG-join sites agree).  Finally runs after
    the merge, deterministically, against the merged state.
 
+   CORE-01 pt3 ref-to-ref binding (2026-05-26): [let r2 = r] and
+   [r2 = r] (where [r] is itself a ref-binder) now extend the
+   borrow-graph by aliasing [r2] to the same borrow [r] holds.  The
+   [ref_source_borrow] helper unifies the &p / &mut p / ref-var cases
+   so [record_ref_binding] (let path) and the [StmtAssign] reborrow
+   block both reach through one extra level of indirection.  Symmetric
+   pre-release on the assign path uses the same shape test
+   ([is_reborrow_source]) so the existing `r = &x` reborrow continues
+   to work; the new path is `r = r_other`.  Closes the
+   reborrow-through-indirection gap in #177 / CORE-01 pt3.
+
    Still deferred:
-   - Reborrow through indirection: `r = some_other_ref_var` (RHS not a
-     direct `&place`) does not yet copy the other binder's graph
-     entry — the ref-binding stays stale.  Same limitation as
-     [record_ref_binding] for the let-graph path; would require
-     symmetric let/assign handling for ref-to-ref binding.
    - Origin/region variables (true Polonius surface) — a region
      var on each [TyRef]/[TyMut] with subset constraints and a
      proper datalog-style loan-live-at-point solver.  Architectural

--- a/test/e2e/fixtures/ref_to_ref_assign_aliases.affine
+++ b/test/e2e/fixtures/ref_to_ref_assign_aliases.affine
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Jonathan D.A. Jewell
+//
+// CORE-01 pt3 ref-to-ref / #177: assign-path. `r = r_other`
+// (RHS = another ref-binder, not a direct &place) pre-releases
+// the old borrow held by r and aliases r to r_other's borrow.
+// Mirrors slice_b_outer_assign_releases_old.affine but the new
+// referent is reached through a second ref-binder rather than
+// a direct &y. Expected: Ok.
+
+module RefToRefAssignAliases;
+
+fn assign_through_ref() -> Int {
+  let mut x = 1;
+  let mut y = 2;
+  let mut r = &x;
+  let z = *r;
+  let s = &y;
+  r = s;
+  x = 10;
+  *r + x + z
+}

--- a/test/e2e/fixtures/ref_to_ref_let_aliases.affine
+++ b/test/e2e/fixtures/ref_to_ref_let_aliases.affine
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Jonathan D.A. Jewell
+//
+// CORE-01 pt3 ref-to-ref / #177: positive case for let-bound
+// ref-to-ref binding. `let r2 = r` (where `r` is itself a
+// ref-binder for `&x`) aliases r2 to the same borrow on x, so
+// later reads through both r and r2 are legal. Pre-fix, r2 had no
+// entry in the borrow-graph and dereferencing it after r's last
+// use would lose the protection that keeps x borrowed.
+// Expected: Ok.
+
+module RefToRefLetAliases;
+
+fn ref_to_ref() -> Int {
+  let x = 7;
+  let r = &x;
+  let r2 = r;
+  *r + *r2
+}

--- a/test/e2e/fixtures/ref_to_ref_protects_owner.affine
+++ b/test/e2e/fixtures/ref_to_ref_protects_owner.affine
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Jonathan D.A. Jewell
+//
+// CORE-01 pt3 ref-to-ref / #177: anti-regression. After
+// `let r = &mut x; let r2 = r;` the aliased ref-binder r2 must
+// still protect x — any write through x while r2 is live is a
+// ConflictingBorrow. Pre-fix the alias was never recorded, so the
+// write to x was silently accepted via the let-graph staleness.
+// Expected: ConflictingBorrow (or MoveWhileBorrowed) on `x = 9`.
+
+module RefToRefProtectsOwner;
+
+fn ref_to_ref_owner_protected() -> Int {
+  let mut x = 1;
+  let r = &mut x;
+  let r2 = r;
+  x = 9;
+  *r2
+}

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -4415,6 +4415,45 @@ let test_slice_c_body_move_persists () =
                    the catch-arm merge — `read_int(y)` after a moved `y` \
                    was silently accepted"
 
+(* CORE-01 pt3 ref-to-ref / #177 — let r2 = r and r = r_other now
+   alias r2 (resp. r) to the same borrow the source binder holds.
+   Pre-fix the alias was never recorded, so the let-graph went stale
+   on reborrow-through-indirection. Three tests pin: (1) let-path
+   positive — both binders dereferenceable; (2) anti-regression —
+   the alias still protects the underlying owner from concurrent
+   writes; (3) assign-path positive — `r = s` releases the old
+   target and aliases r to s's borrow. *)
+let test_ref_to_ref_let_aliases () =
+  match borrow_result (fixture "ref_to_ref_let_aliases.affine") with
+  | Ok () -> ()
+  | Error e ->
+    Alcotest.fail ("ref-to-ref let-path: `let r2 = r` did not alias r2 \
+                    into the borrow-graph — reading through r2 was \
+                    spuriously rejected: " ^ Borrow.format_borrow_error e)
+
+let test_ref_to_ref_protects_owner () =
+  match borrow_result (fixture "ref_to_ref_protects_owner.affine") with
+  | Error (Borrow.ConflictingBorrow _)
+  | Error (Borrow.MoveWhileBorrowed _)
+  | Error (Borrow.UseWhileExclusivelyBorrowed _) -> ()
+  | Error e ->
+    Alcotest.fail ("ref-to-ref anti-regression: expected a borrow-conflict \
+                    error on `x = 9` (r2 must still protect x), got: "
+                   ^ Borrow.format_borrow_error e)
+  | Ok () ->
+    Alcotest.fail "ref-to-ref regressed: the aliased binder r2 did not \
+                   keep x borrowed, so the write to x was silently \
+                   accepted"
+
+let test_ref_to_ref_assign_aliases () =
+  match borrow_result (fixture "ref_to_ref_assign_aliases.affine") with
+  | Ok () -> ()
+  | Error e ->
+    Alcotest.fail ("ref-to-ref assign-path: `r = s` did not release the \
+                    old borrow on `x` and re-alias r to s's borrow — \
+                    the subsequent write to `x` was spuriously \
+                    rejected: " ^ Borrow.format_borrow_error e)
+
 let borrow_tests = [
   Alcotest.test_case "BorrowOutlivesOwner: &local escapes its block"
     `Quick test_borrow_outlives_owner;
@@ -4450,6 +4489,12 @@ let borrow_tests = [
     `Quick test_slice_c_catch_arm_isolation;
   Alcotest.test_case "Slice C anti-regression: body's move persists past try (#177 pt3 Slice C)"
     `Quick test_slice_c_body_move_persists;
+  Alcotest.test_case "ref-to-ref let-path: `let r2 = r` aliases (#177 pt3)"
+    `Quick test_ref_to_ref_let_aliases;
+  Alcotest.test_case "ref-to-ref anti-regression: alias still protects owner (#177 pt3)"
+    `Quick test_ref_to_ref_protects_owner;
+  Alcotest.test_case "ref-to-ref assign-path: `r = s` releases + aliases (#177 pt3)"
+    `Quick test_ref_to_ref_assign_aliases;
 ]
 
 (* ============================================================================


### PR DESCRIPTION
## Summary

Closes the documented reborrow-through-indirection gap (the first item under "Still deferred" at the bottom of `lib/borrow.ml`). `let r2 = r` and `r = s` — where the RHS is itself a ref-binder, not a direct `&place`/`&mut place` — now extend the borrow-graph correctly.

- New `ref_source_borrow` helper: unifies the `&p` / `&mut p` / ref-var lookup so `record_ref_binding` (let path) and the `StmtAssign` reborrow block both see one extra level of indirection.
- New `is_reborrow_source` shape-only test: drives the pre-release decision on the assign path without consulting live borrow state.
- `expire_dead_ref_bindings` now reference-counts borrows by `b_id` across surviving aliases — a borrow is ended only when no live ref-binder still holds it. This was the load-bearing fix: pre-change, `let r = &x; let r2 = r` would correctly alias r2 then drop the underlying borrow when r died, silently re-permitting writes to x.

## Refs

- #177 (CORE-01 pt3)
- One of three small slices being landed today; the other two (Slice C′ loop, Slice D captured-linears) follow in their own PRs. Slice C-full (Polonius) is being handed off to a separate Claude.

## Test plan

- [x] `dune runtest --force` — 327 → **330 tests, 0 failures**
- [x] 3 new e2e fixtures + handlers:
  - `ref_to_ref_let_aliases.affine` — positive let-path (`let r = &x; let r2 = r; *r + *r2`)
  - `ref_to_ref_protects_owner.affine` — anti-regression (write to owner while alias is live must be rejected)
  - `ref_to_ref_assign_aliases.affine` — positive assign-path (`r = s` where s is a ref-binder)
- [x] No regression in existing borrow / Slice A / Slice B / Slice C fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)