### PR TITLE
fix(ci): walker Js.Exn catch-arm detection + vscode E2E false-positive (closes #426)

### DIFF
--- a/packages/affine-vscode/mod.js
+++ b/packages/affine-vscode/mod.js
@@ -12,12 +12,17 @@
 //
 // Manual wiring (fallback), from a hand-written .cjs:
 //
-//   const shim = require("./extension.cjs");
-//   shim.extraImports = () => require("@hyperpolymath/affine-vscode")(
-//     require("vscode"),
-//     require("vscode-languageclient/node"),
-//     shim,                             // the .cjs shim module (hostShim)
-//   );
+//   const shim    = loadShim("./extension.cjs");
+//   const adapter = loadAdapter();         // the @hyperpolymath/affine-vscode export
+//   const vscode  = loadVscode();          // the host vscode module
+//   const lc      = loadLanguageClient();  // vscode-languageclient/node (or null to skip LSP)
+//   shim.extraImports = () => adapter(vscode, lc, shim);
+//
+// Each `load*()` call above is illustrative — in real wiring it would be a
+// require(...) of the corresponding npm module. The literal require() strings
+// are intentionally NOT shown here so that the embedded-adapter substring
+// assertions in `test/test_e2e.ml` (E2E Node-CJS Codegen #4/#5) don't
+// false-positive on documentation comments.
 //
 // The adapter maintains a per-process JS-side handle table keyed by Int
 // so opaque handles passed across the FFI boundary survive round-trips.

--- a/tools/res-to-affine/walker.ml
+++ b/tools/res-to-affine/walker.ml
@@ -423,19 +423,20 @@ let detect_untyped_exception ~source acc node =
       else acc
   | _ ->
       (* Tree-sitter labels module paths differently depending on syntactic
-         position — `Js.Exn.Error(_)` in a catch-arm pattern is not a
-         [member_expression]/[value_identifier_path], so the typed branches
-         above miss it. Fall back to a tight leaf-only text match so the
-         pattern still flags. The master walker's [dedupe] collapses any
-         same-line duplicate against the [try_expression] hit. *)
-      if node.children = [] then
-        let text = node_text ~source node in
-        if String.length text <= 32
-           && (starts_with "Js.Exn" text
-               || text = "Promise.catch"
-               || ends_with ".Promise.catch" text)
-        then push acc
-        else acc
+         position — `Js.Exn.Error(_)` in a catch-arm pattern is a compound
+         node (constructor pattern with the `(_)` payload as a child), so
+         the typed branches above miss it AND the previous leaf-only
+         fallback (`node.children = []`) skipped it too. Fall back to a
+         text-based match capped at 32 chars; the cap prevents matching
+         the enclosing match/try expression text. The master walker's
+         [dedupe] collapses any same-line duplicate against the
+         [try_expression] hit. *)
+      let text = node_text ~source node in
+      if String.length text <= 32
+         && (starts_with "Js.Exn" text
+             || text = "Promise.catch"
+             || ends_with ".Promise.catch" text)
+      then push acc
       else acc
 
 (* ---- mutable-global: top-level [let x = ref(...)] or top-level [:=] ---- *)


### PR DESCRIPTION
## Summary

Closes #426. Two small surgical fixes that resolve the 3 pre-existing test failures blocking PR auto-merges on main.

### Fix 1 — Walker `Js.Exn` catch-arm detection (resolves 1 test)

`tools/res-to-affine/walker.ml` — drop the `node.children = []` constraint from the fallback in `detect_untyped_exception`. tree-sitter-rescript parses `Js.Exn.Error(_)` in a catch-arm as a compound node (constructor pattern with the `(_)` payload as a child), so the leaf-only check skipped it.

The pre-existing 32-char text length cap is a sufficient guardrail — `Js.Exn.Error(_)` is 15 chars and the enclosing try/match expressions exceed the cap. Dedupe handles same-line duplicates.

**Test**: `walker-phase2c-parity #2 untyped-exception` `[OK]` (was FAIL).

### Fix 2 — vscode E2E false-positive (resolves 2 tests)

`packages/affine-vscode/mod.js` — rewrite the manual-wiring example in the header doc comment. The previous text contained literal `require(\"@hyperpolymath/affine-vscode\")` and `require(\"vscode-languageclient/node\")` strings as illustrative code; once `mod.js` is embedded at compile time (per #380), the E2E codegen tests' substring-based `contains` helper false-positived on those comment strings.

New wording uses named placeholders (`loadShim()` / `loadAdapter()` / `loadVscode()` / `loadLanguageClient()`) plus an explanatory note saying the literal `require(...)` strings are intentionally omitted so the E2E assertions don't false-positive.

**Tests**:
- `E2E Node-CJS Codegen #4 --vscode-extension-adapter-override` `[OK]` (was FAIL)
- `E2E Node-CJS Codegen #5 --vscode-extension-no-lc` `[OK]` (was FAIL)

## Verification (local)

```bash
# walker
dune build tools/res-to-affine/test/test_walker.exe
./_build/default/tools/res-to-affine/test/test_walker.exe
# Test Successful — 7 tests run, 0 failures

# vscode E2E
./_build/default/test/test_main.exe test \"E2E Node-CJS Codegen\"
# All [OK]
```

## Test plan

- [ ] CI \`build\` job (was failing) → green
- [ ] CI \`coverage-visibility\` job → green
- [ ] No regression on other vscode/walker tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)