### PR TITLE
feat(parser): accept lower_ident head in qualified_type_name (closes #448 item 1)

### DIFF
--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -154,6 +154,14 @@ module_path:
 qualified_type_name:
   | head = upper_ident qsep rest = qualified_type_name_rest
     { head ^ "::" ^ rest }
+  /* #448 item 1: stdlib has lowercase module names (json, option,
+     prelude, dict, …) that must be representable as qualifier heads
+     at type/effect position. Same right-recursive shape, lookahead
+     at qsep (`.`/`::`) disambiguates against the bare lower_ident →
+     TyVar reduce; `qualified_type_name_rest` stays upper_ident-only
+     so a tail segment like `.value` still parse-errors. */
+  | head = lower_ident qsep rest = qualified_type_name_rest
+    { head ^ "::" ^ rest }
 
 qualified_type_name_rest:
   | name = upper_ident { name }

--- a/test/test_qualified_paths.ml
+++ b/test/test_qualified_paths.ml
@@ -103,6 +103,42 @@ let qualified_reserved_effect_with_use_passes () =
   | Ok () -> ()
   | Error m -> Alcotest.failf "expected Ok, got: %s" m
 
+(* #448 item 1: `qualified_type_name` head now accepts `lower_ident`
+   so stdlib's lowercase module names (json, option, prelude, dict,
+   alib, collections, io, string, result, testing, effects, math)
+   are representable at type position. Parse-side regression guard. *)
+let lowercase_qualified_type_parses () =
+  let src = "use json;\npub fn f(x: json.Value) -> () { () }\n" in
+  match frontend src with
+  | Ok () -> ()
+  | Error m ->
+    (* `json` may not be a known module in this isolated frontend run,
+       so accept any non-parse error — what we explicitly forbid is the
+       pre-fix `parse error at .` from the lowercase head. *)
+    Alcotest.(check bool) "no parse error on lowercase qualifier head"
+      false (contains ~needle:"Parse error" m);
+    Alcotest.(check bool) "no `parse error at .`"
+      false (contains ~needle:"parse error at" m);
+    ignore m
+
+(* Same shape with the `::` separator. *)
+let lowercase_qualified_type_double_colon_parses () =
+  let src = "use json;\npub fn f(x: json::Value) -> () { () }\n" in
+  match frontend src with
+  | Ok () -> ()
+  | Error m ->
+    Alcotest.(check bool) "no parse error on lowercase qualifier head (`::`)"
+      false (contains ~needle:"Parse error" m);
+    ignore m
+
+(* Tail segment still requires UpperCase (TyCon name), so a fully-
+   lowercase qualified path (`json.value`) must STILL parse-error. *)
+let fully_lowercase_qualified_type_still_rejected () =
+  let src = "use json;\npub fn f(x: json.value) -> () { () }\n" in
+  match frontend src with
+  | Ok () -> Alcotest.fail "expected parse error on lowercase tail segment"
+  | Error _ -> ()
+
 let tests = [
   Alcotest.test_case "qualified type + use → passes" `Quick
     qualified_type_with_use_passes;
@@ -116,4 +152,10 @@ let tests = [
     bare_typecon_unaffected;
   Alcotest.test_case "qualified reserved effect + use → passes" `Quick
     qualified_reserved_effect_with_use_passes;
+  Alcotest.test_case "#448(1) lowercase qualifier head parses" `Quick
+    lowercase_qualified_type_parses;
+  Alcotest.test_case "#448(1) lowercase qualifier head + `::` parses" `Quick
+    lowercase_qualified_type_double_colon_parses;
+  Alcotest.test_case "#448(1) fully-lowercase qualified path still rejected" `Quick
+    fully_lowercase_qualified_type_still_rejected;
 ]


### PR DESCRIPTION
## Summary

Item 1 of the qualified-path adjacent gaps surfaced by #448: the `qualified_type_name` production in `lib/parser.mly:154-161` required `upper_ident` as the head segment, so qualified type paths whose first segment was a lowercase stdlib module name (`json`, `option`, `prelude`, `dict`, `alib`, `collections`, `io`, `string`, `result`, `testing`, `effects`, `math`) parse-errored at the separator (`.` or `::`).

Reported symptom: `parse error at .` on `x: json.Value` even with `use json;` in scope.

## Fix

Add a parallel production with `lower_ident` head:

```ocaml
qualified_type_name:
  | head = upper_ident qsep rest = qualified_type_name_rest
    { head ^ "::" ^ rest }
  | head = lower_ident qsep rest = qualified_type_name_rest
    { head ^ "::" ^ rest }
```

`qualified_type_name_rest` stays `upper_ident`-only — the tail segment is the type/effect name proper (a TyCon), so it must remain uppercase. Only the *qualifier* segment was wrongly constrained.

Option (b) from #448 (relax the parser) rather than (a) (rename stdlib modules), per the original triage.

## LR(1) safety

The disambiguation strategy is symmetric to the existing `upper_ident` path: a bare `lower_ident` in type position reduces to TyVar (existing rule at line 504); the parser only shifts past the `lower_ident` if the next token is a `qsep` (`.` or `::`).

Menhir reports the **same conflict counts** as before the change (21 / 1 / 68 / 7), confirming no new conflicts introduced.

## Tests

Three new cases in `test/test_qualified_paths.ml`:

- `#448(1) lowercase qualifier head parses` — `x: json.Value` no longer emits a parse error
- `#448(1) lowercase qualifier head + ::` parses — same with the `::` separator
- `#448(1) fully-lowercase qualified path still rejected` — `x: json.value` MUST still parse-error because the tail segment is now reaching `qualified_type_name_rest` which still requires `upper_ident` (regression guard)

Test results: `dune runtest` → **366 tests passed** (was 363); no regressions on existing `test_qualified_paths` cases.

## Scope

Closes **#448 item 1** only. Does NOT address:
- Item 2 (`use A.B;` leaf-only qualifier registration)
- Item 3 (`use A::{Item}` multi-segment brace-list parse)
- Item 4 (bare unknown TyCon permissive lookup)

Those remain open under the parent issue.

## Downstream

Unblocks `Pkg.Type` syntax with lowercase stdlib heads — directly helps hyperpolymath/echidna#117 (Client.res AffineScript-TEA port) which had `json.Value` / `dict.Dict` references that were stranded behind this parse error.

Refs #228, refs #447, refs #241.