### PR TITLE
docs: point migration trackers at #488 (successor to closed #57)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,7 +42,7 @@ The following files in `.machine_readable/` contain structured project metadata:
 
 ## Language Policy (Hyperpolymath Standard)
 
-> **Policy refresh 2026-05-25**: AffineScript is now the primary application language across the estate (this is its home repo). ReScript / TypeScript / meaningfully-migrated JavaScript are banned going forward — write new code in AffineScript. Existing ReScript stays in place as legacy until the `.res → .affine` migration assistant (#57) walks the corpus. MPL-1.0 / MPL-1.0-or-later are banned; rewrite to MPL-2.0 wherever encountered (code + docs). **Jekyll is banned**; the canonical estate SSG is `hyperpolymath/casket-ssg` (Haskell). This repo already migrated via `.github/workflows/casket-pages.yml`.
+> **Policy refresh 2026-05-25**: AffineScript is now the primary application language across the estate (this is its home repo). ReScript / TypeScript / meaningfully-migrated JavaScript are banned going forward — write new code in AffineScript. Existing ReScript stays in place as legacy until the `.res → .affine` migration assistant (#488) walks the corpus. MPL-1.0 / MPL-1.0-or-later are banned; rewrite to MPL-2.0 wherever encountered (code + docs). **Jekyll is banned**; the canonical estate SSG is `hyperpolymath/casket-ssg` (Haskell). This repo already migrated via `.github/workflows/casket-pages.yml`.
 
 ### ALLOWED Languages & Tools
 
@@ -66,7 +66,7 @@ The following files in `.machine_readable/` contain structured project metadata:
 
 | Language | Status | Disposition |
 |----------|--------|-------------|
-| **ReScript** (`.res`, `.resi`) | Legacy — pre-2026-05-25 | Migrate via `tools/res-to-affine/` (#57) when touching adjacent code; do not add new `.res` files. |
+| **ReScript** (`.res`, `.resi`) | Legacy — pre-2026-05-25 | Migrate via `tools/res-to-affine/` (#488) when touching adjacent code; do not add new `.res` files. |
 | **JavaScript** (`.js`, `.cjs`, `.mjs`) | Legacy / carve-outs only | Approved runtime-exemption carve-outs (see below) remain; net-new JS in a project already migrated to AffineScript is banned. |
 
 ### BANNED — Do Not Use (write zero new occurrences)
@@ -74,7 +74,7 @@ The following files in `.machine_readable/` contain structured project metadata:
 | Banned | Replacement |
 |--------|-------------|
 | TypeScript | **AffineScript** |
-| ReScript (new files) | **AffineScript** (migration via #57) |
+| ReScript (new files) | **AffineScript** (migration via #488) |
 | JavaScript (where the project has been meaningfully migrated to AffineScript) | **AffineScript** |
 | Node.js | Deno |
 | npm | Deno |
@@ -102,7 +102,7 @@ Both are FOSS with independent governance (no Big Tech).
 ### Enforcement Rules
 
 1. **No new TypeScript files** - Write new code in AffineScript (closed exemptions table below covers the residual `.d.ts` / Deno-test cases).
-2. **No new ReScript files** - As of 2026-05-25 policy refresh; AffineScript is the go-forward. Existing `.res` files stay until migrated via #57.
+2. **No new ReScript files** - As of 2026-05-25 policy refresh; AffineScript is the go-forward. Existing `.res` files stay until migrated via #488.
 3. **No package.json for runtime deps** - Use deno.json imports.
 4. **No node_modules in production** - Deno caches deps automatically.
 5. **No Go code** - Use Rust instead.

--- a/docs/MIGRATION-ASSISTANT.adoc
+++ b/docs/MIGRATION-ASSISTANT.adoc
@@ -4,7 +4,8 @@
 :toc: macro
 :toclevels: 2
 
-Tracks issue #57 (parser + metaparser). Companion to
+Tracks issue #488 (partial-port mode), the successor to the now-closed #57
+(parser + metaparser; the declaration-translation phase, delivered). Companion to
 link:RESCRIPT-ELIMINATION.adoc[RESCRIPT-ELIMINATION.adoc], which is the
 authoritative ledger for the broader estate ReScript-surface retirement.
 
@@ -118,7 +119,8 @@ which is what makes the tool earn its keep on idaptik's 542 files.
 
 * `tools/res-to-affine/README.md` — tool usage, Phase plan, design rationale.
 * `editors/tree-sitter-rescript/README.md` — vendoring manifest details.
-* `affinescript#57` — parser + metaparser proposal.
+* `affinescript#57` — parser + metaparser proposal (closed; declaration translation delivered).
+* `affinescript#488` — successor: partial-port mode + module-qualified-reference resolution.
 * `gitbot-fleet#148` — downstream tracker for the consumed ReScript subtree.
 * link:RESCRIPT-ELIMINATION.adoc[`RESCRIPT-ELIMINATION.adoc`] — estate-wide ledger.
 * https://github.com/hyperpolymath/idaptik/blob/main/migration/main/LESSONS.md[idaptik LESSONS.md]

--- a/tools/res-to-affine/README.md
+++ b/tools/res-to-affine/README.md
@@ -8,8 +8,10 @@ with **migration markers** — comments that name each anti-pattern the
 scanner found, point at the source line, and propose the AffineScript
 answer the human migrator should consider before porting.
 
-Tracks: [`affinescript#57`](https://github.com/hyperpolymath/affinescript/issues/57)
-(parser + metaparser).
+Tracks: [`affinescript#488`](https://github.com/hyperpolymath/affinescript/issues/488)
+(partial-port mode) — successor to the now-closed
+[`affinescript#57`](https://github.com/hyperpolymath/affinescript/issues/57)
+(parser + metaparser; declaration translation delivered).
 Consumed by: [`hyperpolymath/gitbot-fleet#148`](https://github.com/hyperpolymath/gitbot-fleet/issues/148)
 and the broader `idaptik` migration.
 


### PR DESCRIPTION
## What

Now that **#57** (the res-to-affine declaration translator) is closed, repoint its **forward-looking** "tracked by / migrate via" references to the live successor **#488**. Docs only.

## Changes

- **`.claude/CLAUDE.md`** — the four language-policy references (the 2026-05-25 policy line, the LEGACY + BANNED tables, and enforcement rule 2) → `#488`.
- **`tools/res-to-affine/README.md`** — the `Tracks:` pointer → `#488` (noting #57 is closed, declaration translation delivered).
- **`docs/MIGRATION-ASSISTANT.adoc`** — the `Tracks issue` line + the References entry → `#488` (with `#57` marked closed).

## Intentionally left as `#57`

Historical / contextual mentions that correctly record #57 are untouched: test comments (`#57 Phase 2b`), the CI/`justfile`/grammar-README comments, dated state snapshots (`STATE-2026-05-26.adoc`), `CORPUS-RUN.md`, and the "Issue #57 proposes…" genesis sentence in the migration doc.

## Validation
- `./tools/check-doc-truthing.sh` → ✅ pass (the over-claim ratchet scans `docs/**`; these edits add no over-claim phrases)
- `./tools/check-no-extension-ts.sh` → ✅ pass
- No code/workflow files touched → `build`/`lint`/`migration-assistant` unaffected.

`Refs #488`

https://claude.ai/code/session_017T8SzHr2yXav8hm4Ho76Uw

---
_Generated by [Claude Code](https://claude.ai/code/session_017T8SzHr2yXav8hm4Ho76Uw)_