### PR TITLE
fix(codegen-js): emit \uXXXX/\u{X} for non-ASCII string literals (closes #460)

### DIFF
--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -721,8 +721,8 @@ and gen_literal (lit : literal) : string =
       if String.length s > 0 && s.[String.length s - 1] = '.' then s ^ "0" else s
   | LitBool (true, _)  -> "true"
   | LitBool (false, _) -> "false"
-  | LitString (s, _)   -> "\"" ^ String.escaped s ^ "\""
-  | LitChar (c, _)     -> "\"" ^ Char.escaped c ^ "\""
+  | LitString (s, _)   -> Js_codegen.js_string_lit s
+  | LitChar (c, _)     -> Js_codegen.js_string_lit (String.make 1 c)
   | LitUnit _          -> "Unit"
 
 and gen_pattern ctx (pat : pattern) : string =

--- a/lib/js_codegen.ml
+++ b/lib/js_codegen.ml
@@ -101,6 +101,62 @@ let mangle (name : string) : string =
   if List.mem name js_reserved then name ^ "_"
   else name
 
+(** Lower a UTF-8 byte string to a JS double-quoted literal that is
+    safe under strict-mode ESM.
+
+    OCaml's [String.escaped] emits non-ASCII bytes as [\NNN] *decimal*
+    sequences; JavaScript parses [\NNN] as *octal* escapes which strict
+    mode rejects ([SyntaxError: Octal escape sequences are not allowed
+    in strict mode]) and which would decode to wrong characters even
+    outside strict mode. This helper instead decodes the UTF-8 byte
+    sequence to code points and emits [\uXXXX] (BMP) or [\u{XXXXX}]
+    (non-BMP) Unicode escapes — accepted everywhere, no parser-mode
+    surprises, and preserves the original character. Closes #460. *)
+let js_string_lit (s : string) : string =
+  let buf = Buffer.create (String.length s + 8) in
+  Buffer.add_char buf '"';
+  let n = String.length s in
+  let i = ref 0 in
+  while !i < n do
+    let b0 = Char.code s.[!i] in
+    if b0 < 0x80 then begin
+      (match Char.chr b0 with
+       | '\\' -> Buffer.add_string buf "\\\\"
+       | '"'  -> Buffer.add_string buf "\\\""
+       | '\n' -> Buffer.add_string buf "\\n"
+       | '\r' -> Buffer.add_string buf "\\r"
+       | '\t' -> Buffer.add_string buf "\\t"
+       | c when b0 >= 0x20 && b0 <= 0x7E -> Buffer.add_char buf c
+       | _ -> Buffer.add_string buf (Printf.sprintf "\\x%02X" b0));
+      incr i
+    end else begin
+      let cp, len =
+        if b0 < 0xC0 then (b0, 1)
+        else if b0 < 0xE0 && !i + 1 < n then
+          let b1 = Char.code s.[!i + 1] in
+          (((b0 land 0x1F) lsl 6) lor (b1 land 0x3F), 2)
+        else if b0 < 0xF0 && !i + 2 < n then
+          let b1 = Char.code s.[!i + 1] in
+          let b2 = Char.code s.[!i + 2] in
+          (((b0 land 0x0F) lsl 12) lor ((b1 land 0x3F) lsl 6) lor (b2 land 0x3F), 3)
+        else if !i + 3 < n then
+          let b1 = Char.code s.[!i + 1] in
+          let b2 = Char.code s.[!i + 2] in
+          let b3 = Char.code s.[!i + 3] in
+          (((b0 land 0x07) lsl 18) lor ((b1 land 0x3F) lsl 12)
+            lor ((b2 land 0x3F) lsl 6) lor (b3 land 0x3F), 4)
+        else (b0, 1)
+      in
+      if cp <= 0xFFFF then
+        Buffer.add_string buf (Printf.sprintf "\\u%04X" cp)
+      else
+        Buffer.add_string buf (Printf.sprintf "\\u{%X}" cp);
+      i := !i + len
+    end
+  done;
+  Buffer.add_char buf '"';
+  Buffer.contents buf
+
 (* ============================================================================
    Expression Code Generation
    ============================================================================ *)
@@ -230,8 +286,8 @@ and gen_literal (lit : literal) : string =
       if String.length s > 0 && s.[String.length s - 1] = '.' then s ^ "0" else s
   | LitBool (true, _)    -> "true"
   | LitBool (false, _)   -> "false"
-  | LitString (s, _)     -> "\"" ^ String.escaped s ^ "\""
-  | LitChar (c, _)       -> "\"" ^ Char.escaped c ^ "\""
+  | LitString (s, _)     -> js_string_lit s
+  | LitChar (c, _)       -> js_string_lit (String.make 1 c)
   | LitUnit _            -> "Unit"
 
 and gen_pattern ctx (pat : pattern) : string =

--- a/tests/codegen-deno/non_ascii.affine
+++ b/tests/codegen-deno/non_ascii.affine
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+// issue #460 — non-ASCII string literals must round-trip under
+// strict-mode ESM. Pre-fix, the JS codegen used OCaml `String.escaped`
+// which emitted `\NNN` decimal sequences; the JS parser reads `\NNN`
+// as OCTAL escapes, which strict-mode ESM rejects with
+// `SyntaxError: Octal escape sequences are not allowed in strict mode`.
+// Post-fix, non-ASCII bytes lower to `\uXXXX` / `\u{XXXXX}` Unicode
+// escapes which all JS parser modes accept.
+
+pub fn emoji_cross() -> String { return "❌"; }
+pub fn emoji_check() -> String { return "✓"; }
+pub fn cjk_hello() -> String { return "你好"; }
+pub fn latin_accent() -> String { return "café résumé"; }
+pub fn non_bmp_sob() -> String { return "😭"; }
+pub fn mixed() -> String { return "[OK] café 你好 ❌"; }
+pub fn ascii_only() -> String { return "plain ASCII"; }
+pub fn quotes_and_backslash() -> String { return "\"escaped\" and \\back"; }

--- a/tests/codegen-deno/non_ascii.harness.mjs
+++ b/tests/codegen-deno/non_ascii.harness.mjs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MPL-2.0
+// issue #460 — round-trip non-ASCII string literals through the
+// Deno-ESM backend under strict-mode ESM. The `import` itself is the
+// strictest test: if the emitted `.deno.js` contains octal escapes,
+// the module fails to parse and the import throws SyntaxError before
+// any assertion can run.
+import assert from "node:assert/strict";
+import {
+  emoji_cross,
+  emoji_check,
+  cjk_hello,
+  latin_accent,
+  non_bmp_sob,
+  mixed,
+  ascii_only,
+  quotes_and_backslash,
+} from "./non_ascii.deno.js";
+
+assert.equal(emoji_cross(), "❌", "BMP emoji ❌ round-trips");
+assert.equal(emoji_check(), "✓", "BMP check mark ✓ round-trips");
+assert.equal(cjk_hello(), "你好", "CJK 'nihao' round-trips");
+assert.equal(latin_accent(), "café résumé", "Latin accented round-trips");
+assert.equal(non_bmp_sob(), "\u{1F62D}", "non-BMP code point round-trips");
+assert.equal(mixed(), "[OK] café 你好 ❌", "mixed ASCII+non-ASCII round-trips");
+assert.equal(ascii_only(), "plain ASCII", "ASCII-only unchanged");
+assert.equal(quotes_and_backslash(), "\"escaped\" and \\back", "quote+backslash escapes preserved");
+
+console.log("non_ascii.harness.mjs OK");


### PR DESCRIPTION
## Summary

Closes #460 — non-ASCII string literals in AffineScript source no longer break strict-mode ESM in the Deno/Node JS backends.

## Root cause

OCaml's \`String.escaped\` emits non-ASCII bytes as \`\\NNN\` **decimal** sequences. JavaScript parses \`\\NNN\` as **octal** escapes which strict-mode ESM rejects:

\`\`\`
SyntaxError: Octal escape sequences are not allowed in strict mode.
\`\`\`

(And even outside strict mode the bytes would decode to the wrong characters — \`\\226\` octal = 0x96, not the 0xE2 lead-byte of ❌.)

## Fix

New helper \`Js_codegen.js_string_lit\` walks the UTF-8 byte sequence, decodes code points, and emits:

| Character class | Output |
|---|---|
| Printable ASCII (0x20-0x7E except \`\\\` \`\"\`) | as-is |
| \`\\\` \`\"\` \`\n\` \`\r\` \`\t\` | conventional escape |
| Other ASCII (control bytes) | \`\\xHH\` |
| Non-ASCII BMP (U+0080..U+FFFF) | \`\\uXXXX\` |
| Non-BMP (U+10000+) | \`\\u{XXXXX}\` |

Wired into both \`js_codegen.ml\` (Node target) and \`codegen_deno.ml\` (Deno-ESM target) at the \`LitString\`/\`LitChar\` emit sites.

## Test plan

New \`tests/codegen-deno/non_ascii.affine\` fixture + harness:

\`\`\`affine
pub fn emoji_cross() -> String { return \"❌\"; }    // BMP U+274C
pub fn non_bmp_sob() -> String { return \"😭\"; }     // non-BMP U+1F62D
pub fn cjk_hello()   -> String { return \"你好\"; }
pub fn latin_accent() -> String { return \"café résumé\"; }
pub fn mixed()       -> String { return \"[OK] café 你好 ❌\"; }
pub fn ascii_only()  -> String { return \"plain ASCII\"; }
pub fn quotes_and_backslash() -> String { return \"\\\"escaped\\\" and \\\\back\"; }
\`\`\`

The \`import\` itself is the strictest test: if the emitted \`.deno.js\` contains octal escapes, the module fails to parse and the harness import throws SyntaxError before any assertion runs.

- [x] Local \`./tools/run_codegen_deno_tests.sh\`: **13/13** harnesses green (including the new fixture)
- [x] Local \`dune test\`: **352/352** unit tests green
- [x] Compiler output spot-check: \`emoji_cross\` emits \`return \"\\u274C\";\`, \`non_bmp_sob\` emits \`return \"\\u{1F62D}\";\`, ASCII passes through unchanged
- [x] Manual: emitted \`.deno.js\` parses + runs under Node 20 ESM (which uses strict mode by default)

## Out of scope

- \`rescript_codegen.ml\` also uses \`String.escaped\` but emits ReScript source (which the rescript compiler then transforms to JS). Whether ReScript inherits the same bug is a separate question; not addressed here.
- Other non-JS codegens (lua, c, rust, julia, gleam, nickel, why3) keep \`String.escaped\` — they target languages with their own escape conventions.

## Refs

- Closes #460 (the gap)
- Refs hyperpolymath/standards#284 (the seam-analyst PR that surfaced this — worked around with ASCII \`[FAIL]\`/\`[OK]\` sentinels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)