### PR TITLE
feat(stdlib): wasmCall extern for invoking WebAssembly exports by name

### DIFF
--- a/docs/bindings-roadmap.adoc
+++ b/docs/bindings-roadmap.adoc
@@ -73,9 +73,9 @@ no further significant ReScript → AffineScript work is tractable.
 
 |5
 |*WASM-exports calling pattern* — invoke individual `exports.fn_name(args)` from a `WasmExports` value
-|`◐` host-side; AS-side `○`
-|`stdlib/Deno.affine` extension or new `stdlib/wasm.affine`
-|`stdlib/Deno.affine` already exposes `wasmInstance(bytes) -> WasmExports` + the type, but no surface to *call* exports. idaptik `vm/wasm` is blocked here; ~30 per-Zig-fn extern fns needed, or one generic `wasm_call(exports, name, args) -> Float`. *Smallest scope, highest leverage — recommended kickoff.*
+|`●` usable (Option A landed)
+|`stdlib/Deno.affine`
+|`wasmCall(exports: WasmExports, name: String, args: [Float]) -> Float` lowers to `exports[name](...args)` with `Number` coercion. Round-trip exercised by `tests/codegen-deno/wasm_call.{affine,harness.mjs}`. *Option A (generic) — typed per-Zig-fn shims can layer on top per-consumer if needed.* Closes #414.
 
 |6
 |*Phoenix Channels / WebSocket* (Socket connect/disconnect, Channel join/leave/push, presence)

--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -157,6 +157,7 @@ const __as_readDirNames = (p) => {
 const __as_isNotFound = (e) => (e instanceof Deno.errors.NotFound);
 const __as_wasmInstance = (bytes) =>
   new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports;
+const __as_wasmCall = (exports, name, args) => Number(exports[name](...(args || [])));
 // `++` is overloaded (string concat / array concat); `a + b` would
 // stringify arrays. Dispatch on shape so stdlib/string.affine's
 // `result ++ [x]` and `a ++ b` are both correct.
@@ -250,6 +251,7 @@ let () =
   (* ---- misc host ---- *)
   b "dateNow"     (fun _ -> "Date.now()");
   b "wasmInstance" (fun a -> Printf.sprintf "__as_wasmInstance(%s)" (arg 0 a));
+  b "wasmCall"     (fun a -> Printf.sprintf "__as_wasmCall(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
   (* Generic JS array push helper (returns the array, fluent). *)
   b "arrayPush" (fun a -> Printf.sprintf "(%s.push(%s), %s)" (arg 0 a) (arg 1 a) (arg 0 a));
   (* ---- honest string/number primitives underpinning the

--- a/stdlib/Deno.affine
+++ b/stdlib/Deno.affine
@@ -124,6 +124,15 @@ pub extern fn stripSuffix(s: String, suffix: String) -> String;
 /// `new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports`.
 pub extern fn wasmInstance(bytes: Bytes) -> WasmExports;
 
+/// `exports[name](...args)` — invoke a named export with a list of
+/// Float arguments. WebAssembly's i32/i64/f32/f64 scalar types all
+/// coerce to JS Number, so a single Float-typed surface covers the
+/// common case (multi-value / void returns are out of scope here —
+/// add a specialised extern when needed). Caller is responsible for
+/// the export existing and having a compatible arity; absent exports
+/// throw `TypeError: ... is not a function` at the host boundary.
+pub extern fn wasmCall(exports: WasmExports, name: String, args: [Float]) -> Float;
+
 // ── Array helper ───────────────────────────────────────────────────
 //
 // AffineScript has no mutable-array push primitive in this subset;

--- a/tests/codegen-deno/wasm_call.affine
+++ b/tests/codegen-deno/wasm_call.affine
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MPL-2.0
+// bindings #5 (closes #414): wasmCall extern exercises the
+// `exports[name](...args)` lowering path on the Deno-ESM backend.
+//
+// Pure logic — the harness instantiates a tiny inline wasm module
+// exporting `add(i32, i32) -> i32` and passes the WasmExports value
+// into addViaWasm; nothing here touches the `Deno` global or FS.
+
+use Deno::{WasmExports, wasmCall};
+
+pub fn addViaWasm(exports: WasmExports, a: Float, b: Float) -> Float =
+  wasmCall(exports, "add", [a, b]);

--- a/tests/codegen-deno/wasm_call.harness.mjs
+++ b/tests/codegen-deno/wasm_call.harness.mjs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+// bindings #5 (closes #414) — Node ESM harness for the wasmCall extern.
+//
+// Instantiates a 41-byte inline wasm module exporting
+// `add(i32, i32) -> i32` and asserts that addViaWasm, which lowers to
+// __as_wasmCall(exports, "add", [a, b]), round-trips correctly.
+
+import assert from "node:assert/strict";
+import { addViaWasm } from "./wasm_call.deno.js";
+
+// Hand-built minimal wasm module:
+//   (module
+//     (func (export "add") (param i32 i32) (result i32)
+//       local.get 0  local.get 1  i32.add))
+const wasmBytes = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+  0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, // type: (i32,i32)->i32
+  0x03, 0x02, 0x01, 0x00,                               // func 0 of type 0
+  0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00, // export "add" func 0
+  0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b, // body
+]);
+
+const instance = new WebAssembly.Instance(new WebAssembly.Module(wasmBytes));
+const exports = instance.exports;
+
+assert.equal(addViaWasm(exports, 2, 3), 5, "addViaWasm(2,3) == 5");
+assert.equal(addViaWasm(exports, -1, 1), 0, "addViaWasm(-1,1) == 0");
+assert.equal(addViaWasm(exports, 0, 0), 0, "addViaWasm(0,0) == 0");
+assert.equal(addViaWasm(exports, 100, 200), 300, "addViaWasm(100,200) == 300");
+
+console.log("wasm_call.harness.mjs OK");


### PR DESCRIPTION
Closes #414. Implements bindings #5 (`docs/bindings-roadmap.adoc`).

## Summary

Adds the generic Option A surface for calling individual WebAssembly exports by name from AffineScript code:

```affine
pub extern fn wasmCall(
  exports: WasmExports,
  name: String,
  args: [Float]
) -> Float;
```

Lowers on the `--deno-esm` backend to `Number(exports[name](...(args || [])))`. Number coercion means i32/i64/f32/f64 return types all flow back as `Float` at the AS boundary.

## Why this shape

Two approaches were on the table (from `docs/bindings-roadmap.adoc` and #414):

| Option | Shape | Trade |
|---|---|---|
| **A (chosen)** | One generic `wasmCall(exports, name, args) -> Float` | Tiny surface, future-proof, stringly-typed export name |
| B | ~30 per-export typed externs matching a specific Zig module | Typed at compile time, brittle to Zig-side changes |

Option A unblocks both idaptik `vm/wasm` (the immediate consumer) and every future WASM-host integration in the estate, with ~10 LoC of stdlib + codegen. Typed per-Zig-fn wrappers can layer on top per-consumer where the discipline is worth the brittleness.

## Files

| File | Change |
|---|---|
| `stdlib/Deno.affine` | New `wasmCall` extern with docstring |
| `lib/codegen_deno.ml` | New `__as_wasmCall` runtime helper + lowering-table entry |
| `tests/codegen-deno/wasm_call.affine` | Test fixture (AS source) |
| `tests/codegen-deno/wasm_call.harness.mjs` | Node ESM harness with 41-byte hand-built wasm module exporting `add(i32, i32) -> i32` |
| `docs/bindings-roadmap.adoc` | Row #5 status `◐` → `●`, rationale updated to point at this PR |

## Test plan

- [x] `tools/run_codegen_deno_tests.sh` — all 7 harnesses green, including the new `wasm_call.harness.mjs` (4 assertions: `add(2,3)=5`, `add(-1,1)=0`, `add(0,0)=0`, `add(100,200)=300`)
- [ ] `dune build` clean
- [ ] Hypatia / governance checks
- [ ] No new TypeScript files (DOC-FORMAT N/A — single .adoc edit, not a new doc)

## Out of scope

- Wasm void / multi-value return shapes — add a specialised extern when a consumer asks.
- Typed per-Zig-fn shims for idaptik vm/wasm — layered on top of `wasmCall` in idaptik when the migration restarts there.
- Interp-side (`affinescript eval`) handling — wasm calling is `--deno-esm`-target only, consistent with `wasmInstance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)