### PR TITLE
ci: concurrency cancel-in-progress on 4 workflows missing it

### DIFF
--- a/.github/workflows/affine-vscode-publish.yml
+++ b/.github/workflows/affine-vscode-publish.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/instant-sync.yml
+++ b/.github/workflows/instant-sync.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -34,6 +34,10 @@ permissions:
   contents: read
   id-token: write # JSR OIDC; no token secret needed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Same pattern as proven#115 / ephapax#248 / typed-wasm#120. 4 affinescript workflows without concurrency: release, publish-jsr, affine-vscode-publish, instant-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)