### PR TITLE
docs(tw_section): update stale typed-wasm proposal 0001 reference (accepted + ADR-0002/0003)

### DIFF
--- a/lib/tw_section.mli
+++ b/lib/tw_section.mli
@@ -8,12 +8,15 @@
     (avoiding a cycle with [Codegen]). Callers map their domain
     types to bytes before invoking.
 
-    Forward-compatibility slot for typed-wasm proposal 0001 (issue
-    hyperpolymath/typed-wasm#34): [Encode.regions] and
-    [Encode.capabilities] land here when the proposal promotes to
-    [accepted]. Sharing the internal LE writers (u8 / u32le / leb128)
-    inside this module prevents the 3-sections × 2-copies = 6-encoder
-    fan-out flagged by hyperpolymath/affinescript#444. *)
+    Forward-compatibility slot for typed-wasm proposals 0001 + 0002
+    (now [accepted] 2026-05-30; promoted to typed-wasm ADR-0002
+    [multi-producer carrier sections] and ADR-0003 [access-site
+    carrier]). [Encode.regions], [Encode.capabilities], and
+    [Encode.access_sites] land here as codegen produces them — see
+    hyperpolymath/affinescript#462 (typed access-sites emission).
+    Sharing the internal LE writers (u8 / u32le / leb128) inside this
+    module prevents the 3-sections × 2-copies = 6-encoder fan-out
+    flagged by hyperpolymath/affinescript#444. *)
 
 module Encode : sig
   (** v1 wire format for [typedwasm.ownership]:


### PR DESCRIPTION
## Summary

\`lib/tw_section.mli\` describes the forward-compatibility slot for
typed-wasm carrier-section encoders. Its header gates that slot on
\"the proposal promotes to [accepted]\" — but the gating event
happened on 2026-05-30:

- typed-wasm proposal 0001 (\`docs/proposals/0001-multi-producer-carrier-section.adoc\`) reached \`[accepted]\` and was promoted to typed-wasm ADR-0002 in typed-wasm#116
- typed-wasm proposal 0002 (\`docs/proposals/0002-access-site-carrier.adoc\`) reached \`[accepted]\` and was promoted to typed-wasm ADR-0003 in the same PR

This PR refreshes the header to reflect the new state and adds
\`access_sites\` to the list of encoders the slot reserves, with a
pointer to active downstream work (#462). No substantive behaviour
change — encoders still land here as codegen produces them.

## Test plan

- [ ] CI green (single-file .mli comment update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)