### PR TITLE
ci: drop continue-on-error on test-run step (bisect_ppx)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
         run: opam install . --deps-only --with-test --with-doc
 
       - name: Run tests with bisect_ppx instrumentation
-        continue-on-error: true
         run: |
           opam exec -- dune runtest --force --instrument-with bisect_ppx
 


### PR DESCRIPTION
## Summary

The "Run tests with bisect_ppx instrumentation" step in `.github/workflows/ci.yml` carried `continue-on-error: true`. Result: test failures (including QTT typechecker test regressions) were being reported as CI passes.

## What changes

Removes one line: `continue-on-error: true` from the test-run step at line 178.

## What is NOT changed

Intentional soft-fail patterns preserved on non-test steps:
- `Lint with odoc` (line 105) — docs lint.
- `Build bench targets` + `Run benches` (lines 127, 131) — benchmarks.
- `Generate HTML coverage report` (line 183) — coverage tooling artefact (failure here shouldn't mask test results).

## Pattern context

Same anti-pattern class as:
- echo-types' N5Falsifier xfail gate (resolved via echo-types#136).
- echidna's Tier-2/3 live-test soft-fail (resolved via echidna#118).

The principle: "CI green" must reliably mean "tests pass". Soft-failing test steps breaks that invariant.

## Refs

Estate prover-CI hygiene audit, recorded at:
\`standards/adoption-readiness-grades/AUDIT-FINDINGS-2026-05-28.adoc\`.

## Test plan

- [ ] CI runs on this PR (hard-fails on real test regressions instead of silently masking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)