### PR TITLE
ci(codeql): cron weekly→monthly (cut 3, standards#233 Option B)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main, master]
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 1 * *'
 
 # Estate guardrail: cancel superseded runs so re-pushes / rebased PR
 # updates do not pile up queued runs against the shared account-wide

--- a/affinescript-vite/.github/workflows/codeql.yml
+++ b/affinescript-vite/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main, master]
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 1 * *'
 
 permissions:
   contents: read

--- a/affinescriptiser/.github/workflows/codeql.yml
+++ b/affinescriptiser/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main, master]
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 1 * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Single-line cron change in `.github/workflows/codeql.yml` (and any vendored subpath copies in this repo):

```diff
 schedule:
-  - cron: '0 6 * * 1'   # weekly Monday 06:00 UTC
+  - cron: '0 6 1 * *'   # monthly 1st 06:00 UTC
```

Mirrors `hyperpolymath/standards#286` (canonical caller template).

## Scope

Owner-decision Option B from `standards#233` selected 2026-05-30. PR-trigger runs (`push` + `pull_request`) unchanged — every PR still gets CodeQL coverage.

## Sweep

Estate-wide tracker: `hyperpolymath/standards#288`.

Refs hyperpolymath/standards#233 #288 #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)