### PR TITLE
style(lib/dune): apply ocamlformat to silence persistent build red

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -4,12 +4,16 @@
 ; the generated `.cjs` (eliminating the runtime `require()` of
 ; @hyperpolymath/affine-vscode, which used to fail when the adapter
 ; wasn't installed — see issues #104 / #139).
+
 (rule
  (target affine_vscode_adapter_source.ml)
- (deps (file ../packages/affine-vscode/mod.js))
+ (deps
+  (file ../packages/affine-vscode/mod.js))
  (action
-  (with-stdout-to %{target}
-   (bash "echo '(* AUTO-GENERATED from packages/affine-vscode/mod.js. Do not edit. *)'; echo 'let source = {affine_vscode|'; cat %{dep:../packages/affine-vscode/mod.js}; echo '|affine_vscode}'"))))
+  (with-stdout-to
+   %{target}
+   (bash
+    "echo '(* AUTO-GENERATED from packages/affine-vscode/mod.js. Do not edit. *)'; echo 'let source = {affine_vscode|'; cat %{dep:../packages/affine-vscode/mod.js}; echo '|affine_vscode}'"))))
 
 (library
  (name affinescript)


### PR DESCRIPTION
## Summary

- `lib/dune`'s `affine_vscode_adapter_source.ml` rule (added in PR #380) has been failing the CI `Check formatting` step on every run since it landed — main has been red on this for days.
- Apply ocamlformat's preferred wrapping: blank line before `(rule`, `deps` / `with-stdout-to` / `bash` split across lines. Diff verbatim matches what the failing run printed.
- Pure formatting — `dune build` output for `affine_vscode_adapter_source.ml` is byte-identical.

## Test plan

- [ ] CI `build` job passes (the `Check formatting` step is what was red).
- [ ] No other regressions — only `lib/dune` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)