### PR TITLE
feat(stdlib): Sqlite schema introspection + bulk I/O + error inspection — db-theory #1c (6 externs)

### DIFF
--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -541,6 +541,25 @@ const __as_dbColumnText   = (s, idx) => {
 };
 const __as_dbReset        = (s) => { globalThis.__as_sqlite.reset(s); return 0; };
 const __as_dbFinalize     = (s) => { globalThis.__as_sqlite.finalize(s); return 0; };
+// ---- Sqlite schema introspection + bulk I/O + error inspection (db-theory #1c) ----
+// Five more adapter methods (`schemaTables`, `schemaColumns`,
+// `tableExists`, `importCsv`, `exportCsv`, `lastError`); each
+// real-world adapter (jsr:@db/sqlite, better-sqlite3) backs them with
+// a one-liner over `PRAGMA table_info` / a `Database.prepare()`
+// iterator / a `fs.writeFileSync(..., csv)` call.
+const __as_dbSchemaTables  = (h) => String(globalThis.__as_sqlite.schemaTables(h));
+const __as_dbSchemaColumns = (h, table) => String(globalThis.__as_sqlite.schemaColumns(h, table));
+const __as_dbTableExists   = (h, table) => Boolean(globalThis.__as_sqlite.tableExists(h, table));
+const __as_dbImportCsv     = (h, table, path, hasHeader) =>
+  Number(globalThis.__as_sqlite.importCsv(h, table, path, Boolean(hasHeader))) | 0;
+const __as_dbExportCsv     = (h, sql, paramsJson, path) => {
+  const params = paramsJson === "" || paramsJson === "[]" ? [] : JSON.parse(paramsJson);
+  return Number(globalThis.__as_sqlite.exportCsv(h, sql, params, path)) | 0;
+};
+const __as_dbLastError     = (h) => {
+  const v = globalThis.__as_sqlite.lastError(h);
+  return v == null ? "" : String(v);
+};
 const __as_httpFetch = async (url, method, headers, bodyOpt) => {
   const init = { method, headers: __as_httpHeadersToObject(headers) };
   if (bodyOpt && bodyOpt.tag === "Some") init.body = bodyOpt.value;
@@ -840,7 +859,14 @@ let () =
   b "db_column_int"  (fun a -> Printf.sprintf "__as_dbColumnInt(%s, %s)" (arg 0 a) (arg 1 a));
   b "db_column_text" (fun a -> Printf.sprintf "__as_dbColumnText(%s, %s)" (arg 0 a) (arg 1 a));
   b "db_reset"       (fun a -> Printf.sprintf "__as_dbReset(%s)" (arg 0 a));
-  b "db_finalize"    (fun a -> Printf.sprintf "__as_dbFinalize(%s)" (arg 0 a))
+  b "db_finalize"    (fun a -> Printf.sprintf "__as_dbFinalize(%s)" (arg 0 a));
+  (* ---- Sqlite schema introspection + bulk I/O + error inspection (db-theory #1c) ---- *)
+  b "db_schema_tables"  (fun a -> Printf.sprintf "__as_dbSchemaTables(%s)" (arg 0 a));
+  b "db_schema_columns" (fun a -> Printf.sprintf "__as_dbSchemaColumns(%s, %s)" (arg 0 a) (arg 1 a));
+  b "db_table_exists"   (fun a -> Printf.sprintf "__as_dbTableExists(%s, %s)" (arg 0 a) (arg 1 a));
+  b "db_import_csv"     (fun a -> Printf.sprintf "__as_dbImportCsv(%s, %s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a) (arg 3 a));
+  b "db_export_csv"     (fun a -> Printf.sprintf "__as_dbExportCsv(%s, %s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a) (arg 3 a));
+  b "db_last_error"     (fun a -> Printf.sprintf "__as_dbLastError(%s)" (arg 0 a))
 
 (* ============================================================================
    Identifier sanitisation (JS reserved words -> trailing underscore)

--- a/stdlib/Sqlite.affine
+++ b/stdlib/Sqlite.affine
@@ -68,3 +68,59 @@ pub extern fn db_column_int(s: Stmt, idx: Int) -> Int;
 pub extern fn db_column_text(s: Stmt, idx: Int) -> String;
 pub extern fn db_reset(s: Stmt) -> Int;
 pub extern fn db_finalize(s: Stmt) -> Int;
+
+// ── Schema introspection (db-theory #1c) ───────────────────────────
+//
+// Read the database's `sqlite_master`-equivalent metadata. Both
+// returns are JSON-encoded strings for consistency with the
+// convenience surface — caller parses with `json::parse`. A typed
+// `Schema` carrier with stronger guarantees (column types as a typed
+// enum, NOT NULL / PRIMARY KEY flags exposed) is the natural follow-on
+// once the wider db-theory programme lands a typed `Schema<T>` carrier
+// (db-theory #8 — declarative schema as type).
+
+/// JSON array of table names — `'["users","posts","comments"]'`.
+/// Excludes sqlite_*-prefixed internal tables.
+pub extern fn db_schema_tables(d: Db) -> String;
+
+/// JSON array of column descriptors for `table` — each entry has
+/// shape `{"name": "id", "type": "INTEGER", "notnull": true, "pk": true}`.
+/// Returns `"[]"` if the table does not exist.
+pub extern fn db_schema_columns(d: Db, table: String) -> String;
+
+/// `true` iff `table` exists in the current database (excludes views,
+/// indexes, and the sqlite_* internal namespace). Convenience over
+/// parsing `db_schema_tables`.
+pub extern fn db_table_exists(d: Db, table: String) -> Bool;
+
+// ── Bulk I/O (db-theory #1c) ───────────────────────────────────────
+//
+// CSV is the lingua franca for spreadsheet / data-engineering
+// pipelines; both directions stay narrow (no JSON-lines / Parquet
+// / Avro yet — those are separate bindings if and when needed).
+//
+// `db_import_csv` assumes the destination table already exists and the
+// CSV column order matches the table column order. `has_header=true`
+// skips the first row. Returns the number of rows inserted.
+//
+// `db_export_csv` runs `sql` with `params_json` substituted (same shape
+// as `db_query`), writes one row per result-row to `csv_path`, prepending
+// a header row of column names. Returns the number of rows written.
+
+pub extern fn db_import_csv(d: Db, table: String, csv_path: String, has_header: Bool) -> Int;
+pub extern fn db_export_csv(d: Db, sql: String, params_json: String, csv_path: String) -> Int;
+
+// ── Error inspection (db-theory #1c) ───────────────────────────────
+//
+// Most extern calls signal failure by raising in the host adapter
+// (caught by the AffineScript-side `try`/`catch` desugar). When a call
+// returns a sentinel instead of raising (e.g. `db_query_one` returns
+// `"null"` for "no row"), use `db_last_error` to disambiguate "no row"
+// from "error". Returns `""` if no error has been recorded on this
+// connection.
+//
+// A typed `DbError` carrier — landing in db-theory #1d alongside the
+// `Result<T, DbError>` shape — will eventually obsolete this string
+// surface, but it stays for the prototyping path.
+
+pub extern fn db_last_error(d: Db) -> String;

--- a/tests/codegen-deno/sqlite_introspect_bulk.affine
+++ b/tests/codegen-deno/sqlite_introspect_bulk.affine
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MPL-2.0
+// db-theory #1c — Sqlite schema introspection + bulk I/O + error
+// inspection codegen smoke.
+//
+// Six smoke functions exercise:
+//   - db_schema_tables       (list created tables, JSON array)
+//   - db_schema_columns      (list columns of a table, JSON array)
+//   - db_table_exists        (boolean reflection)
+//   - db_import_csv          (mocked path import, returns row count)
+//   - db_export_csv          (mocked path export, returns row count)
+//   - db_last_error          (string error sentinel after a forced fault)
+
+use Sqlite::{db_open, db_close, db_execute, db_schema_tables, db_schema_columns, db_table_exists, db_import_csv, db_export_csv, db_last_error};
+
+pub fn smoke_schema_tables(path: String) -> String {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE users(id INTEGER, name TEXT)");
+  let _id2 = db_execute(d, "CREATE TABLE posts(id INTEGER, body TEXT)");
+  let json = db_schema_tables(d);
+  let _id3 = db_close(d);
+  json
+}
+
+pub fn smoke_schema_columns(path: String) -> String {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(id INTEGER, name TEXT, age INTEGER)");
+  let json = db_schema_columns(d, "t");
+  let _id2 = db_close(d);
+  json
+}
+
+pub fn smoke_table_exists_true(path: String) -> Bool {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE present(id INTEGER)");
+  let yes = db_table_exists(d, "present");
+  let _id2 = db_close(d);
+  yes
+}
+
+pub fn smoke_table_exists_false(path: String) -> Bool {
+  let d = db_open(path);
+  let no = db_table_exists(d, "absent");
+  let _id1 = db_close(d);
+  no
+}
+
+pub fn smoke_import_csv(path: String, table: String, csv_path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE rows(a INTEGER, b TEXT)");
+  let n = db_import_csv(d, table, csv_path, true);
+  let _id2 = db_close(d);
+  n
+}
+
+pub fn smoke_export_csv(path: String, sql: String, params_json: String, csv_path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE rows(a INTEGER, b TEXT)");
+  let _id2 = db_execute(d, "INSERT INTO rows VALUES (1, 'one'), (2, 'two'), (3, 'three')");
+  let n = db_export_csv(d, sql, params_json, csv_path);
+  let _id3 = db_close(d);
+  n
+}
+
+pub fn smoke_last_error_empty(path: String) -> String {
+  let d = db_open(path);
+  let e = db_last_error(d);
+  let _id1 = db_close(d);
+  e
+}
+
+pub fn smoke_last_error_set(path: String) -> String {
+  let d = db_open(path);
+  // Mock-side: an execute with the magic string `RAISE` records an
+  // error retrievable via db_last_error without throwing through to
+  // the AffineScript side (the smoke validates the read-back path).
+  let _id1 = db_execute(d, "RAISE 'simulated failure'");
+  let e = db_last_error(d);
+  let _id2 = db_close(d);
+  e
+}

--- a/tests/codegen-deno/sqlite_introspect_bulk.harness.mjs
+++ b/tests/codegen-deno/sqlite_introspect_bulk.harness.mjs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MPL-2.0
+// db-theory #1c — Node ESM harness for the Sqlite schema-introspection +
+// bulk-I/O + error-inspection codegen smoke.
+//
+// Extends the #1a/#1b mock adapter with `schemaTables`, `schemaColumns`,
+// `tableExists`, `importCsv`, `exportCsv`, `lastError`. The csv methods
+// here use a virtual filesystem map keyed by path so the smoke runs
+// hermetically (no real disk I/O); production adapters back the same
+// methods with `Deno.readTextFileSync` / `fs.writeFileSync`.
+
+import assert from "node:assert/strict";
+
+let nextDbHandle = 1;
+const dbs = new Map();
+const vfs = new Map();   // path -> string contents
+const errors = new Map(); // db handle -> last error message
+
+const parseRowLiteral = (s) => {
+  const out = [];
+  let buf = "";
+  let inStr = false;
+  for (const ch of s) {
+    if (ch === "'") { inStr = !inStr; buf += ch; }
+    else if (ch === "," && !inStr) { out.push(buf.trim()); buf = ""; }
+    else buf += ch;
+  }
+  if (buf.trim()) out.push(buf.trim());
+  return out.map((t) => (
+    t.startsWith("'") && t.endsWith("'") ? t.slice(1, -1) :
+    /^-?\d+$/.test(t) ? Number(t) :
+    t
+  ));
+};
+
+globalThis.__as_sqlite = {
+  open(path) {
+    const h = nextDbHandle++;
+    dbs.set(h, { path, tables: new Map(), schema: new Map() });
+    errors.set(h, "");
+    return h;
+  },
+  close(h) { dbs.delete(h); errors.delete(h); },
+
+  execute(h, sql) {
+    const db = dbs.get(h);
+    if (!db) throw new Error("invalid db handle " + h);
+
+    // Fault-injection convention for the smoke: a literal SQL string
+    // starting with `RAISE` records a last-error and returns without
+    // throwing, so the smoke can validate the read-back path.
+    if (/^\s*RAISE\s+'(.+)'\s*$/i.test(sql)) {
+      const m = sql.match(/^\s*RAISE\s+'(.+)'\s*$/i);
+      errors.set(h, m[1]);
+      return;
+    }
+
+    const create = sql.match(/CREATE TABLE (\w+)\s*\(([^)]+)\)/i);
+    if (create) {
+      const cols = create[2].split(",").map((c) => {
+        const parts = c.trim().split(/\s+/);
+        return { name: parts[0], type: parts[1] || "" };
+      });
+      db.tables.set(create[1], []);
+      db.schema.set(create[1], cols);
+      errors.set(h, "");
+      return;
+    }
+
+    const insert = sql.match(/INSERT INTO (\w+)\s+VALUES\s+(.+)/i);
+    if (insert) {
+      const tableName = insert[1];
+      const valuesPart = insert[2].replace(/;$/, "").trim();
+      const tupleRe = /\(([^)]+)\)/g;
+      let m;
+      while ((m = tupleRe.exec(valuesPart))) {
+        const cols = parseRowLiteral(m[1]);
+        const tbl = db.tables.get(tableName);
+        if (!tbl) { errors.set(h, "no such table " + tableName); throw new Error(errors.get(h)); }
+        tbl.push(cols);
+      }
+      errors.set(h, "");
+    }
+  },
+
+  // ── Schema introspection ──────────────────────────────────────────
+
+  schemaTables(h) {
+    const db = dbs.get(h);
+    if (!db) return "[]";
+    const names = [...db.tables.keys()].filter((n) => !n.startsWith("sqlite_"));
+    return JSON.stringify(names);
+  },
+
+  schemaColumns(h, table) {
+    const db = dbs.get(h);
+    if (!db) return "[]";
+    const cols = db.schema.get(table);
+    if (!cols) return "[]";
+    return JSON.stringify(cols.map((c, i) => ({
+      name: c.name,
+      type: c.type,
+      notnull: false,
+      pk: i === 0 && /id/i.test(c.name),
+    })));
+  },
+
+  tableExists(h, table) {
+    const db = dbs.get(h);
+    if (!db) return false;
+    return db.tables.has(table) && !table.startsWith("sqlite_");
+  },
+
+  // ── Bulk I/O ──────────────────────────────────────────────────────
+
+  importCsv(h, table, csvPath, hasHeader) {
+    const db = dbs.get(h);
+    if (!db) { errors.set(h, "invalid handle"); return 0; }
+    const text = vfs.get(csvPath);
+    if (text == null) { errors.set(h, "no such csv " + csvPath); return 0; }
+    const tbl = db.tables.get(table);
+    if (!tbl) { errors.set(h, "no such table " + table); return 0; }
+    const cols = db.schema.get(table) || [];
+    const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+    const data = hasHeader ? lines.slice(1) : lines;
+    let inserted = 0;
+    for (const line of data) {
+      const fields = line.split(",").map((f) => {
+        const t = f.trim();
+        return /^-?\d+$/.test(t) ? Number(t) : t;
+      });
+      // Pad/truncate to schema width.
+      while (fields.length < cols.length) fields.push(null);
+      tbl.push(fields.slice(0, cols.length));
+      inserted++;
+    }
+    errors.set(h, "");
+    return inserted;
+  },
+
+  exportCsv(h, sql, params, csvPath) {
+    const db = dbs.get(h);
+    if (!db) { errors.set(h, "invalid handle"); return 0; }
+    const tblMatch = sql.match(/FROM\s+(\w+)/i);
+    if (!tblMatch) { errors.set(h, "no FROM in sql"); return 0; }
+    const table = tblMatch[1];
+    const rows = db.tables.get(table) || [];
+    const schema = db.schema.get(table) || [];
+    const header = schema.map((c) => c.name).join(",");
+    const body = rows.map((r) => r.map((v) => v == null ? "" : String(v)).join(",")).join("\n");
+    vfs.set(csvPath, header + "\n" + body + "\n");
+    errors.set(h, "");
+    return rows.length;
+  },
+
+  lastError(h) { return errors.get(h) ?? ""; },
+
+  // Convenience surface methods present from the #1a/#1b mock — not
+  // exercised in this smoke but kept for future stack-on harnesses.
+  query() { return []; },
+  queryOne() { return null; },
+  queryInt() { return 0; },
+  prepare() { throw new Error("prepare not used in this smoke"); },
+  bindInt() {}, bindText() {}, bindNull() {},
+  step() { return false; },
+  columnCount() { return 0; },
+  columnInt() { return 0; },
+  columnText() { return ""; },
+  reset() {}, finalize() {},
+};
+
+const mod = await import("./sqlite_introspect_bulk.deno.js");
+
+// ── schema_tables ────────────────────────────────────────────────────
+const tablesJson = mod.smoke_schema_tables(":memory:");
+const tables = JSON.parse(tablesJson);
+assert.deepEqual(
+  tables.sort(),
+  ["posts", "users"],
+  "smoke_schema_tables: returns the two created tables (sqlite_* excluded)",
+);
+
+// ── schema_columns ──────────────────────────────────────────────────
+const colsJson = mod.smoke_schema_columns(":memory:");
+const cols = JSON.parse(colsJson);
+assert.equal(cols.length, 3, "smoke_schema_columns: 3 columns parsed");
+assert.equal(cols[0].name, "id", "first column is id");
+assert.equal(cols[0].pk, true, "id column flagged as PK");
+assert.equal(cols[1].name, "name", "second column is name");
+assert.equal(cols[2].name, "age", "third column is age");
+
+// ── table_exists ────────────────────────────────────────────────────
+assert.equal(mod.smoke_table_exists_true(":memory:"), true, "present table: exists=true");
+assert.equal(mod.smoke_table_exists_false(":memory:"), false, "absent table: exists=false");
+
+// ── import_csv ──────────────────────────────────────────────────────
+vfs.set("/tmp/in.csv", "a,b\n1,alpha\n2,beta\n3,gamma\n");
+const inserted = mod.smoke_import_csv(":memory:", "rows", "/tmp/in.csv");
+assert.equal(inserted, 3, "smoke_import_csv: 3 data rows imported (header skipped)");
+
+// ── export_csv ──────────────────────────────────────────────────────
+const exported = mod.smoke_export_csv(":memory:", "SELECT a, b FROM rows", "[]", "/tmp/out.csv");
+assert.equal(exported, 3, "smoke_export_csv: 3 rows exported");
+const out = vfs.get("/tmp/out.csv");
+assert.ok(out.startsWith("a,b\n"), "exported CSV starts with column header");
+assert.ok(out.includes("1,one"), "exported CSV contains first row");
+assert.ok(out.includes("3,three"), "exported CSV contains third row");
+
+// ── last_error ──────────────────────────────────────────────────────
+assert.equal(mod.smoke_last_error_empty(":memory:"), "", "smoke_last_error_empty: returns ''");
+assert.equal(
+  mod.smoke_last_error_set(":memory:"),
+  "simulated failure",
+  "smoke_last_error_set: fault-injected message round-trips",
+);
+
+console.log("sqlite_introspect_bulk OK");


### PR DESCRIPTION
## Summary

Closes out the SQLite stdlib triad (#522 foundation + #524 prepared statements + this PR). Adds the three remaining practical surfaces:

| layer | externs |
|---|---|
| **Schema introspection** | `db_schema_tables(d)`, `db_schema_columns(d, table)`, `db_table_exists(d, table)` |
| **Bulk CSV I/O** | `db_import_csv(d, table, path, has_header)`, `db_export_csv(d, sql, params, path)` |
| **Error inspection** | `db_last_error(d)` (typed `DbError` carrier lands in #1d) |

## Codegen + adapter

6 `b "name"` registrations + 6 `__as_db*` JS helpers, each delegating to one new method on `globalThis.__as_sqlite` (`schemaTables`, `schemaColumns`, `tableExists`, `importCsv`, `exportCsv`, `lastError`). Real adapters back these with one-line wrappers (PRAGMA table_info, prepare().iterate(), fs writes).

## Smoke harness (`tests/codegen-deno/sqlite_introspect_bulk.{affine,harness.mjs}`)

8 smoke functions × 9 assertions — schema_tables ordering, column descriptor shape (incl. PK flag), table_exists true/false, CSV import skipping header, CSV export including header, last_error empty/fault-injected. Mock extends the #1a/#1b adapter with the 6 new methods plus a virtual filesystem map for hermetic CSV testing.

## Verification

- `dune build`: clean
- `dune runtest`: **363 / 363** green
- `tools/run_codegen_deno_tests.sh`: **33 / 33** harnesses pass (was 32)

## Stacked on #524

#524 (db-theory #1b — prepared statements) **MERGED 13:15Z**. This branch forks from its head and rebases cleanly.

## db-theory #1d (next PR, separate)

- `extern type DbError` opaque carrier
- `Result<T, DbError>`-shaped variants of the convenience surface
- Design-blocked on the wider error-model question (do we add `Result` returns to all extern fns or keep the JSON-string sentinel pattern?)

## Test plan

- [x] dune build clean
- [x] dune runtest 363/363 green
- [x] 33/33 codegen-deno harnesses pass
- [x] 9 introspection/bulk/error smoke assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)