### PR TITLE
chore(ci): bump hypatia-scan-reusable pin off orphan SHA to canonical main

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -25,5 +25,5 @@ permissions:
 
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@97df762107501909f50bb770e9bc200b6c415600
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@5eb28d7d8790d5389b7b6a5233fe6265a775e3d0
     secrets: inherit


### PR DESCRIPTION
Pure hygiene: hypatia-scan.yml pinned to an orphan PR-branch SHA `97df762` (the pre-squash form of standards#193). File content is identical to canonical squash-merged SHA `915139d` and to current standards/main `5eb28d7` (no commits to hypatia-scan-reusable.yml between them).

Bumped to standards/main HEAD per cross-check guidance in [standards#220](https://github.com/hyperpolymath/standards/pull/220).

Auto-merge SQUASH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)