### PR TITLE
docs(stdlib-roadmap): rows #3 + #4 ◯→●, codegen bug closed by #257

### DIFF
--- a/docs/stdlib-roadmap.adoc
+++ b/docs/stdlib-roadmap.adoc
@@ -100,16 +100,16 @@ checker accepts code that the runtime can't execute.
 |Same site as #1; the pilot reverted from `++` to `Cons` calls.
 
 |3
-|*`for x in xs` codegen* — wasm codegen for `for-in` (issue #255)
-|`◯` blocked-by-#255
+|*`for x in xs` codegen* — wasm codegen for `for-in` (closed as #257)
+|`●`
 |N/A (codegen)
-|Stdlib-adjacent: any iteration over a `list` triggers this. *Not a stdlib gap — a codegen bug.* Listed so it doesn't get re-scoped as stdlib work.
+|Stdlib-adjacent: any iteration over a `list` triggers this. *Not a stdlib gap — a codegen bug.* Closed by PR #257 (2026-05-19).
 
 |4
 |*`while` + `mut` codegen* — same codegen surface as #3
-|`◯` blocked-by-#255-adjacent
+|`●`
 |N/A (codegen)
-|Same disposition as #3.
+|Same disposition as #3 — closed by PR #257.
 
 |5
 |*Cross-file `use` resolvability* — `use stdlib::Option` works from a single-file standalone check


### PR DESCRIPTION
## Summary

PR #257 (`fix(codegen)!: wasm for-in/while loop bodies never executed (Closes #255)`) shipped 2026-05-19 and resolved the codegen bug that stdlib roadmap rows #3 (`for x in xs` codegen) and #4 (`while` + `mut` codegen) were waiting on. The status markers were stale at `◯ blocked-by-#255`.

Flips both rows to `●` with a reference to the closing PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)