### PR TITLE
docs(ledger): truth INT-02 closure + spin satellite-shell scope to #489 (Refs #179, #489)

### DIFF
--- a/docs/ECOSYSTEM.adoc
+++ b/docs/ECOSYSTEM.adoc
@@ -164,8 +164,12 @@ target.
 Linear-msg invariant; reuses the INT-02 loader. 9 Deno tests vs the
 canonical `affinescript tea-bridge` + a re-entrancy fixture.
 
-|`affinescript-dom-loader` |scaffold |Was imaginary until #175. INT-02
-(#179) builds the host-agnostic loader. Blocks INT-05/08/11.
+|`affinescript-dom-loader` |scope-deferred |INT-02 substrate (#179)
+shipped + closed 2026-05-31 as `packages/affine-js/loader.js` — already
+host-agnostic (Deno/Node/browser parity). Whether the satellite repo
+still earns its keep (vs. folding into `affine-js`) is the open question
+in #489; revisit when INT-08 reconciler runtime (#183) unblocks (#255)
+and dictates any DOM-specific loader surface.
 
 |`affinescript-cadre` |scaffold |Was imaginary until #175. Router/navigation
 satellite (internal `lib/tea_router.ml` contract exists).
@@ -199,16 +203,16 @@ link:TECH-DEBT.adoc[TECH-DEBT.adoc].
 `use Mod::{fn}`/`::*` PROVEN+locked (deno link harness); `use Mod;`/`as`
 + `Mod.fn(x)` qualified-value path WIRED+locked (parse-boundary lowering;
 4 hermetic tests). Distinct parser follow-up: `Mod::fn(x)` in expr position
-|INT-02 |Host-agnostic loader bridge (`affinescript-dom-loader`) |#179 |loader
-in `packages/affine-js` (SAT-02 fixed; Deno/Node/browser parity,
-multi-namespace import object, ownership-section accessor). *PROVEN +
-regression-locked:* 14 unit tests via pinned `deno task test` (was
-flag-fragile — no run task) + `tests/modules/loader-bridge/` drives the
-*real* loader API over genuine compiler-emitted cross-module wasm
+|INT-02 |Host-agnostic loader bridge (`affinescript-dom-loader`) |#179
+**CLOSED 2026-05-31** |loader in `packages/affine-js` (SAT-02 fixed;
+Deno/Node/browser parity, multi-namespace import object, ownership-section
+accessor). *PROVEN + regression-locked:* 14 unit tests via pinned
+`deno task test` (was flag-fragile — no run task) + `tests/modules/loader-bridge/`
+drives the *real* loader API over genuine compiler-emitted cross-module wasm
 (`readBytes`+`buildImportObject` link `CrossCallee.consume(42)`=42;
 `parseOwnershipSection` reads a real Linear-param entry) — closes
-INT-01 ↔ INT-02. S1; unblocks INT-05/08/11. The `affinescript-dom-loader`
-satellite shell is downstream.
+INT-01 ↔ INT-02. S1; **unblocked INT-05/08/11**. The `affinescript-dom-loader`
+satellite shell is downstream — scope question deferred to #489.
 |INT-03 |WASI preview2 / host I/O beyond stdout |#180 |S1, ADR-015
 ACCEPTED (owner-chosen full WASM Component-Model re-target). Staged
 S1..S6c; legacy preview1 stdout path remains the default until S6c
@@ -255,7 +259,8 @@ manual-only `publish-jsr.yml`; docs/PACKAGING.adoc). INT-01 dep
 cleared. NOT published (owner-gated: needs explicit go + JSR/npm
 auth). Compiler-binary distribution = design fork #260
 |INT-05 |Loader-driven multi-module app bundling |ledger-only |planned
-(blocked by INT-02)
+(INT-02 dep cleared 2026-05-31 via #179; no other blockers — next-up
+candidate for an issue-spinout)
 |INT-06 |Server-side runtime profile (on INT-03 WASI p2) |ledger-only
 |planned (blocked by #485)
 |INT-07 |`affinescript-tea` runtime satellite |#182 |runtime + run loop
@@ -271,7 +276,8 @@ loop-codegen defect, pre-existing)
 distribution decided (ADR-019: Releases + thin Deno/JSR shim, #260).
 Consumes the shim once #260 S2/S3 land
 |INT-11 |Browser host parity (DOM loader + reconciler end-to-end) |
-ledger-only |planned (blocked by INT-02/08)
+ledger-only |planned (INT-02 dep cleared 2026-05-31 via #179; still
+blocked by INT-08 runtime via #255). Satellite-repo question = #489.
 |INT-12 |typed-wasm convergence: AffineScript-emitted fixtures into the
 typed-wasm cross-compat suite (closes the Stage-E runway) |ledger-only |
 planned (Stage E; coordinates with `hyperpolymath/typed-wasm` C5.1)

--- a/docs/TECH-DEBT.adoc
+++ b/docs/TECH-DEBT.adoc
@@ -360,11 +360,12 @@ a parse error (`::`-in-value-expr unwired; `::` reserved for
 `Type::Variant`). |S1 |`use ::{}`/`::*` + `use Mod;`/`as`-qualified
 `Mod.fn(x)` DONE (PR Refs #178); `::`-in-expression a separate parser
 follow-up
-|INT-02 |Host-agnostic loader bridge |S1 |*PROVEN + locked* (Refs #179):
-`packages/affine-js` loader (SAT-02 fixed; Deno/Node/browser parity,
-multi-ns import object, ownership accessor); 14 unit tests via pinned
-`deno task test` + `tests/modules/loader-bridge/` e2e on real
-compiler-emitted xmod wasm (closes INT-01↔INT-02). Unblocks INT-05/08/11
+|INT-02 |Host-agnostic loader bridge |S1 |**#179 CLOSED 2026-05-31** —
+*PROVEN + locked*: `packages/affine-js` loader (SAT-02 fixed;
+Deno/Node/browser parity, multi-ns import object, ownership accessor);
+14 unit tests via pinned `deno task test` + `tests/modules/loader-bridge/`
+e2e on real compiler-emitted xmod wasm (closes INT-01↔INT-02). INT-05/08/11
+INT-02 dep cleared. Satellite-repo scope question = #489.
 |INT-03 |WASI preview2 / host I/O |S1 |#180 ADR-015 (full
 Component-Model re-target, S1..S6c). **#180 closed 2026-05-31 —
 substrate done.** Shipped: S1 ADR (#252), S2 toolchain (#286,


### PR DESCRIPTION
INT-02 substrate (host-agnostic loader bridge) shipped in #250 + proven in #267 back on 2026-05-19, but the issue (#179) stayed open under the PR-body convention *\"Refs not Closes — owner-gated; the `affinescript-dom-loader` satellite shell is downstream\"*.

Re-verified on `main` @ `efa0339` 2026-05-31 — 14/14 unit tests via `deno task test` + e2e harness `tests/modules/loader-bridge/run.sh` on real compiler-emitted xmod wasm both green. Closed #179.

The *satellite-shell scope question* (separate `hyperpolymath/affinescript-dom-loader` repo vs. fold into `packages/affine-js` vs. defer until INT-08 runtime unblocks) is now **#489** with A/B/C options + recommendation pending owner call.

## Ledger updates

| Doc | Row | Change |
|---|---|---|
| `ECOSYSTEM.adoc` | satellite-registry `affinescript-dom-loader` | `scaffold` → `scope-deferred`; back-pointer to #489 / #183 / #255 |
| `ECOSYSTEM.adoc` | INT-02 | added \"#179 CLOSED 2026-05-31\"; satellite-shell pointer → #489 |
| `ECOSYSTEM.adoc` | INT-05 | \"blocked by INT-02\" → INT-02 dep cleared; flagged next-up for issue-spinout |
| `ECOSYSTEM.adoc` | INT-11 | INT-02 dep cleared; still blocked by INT-08 runtime via #255; satellite-repo pointer → #489 |
| `TECH-DEBT.adoc` | INT-02 | matched closure language; satellite-repo pointer → #489 |

`SAT-02` row in TECH-DEBT was already marked FIXED + Proven + locked — left as-is.

No code change. Pure ledger truthing.

Refs #179, #489.