### PR TITLE
fix(ci): self-provision GitHub Pages so casket-pages.yml stops failing on main

### DIFF
--- a/.github/workflows/casket-pages.yml
+++ b/.github/workflows/casket-pages.yml
@@ -80,6 +80,15 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+        with:
+          # Self-provision Pages on first run instead of failing with
+          # 404 ("Get Pages site failed"). The repo had Pages disabled
+          # at the GitHub level since the workflow was added; rather
+          # than maintain that as out-of-band state, let the workflow
+          # enable it. Idempotent on subsequent runs. The workflow's
+          # own permissions (pages: write, id-token: write) authorise
+          # this.
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
## Summary

Orphan branch surfaced during 2026-05-27 estate sweep — 1 commit ahead of main, no PR ever filed. Self-provisions GitHub Pages so `casket-pages.yml` stops failing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>