### PR TITLE
feat(stdlib): motion library binding (bindings #4)

### DIFF
--- a/docs/bindings-roadmap.adoc
+++ b/docs/bindings-roadmap.adoc
@@ -67,9 +67,9 @@ no further significant ReScript → AffineScript work is tractable.
 
 |4
 |*motion* (animate, animateMini, tween, ease, spring)
-|`○`
-|`affinescript-motion`
-|idaptik `src/bindings/Motion.res`; player + UI transitions.
+|`◐` scaffold (animate / await / cancel landed)
+|`stdlib/Motion.affine` (eventual home: `affinescript-motion`)
+|idaptik `src/bindings/Motion.res`; player + UI transitions. Initial surface (`motionAnimate` / `motionAwait` / `motionCancel`) lands in `stdlib/` parallel to Http / Sqlite / Crypto; consumer provides `globalThis.__as_motion` at module-init time. Test fixture: `tests/codegen-deno/motion_smoke.{affine,harness.mjs}`. Follow-ups: `animateMini`, `tween`, `ease`, `spring`, typed keyframe shapes.
 
 |5
 |*WASM-exports calling pattern* — invoke individual `exports.fn_name(args)` from a `WasmExports` value

--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -157,6 +157,22 @@ const __as_readDirNames = (p) => {
 const __as_isNotFound = (e) => (e instanceof Deno.errors.NotFound);
 const __as_wasmInstance = (bytes) =>
   new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports;
+const __as_wasmCall = (exports, name, args) => Number(exports[name](...(args || [])));
+// ---- motion (bindings #4): consumer-provided import ----
+// Host JS environment must expose globalThis.__as_motion (the motion
+// library or a compatible mock). Tests set it in the harness before
+// importing the generated module; production consumers typically do
+// `import * as m from "motion"; globalThis.__as_motion = m;` once at
+// module-init time. The AffineScript-side externs (stdlib/Motion.affine)
+// don't see this indirection — they call __as_motion* helpers directly.
+const __as_motionAnimate = (target, keyframes, options) =>
+  globalThis.__as_motion.animate(target, keyframes, options);
+const __as_motionAwait = (controls) =>
+  Promise.resolve(controls).then(() => 0);
+const __as_motionCancel = (controls) => {
+  if (controls && typeof controls.cancel === "function") controls.cancel();
+  return 0;
+};
 // `++` is overloaded (string concat / array concat); `a + b` would
 // stringify arrays. Dispatch on shape so stdlib/string.affine's
 // `result ++ [x]` and `a ++ b` are both correct.
@@ -250,6 +266,11 @@ let () =
   (* ---- misc host ---- *)
   b "dateNow"     (fun _ -> "Date.now()");
   b "wasmInstance" (fun a -> Printf.sprintf "__as_wasmInstance(%s)" (arg 0 a));
+  b "wasmCall"     (fun a -> Printf.sprintf "__as_wasmCall(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  (* ---- motion (bindings #4) ---- *)
+  b "motionAnimate" (fun a -> Printf.sprintf "__as_motionAnimate(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  b "motionAwait"   (fun a -> Printf.sprintf "(await __as_motionAwait(%s))" (arg 0 a));
+  b "motionCancel"  (fun a -> Printf.sprintf "__as_motionCancel(%s)" (arg 0 a));
   (* Generic JS array push helper (returns the array, fluent). *)
   b "arrayPush" (fun a -> Printf.sprintf "(%s.push(%s), %s)" (arg 0 a) (arg 1 a) (arg 0 a));
   (* ---- honest string/number primitives underpinning the

--- a/stdlib/Motion.affine
+++ b/stdlib/Motion.affine
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// Motion.affine — bindings for the `motion` npm library (bindings #4
+// in docs/bindings-roadmap.adoc).
+//
+// Provides a typed surface over motion's `animate()` for tween / spring
+// animations. Targets the Deno-ESM backend; the consumer (or its host
+// wrapper) is responsible for putting the motion library at
+// `globalThis.__as_motion` before any generated module that uses these
+// externs runs. The test harness pattern is in
+// `tests/codegen-deno/motion_smoke.harness.mjs`.
+//
+// This file lives in `stdlib/` for parity with Http / Sqlite / Crypto.
+// The dedicated `affinescript-motion` package home flagged in the
+// bindings roadmap is the long-term destination; the migration from
+// here to there is additive and source-compatible.
+//
+// Surface coverage in this version: `animate` (with await + cancel).
+// Follow-ups (deferred): `animateMini`, `tween`, `ease`, `spring`,
+// keyframe-typing, transform-property typing. Status row in
+// `docs/bindings-roadmap.adoc` (#4) updates with each coverage tranche.
+
+module Motion;
+
+// `Json` from stdlib/Deno.affine is the estate's opaque-host-value
+// type. We reuse it rather than declaring a parallel hierarchy of
+// Element / Keyframes / AnimationOptions — typed shapes for those
+// are tracked separately under the `affinescript-motion` follow-up.
+use Deno::{Json};
+
+// Opaque handle to an in-flight motion animation. Underlying value is
+// a motion `AnimationPlaybackControls` — thenable + `.cancel()`.
+// Treated opaquely at the AS boundary.
+pub extern type AnimationControls;
+
+/// `motion.animate(target, keyframes, options) -> AnimationPlaybackControls`.
+///
+/// `target`, `keyframes`, and `options` cross the boundary as opaque
+/// `Json`. The runtime helper forwards them unchanged to the
+/// host-provided motion library.
+pub extern fn motionAnimate(
+  target: Json,
+  keyframes: Json,
+  options: Json
+) -> AnimationControls;
+
+/// Wait for an animation to finish (or be cancelled). Returns 0 on
+/// completion. Lowers to `await Promise.resolve(controls).then(...)`,
+/// so a controls value whose underlying promise rejects will surface
+/// here as a JS exception — consumers wanting Result semantics should
+/// wrap in `try`/`catch` at the call site.
+pub extern fn motionAwait(controls: AnimationControls) -> Int / { Async };
+
+/// `controls.cancel()` — force-cancel an in-flight animation.
+/// Returns 0. A controls value without a `.cancel` method (e.g. a
+/// mock) is treated as already-cancelled; this is a no-op return 0.
+pub extern fn motionCancel(controls: AnimationControls) -> Int;

--- a/tests/codegen-deno/motion_smoke.affine
+++ b/tests/codegen-deno/motion_smoke.affine
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+// bindings #4 — Motion library smoke test.
+//
+// The harness installs a mock at globalThis.__as_motion before
+// importing the generated module; we re-export thin wrappers so the
+// harness can drive `motionAnimate` / `motionCancel` via stable names.
+
+use Deno::{Json};
+use Motion::{AnimationControls, motionAnimate, motionCancel};
+
+pub fn smokeAnimate(target: Json, keyframes: Json, options: Json) -> AnimationControls =
+  motionAnimate(target, keyframes, options);
+
+pub fn smokeCancel(controls: AnimationControls) -> Int =
+  motionCancel(controls);

--- a/tests/codegen-deno/motion_smoke.harness.mjs
+++ b/tests/codegen-deno/motion_smoke.harness.mjs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+// bindings #4 — Node ESM harness for the motion library binding.
+//
+// Installs a globalThis.__as_motion mock before importing the
+// generated module, drives smokeAnimate / smokeCancel, and asserts
+// the arguments + cancel side-effect were observed.
+
+import assert from "node:assert/strict";
+
+let lastAnimateCall = null;
+let cancelCount = 0;
+
+globalThis.__as_motion = {
+  animate(target, keyframes, options) {
+    lastAnimateCall = { target, keyframes, options };
+    return {
+      then(cb) { if (cb) cb(); return this; },
+      cancel() { cancelCount += 1; },
+    };
+  },
+};
+
+const { smokeAnimate, smokeCancel } = await import("./motion_smoke.deno.js");
+
+const controls = smokeAnimate("#player", { x: 100, opacity: 0.5 }, { duration: 1.0 });
+assert.equal(lastAnimateCall.target, "#player", "target reaches host");
+assert.deepEqual(lastAnimateCall.keyframes, { x: 100, opacity: 0.5 }, "keyframes reach host");
+assert.deepEqual(lastAnimateCall.options, { duration: 1.0 }, "options reach host");
+
+assert.equal(smokeCancel(controls), 0, "cancel returns 0");
+assert.equal(cancelCount, 1, "cancel invoked exactly once");
+
+// Cancel a null-controls value is a no-op (mock controls without .cancel)
+assert.equal(smokeCancel({}), 0, "cancel on bare object returns 0");
+assert.equal(cancelCount, 1, "cancel count unchanged for bare object");
+
+console.log("motion_smoke.harness.mjs OK");


### PR DESCRIPTION
First tranche of bindings #4 (`docs/bindings-roadmap.adoc`).

## Summary

Adds `stdlib/Motion.affine` providing the initial typed surface over the [`motion`](https://www.npmjs.com/package/motion) npm library: `animate` → `awaitable AnimationControls` → `cancel`. Surface mirrors the existing Http / Sqlite / Crypto stdlib pattern.

Also bundles the `wasmCall` extern that has been waiting on CI in PR #419 (same `codegen_deno.ml` runtime + lowering region — bundling keeps history linear). Closes #414 via the bundle.

## Surface

```affine
pub extern type AnimationControls;
pub extern fn motionAnimate(target: Json, keyframes: Json, options: Json) -> AnimationControls;
pub extern fn motionAwait(controls: AnimationControls) -> Int / { Async };
pub extern fn motionCancel(controls: AnimationControls) -> Int;
```

Args cross the boundary as opaque `Json` (typed keyframe shapes are a follow-up when `affinescript-motion` lands as a dedicated package).

## Lowering

```javascript
const __as_motionAnimate = (target, keyframes, options) =>
  globalThis.__as_motion.animate(target, keyframes, options);
const __as_motionAwait = (controls) =>
  Promise.resolve(controls).then(() => 0);
const __as_motionCancel = (controls) => {
  if (controls && typeof controls.cancel === "function") controls.cancel();
  return 0;
};
```

Consumer responsibility: production code sets `globalThis.__as_motion = motionLibrary` at module init. Documented in `stdlib/Motion.affine`'s preamble.

## Files

| File | Change |
|---|---|
| `stdlib/Motion.affine` | NEW — opaque type + 3 externs with effect rows |
| `lib/codegen_deno.ml` | `__as_motion*` runtime helpers + lowering table entries; `__as_wasmCall` helper restored |
| `tests/codegen-deno/motion_smoke.affine` | NEW — AS fixture, `use Motion::{...}` round-trip |
| `tests/codegen-deno/motion_smoke.harness.mjs` | NEW — Node ESM harness with mocked `globalThis.__as_motion` |
| `docs/bindings-roadmap.adoc` | Row #4 status `○` → `◐` scaffold |

## Test plan

- [x] `tools/run_codegen_deno_tests.sh` — all 7 harnesses green, including new `motion_smoke` (4 assertions: target/keyframes/options pass-through, cancel side-effect, no-op cancel on bare object)
- [x] `dune build bin/main.exe` clean
- [x] `use Motion::{...}` from a `tests/codegen-deno/` fixture resolves (validates stdlib import path works from standalone-compile mode)

## Follow-ups

Deferred per row #4 rationale:
- `animateMini`, `tween`, `ease`, `spring` (additional surface)
- Typed keyframe shapes (currently opaque `Json`)
- Migration from `stdlib/Motion.affine` to dedicated `affinescript-motion` package (additive + source-compatible)

## Relationship to PR #419

#419 (wasmCall) was opened with auto-merge armed but blocked on pre-existing E2E flakes. This PR includes the same wasmCall changes; merging this supersedes #419, which should be closed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)