### PR TITLE
feat(stdlib): Transaction.affine — affine-bounded write-set isolation — db-theory #2 (8 externs)

### DIFF
--- a/docs/academic/proofs/db-theory-2-transaction-safety.md
+++ b/docs/academic/proofs/db-theory-2-transaction-safety.md
@@ -68,7 +68,7 @@ The Security-record instance lives in a sibling `TransactionSecurity.agda`, para
 
 - AffineScript stdlib: `stdlib/Transaction.affine` carries the safety obligation statement in its module-level docstring and references this file by name.
 - AffineScript codegen + smoke: `lib/codegen_deno.ml` and `tests/codegen-deno/transaction_smoke.{affine,harness.mjs}` *witness* the property at the Node runtime level by snapshotting tables on `txBegin` and restoring on `txRollback`. The witness is not a proof — it's an executable check that the runtime mock observes the same invariant the formal proof will eventually establish.
-- Echo-types upstream: tracked at `hyperpolymath/echo-types` (issue to be filed alongside this document landing; link added once the issue number is allocated).
+- Echo-types upstream: tracked at [`hyperpolymath/echo-types#174`](https://github.com/hyperpolymath/echo-types/issues/174) — proposes the new `TransactionMutations.agda` module shape (and sibling `TransactionSecurity.agda` providing the `Security` instance) reducing to the existing `EchoNoSectionGeneric.no-section-of-collapsing-map`. Acceptance criteria include zero new axioms (`Print Assumptions` clean) and a back-link from the upstream commit SHA into this document.
 
 ## 5. Why this matters
 

--- a/docs/academic/proofs/db-theory-2-transaction-safety.md
+++ b/docs/academic/proofs/db-theory-2-transaction-safety.md
@@ -1,0 +1,75 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk> -->
+
+# DB-Theory #2 — Transaction Safety (Rollback-Discards-Writes)
+
+**Status**: Carrier wired (`stdlib/Transaction.affine`, codegen, Deno-ESM smoke); formal proof obligation **pending upstream against `hyperpolymath/echo-types`**.
+
+## 1. The obligation
+
+Let `Tx` be the opaque affine handle returned by `tx_begin(d: Db)` in `stdlib/Transaction.affine`. Let `t : Tx` be such a handle, and let `σ₀` be the database state immediately before `tx_begin(d)`. Let `W` be the multiset of mutating SQL statements (`INSERT`, `UPDATE`, `DELETE`, schema mutations) executed against `d` (or any handle aliased through `tx_db(t)`) between `tx_begin(d)` and the consumption of `t`.
+
+**Safety property #DB-2.1 (rollback-discards-writes)**: if `t` is consumed by `tx_rollback(t)`, then for every query `q` issued against `d` *after* the rollback, the answer to `q` is precisely the answer it would have had over `σ₀` (i.e. as if `W` had never happened).
+
+**Safety property #DB-2.2 (commit-promotes-writes)**: if `t` is consumed by `tx_commit(t)`, then for every query `q` issued after the commit, the answer is the same as serially applying `W` to `σ₀`.
+
+**Safety property #DB-2.3 (savepoint locality)**: if a savepoint `s` is opened with `tx_savepoint(t, s)`, mutations `W_s` are issued, and then `tx_rollback_to(t, s)` is called, the database state mid-transaction reverts to the state at `tx_savepoint(t, s)` while leaving the outer transaction live.
+
+## 2. Echo-types audit (2026-06-01)
+
+Per owner directive, every proof in AffineScript must first audit `hyperpolymath/echo-types`, reuse if applicable, extend upstream **with proofs** if not, then cross-document.
+
+**Audit finding** (full report under `tasklist/sub-agent reports/2026-06-01-transaction-echo-audit`): echo-types has no Transaction-specific instantiation today, but carries three reusable abstractions:
+
+1. `EchoLinear.LEcho` + the `weaken : LEcho linear → LEcho affine` collapse map, with `no-section-weaken` proving no recovery after weakening.
+2. `EchoSecurity.Security` record + `exit-collapses-at` / `audit-no-recovery-at` — the boundary-collapse template structurally mirrors rollback-discards-writes.
+3. `EchoNoSectionGeneric.no-section-of-collapsing-map` — the generic lemma the Transaction proof reduces to.
+
+## 3. Proposed upstream extension
+
+A new module `TransactionMutations.agda` in echo-types, structured as follows:
+
+```agda
+module TransactionMutations where
+
+-- The write-set carrier: an opaque set of mutations parametrised by
+-- the table-type T being mutated.
+record WriteSet (T : Set) : Set where
+  field
+    applied : List Mutation     -- audit trail
+    -- Algebra: `empty`, `append`, `compose` give a monoid action on
+    -- DbState — the action and its laws are deferred to a separate
+    -- module to keep this carrier import-light.
+
+-- The rollback log is the witness that a WriteSet was discarded.
+record RollbackLog {T : Set} (ws : WriteSet T) : Set where
+  field
+    discarded-at : Timestamp
+    -- The trivial receipt: rollback emits no recoverable signal.
+    receipt : Trivial
+
+-- The collapse map that powers the safety proof: every WriteSet
+-- rolls back to the trivial receipt, and the generic
+-- no-section-of-collapsing-map (already in echo-types) gives the
+-- no-recovery lemma free.
+rollback-collapses-at :
+  {T : Set} (ws : WriteSet T) → RollbackLog ws → Trivial
+rollback-collapses-at _ _ = trivial
+
+rollback-discards-writes :
+  {T : Set} (ws : WriteSet T) →
+  EchoNoSectionGeneric.no-section-of (rollback-collapses-at ws)
+rollback-discards-writes ws = no-section-of-collapsing-map _
+```
+
+The Security-record instance lives in a sibling `TransactionSecurity.agda`, parametrising `EchoSecurity.Security` by `(Resource := WriteSet T)`, `(Receipt := RollbackLog ws)`, `(exit := rollback-collapses-at ws)`.
+
+## 4. Cross-doc seam
+
+- AffineScript stdlib: `stdlib/Transaction.affine` carries the safety obligation statement in its module-level docstring and references this file by name.
+- AffineScript codegen + smoke: `lib/codegen_deno.ml` and `tests/codegen-deno/transaction_smoke.{affine,harness.mjs}` *witness* the property at the Node runtime level by snapshotting tables on `txBegin` and restoring on `txRollback`. The witness is not a proof — it's an executable check that the runtime mock observes the same invariant the formal proof will eventually establish.
+- Echo-types upstream: tracked at `hyperpolymath/echo-types` (issue to be filed alongside this document landing; link added once the issue number is allocated).
+
+## 5. Why this matters
+
+Transactions are the canonical user-facing application of affine resource discipline to data: the type system already enforces "at most one consumption" of `Tx`, and the safety theorem closes the loop by saying that the *one* consumption that discards (rollback) is observationally equivalent to never having started. This is the proof every database textbook assumes — having it mechanised against an echo-types carrier means AffineScript's transaction surface inherits the same "no recovery from boundary collapse" story echo-types already proves for region-exit auditing.

--- a/docs/academic/proofs/db-theory-3-aggregation-as-fold.md
+++ b/docs/academic/proofs/db-theory-3-aggregation-as-fold.md
@@ -1,0 +1,85 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk> -->
+
+# DB-Theory #3 — Aggregation-as-Monoid-Homomorphism
+
+**Status**: Carrier wired (`stdlib/Aggregate.affine`, codegen, Deno-ESM smoke); formal proof obligation **pending upstream against [`hyperpolymath/echo-types#175`](https://github.com/hyperpolymath/echo-types/issues/175)**.
+
+## 1. The obligation
+
+For each scalar aggregator `M = (Elem, ε, ⊕)` and any partition `{group_k}` of the row set by key `k`:
+
+**Safety property #DB-3.1 (aggregation-as-fold)**:
+```
+aggregate(SELECT M(v) FROM t GROUP BY k)
+  ≡  { k ↦ foldr ⊕ ε (map agg group_k) }
+```
+
+The aggregators are commutative monoids:
+
+| Aggregator | `Elem`              | `ε` | `⊕`   | Commutative? | Idempotent? |
+|------------|---------------------|-----|-------|--------------|-------------|
+| COUNT      | `ℕ`                 | `0` | `+`   | ✓            | ✗           |
+| SUM        | `ℕ` (or `ℤ`, `ℝ`)   | `0` | `+`   | ✓            | ✗           |
+| MIN        | `ℕ ∪ {∞}`           | `∞` | `min` | ✓            | ✓           |
+| MAX        | `ℕ ∪ {-∞}`          | `-∞`| `max` | ✓            | ✓           |
+| AVG        | **not a monoid** (no identity) — derived as `SUM/COUNT` |
+
+## 2. Echo-types audit (2026-06-01)
+
+Per owner directive, every proof must first audit `hyperpolymath/echo-types`.
+
+**Finding**: no existing monoid / semiring / aggregation infrastructure today. Closest scaffolding:
+
+1. `EchoCost.CostAlgebra` — left-identity + monotonicity, but no composition law. Reusable as a `Monoid` *instance* once the carrier exists.
+2. `Ordinal/Brouwer/OmegaPow.agda#additive-principal` — exactly the monoid closure property for ω^n exponents.
+3. `EchoDecorationStructure.agda` — observer-level lattice; aggregation lives at the data level.
+4. `docs/adjacency/provenance-semirings.adoc` — explicitly names the distinctness story (echo adds types; semirings add scalars).
+
+**Steer**: minor extension — one new module. Tracked at echo-types#175.
+
+## 3. Proposed upstream extension
+
+A new module `EchoAggregation.agda`:
+
+```agda
+record Monoid (ℓ : Level) : Set (suc ℓ) where
+  field
+    Elem       : Set ℓ
+    ε          : Elem
+    _⊕_        : Elem → Elem → Elem
+    assoc      : ∀ a b c → (a ⊕ b) ⊕ c ≡ a ⊕ (b ⊕ c)
+    identity-l : ∀ a → ε ⊕ a ≡ a
+    identity-r : ∀ a → a ⊕ ε ≡ a
+
+record GroupAggregator {ℓ} (K V : Set) (M : Monoid ℓ) : Set ℓ where
+  open Monoid M
+  field
+    agg : V → Elem
+
+-- Headline lemma (signature — proof may follow in stacked PR):
+aggregation-as-fold :
+  ∀ {ℓ} {K V : Set} {M : Monoid ℓ} (ga : GroupAggregator K V M)
+  → (rows : List (K × V))
+  → (k : K)
+  → group-of k (groupBy proj₁ rows)
+    ≡ foldr (_⊕_ ∘ agg) ε (lookup k (partition rows))
+```
+
+Plus concrete instances `countMonoid : Monoid ℓ-zero`, `sumMonoid`, `minMonoid`, `maxMonoid`.
+
+## 4. Cross-doc seam
+
+- **AffineScript stdlib**: `stdlib/Aggregate.affine` carries the obligation in its module docstring with the aggregator monoid table.
+- **AffineScript codegen + smoke**: `lib/codegen_deno.ml` + `tests/codegen-deno/aggregate_smoke.{affine,harness.mjs}` *witness* the property at the Node runtime level — the mock implements `groupBy` by bucketing rows by key column then folding the aggregator over each bucket. The witness is not a proof; it's an executable check that the runtime mock observes the same invariant the formal proof will eventually establish.
+- **Echo-types upstream**: tracked at [`hyperpolymath/echo-types#175`](https://github.com/hyperpolymath/echo-types/issues/175). Once landed, back-link the commit SHA / module path here.
+
+## 5. Why this matters
+
+Aggregation is the most-used non-trivial query shape outside selection/projection. Wiring aggregators as typed commutative monoids (rather than ad-hoc per-shape SQL strings) gives:
+
+- **Distributivity proofs free**: aggregation distributes over filtering (db-theory #4) and indexed scans (db-theory #6) via monoid homomorphism.
+- **CRDT bridge for free**: `OR-Set` and `GCounter` (db-theory #9) are precisely *monoids with convergence* — the same carrier extends.
+- **Provenance-semiring bridge**: the Green/Karvounarakis/Tannen framing instantiates here once `EchoAggregation` lands.
+
+Sibling: [echo-types#174](https://github.com/hyperpolymath/echo-types/issues/174) (Transaction safety / `no-section-of-collapsing-map`).

--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -574,6 +574,17 @@ const __as_txRelease     = (t, n) => { globalThis.__as_sqlite.txRelease(t, n); r
 const __as_txRollbackTo  = (t, n) => { globalThis.__as_sqlite.txRollbackTo(t, n); return 0; };
 const __as_txDb          = (t) => globalThis.__as_sqlite.txDb(t);
 const __as_txIsLive      = (t) => (globalThis.__as_sqlite.txIsLive(t) ? 1 : 0);
+// ---- Sqlite aggregation (db-theory #3 / stdlib/Aggregate.affine) ----
+// Each scalar aggregator delegates to a host adapter method that runs
+// the SQL, expects a single-row result, and unwraps column 0. `groupBy`
+// / `groupCount` return JSON strings (caller parses).
+const __as_dbCount       = (h, sql, params) => Number(globalThis.__as_sqlite.aggCount(h, sql, params)) | 0;
+const __as_dbSum         = (h, sql, params) => Number(globalThis.__as_sqlite.aggSum(h, sql, params)) | 0;
+const __as_dbMinInt      = (h, sql, params) => Number(globalThis.__as_sqlite.aggMinInt(h, sql, params)) | 0;
+const __as_dbMaxInt      = (h, sql, params) => Number(globalThis.__as_sqlite.aggMaxInt(h, sql, params)) | 0;
+const __as_dbAvg         = (h, sql, params) => Number(globalThis.__as_sqlite.aggAvg(h, sql, params));
+const __as_dbGroupBy     = (h, sql, params) => String(globalThis.__as_sqlite.groupBy(h, sql, params));
+const __as_dbGroupCount  = (h, table, keyCol) => String(globalThis.__as_sqlite.groupCount(h, table, keyCol));
 const __as_httpFetch = async (url, method, headers, bodyOpt) => {
   const init = { method, headers: __as_httpHeadersToObject(headers) };
   if (bodyOpt && bodyOpt.tag === "Some") init.body = bodyOpt.value;
@@ -889,7 +900,15 @@ let () =
   b "tx_release"      (fun a -> Printf.sprintf "__as_txRelease(%s, %s)" (arg 0 a) (arg 1 a));
   b "tx_rollback_to"  (fun a -> Printf.sprintf "__as_txRollbackTo(%s, %s)" (arg 0 a) (arg 1 a));
   b "tx_db"           (fun a -> Printf.sprintf "__as_txDb(%s)" (arg 0 a));
-  b "tx_is_live"      (fun a -> Printf.sprintf "__as_txIsLive(%s)" (arg 0 a))
+  b "tx_is_live"      (fun a -> Printf.sprintf "__as_txIsLive(%s)" (arg 0 a));
+  (* ---- Sqlite aggregation (db-theory #3 / stdlib/Aggregate.affine) ---- *)
+  b "db_count"        (fun a -> Printf.sprintf "__as_dbCount(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  b "db_sum"          (fun a -> Printf.sprintf "__as_dbSum(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  b "db_min_int"      (fun a -> Printf.sprintf "__as_dbMinInt(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  b "db_max_int"      (fun a -> Printf.sprintf "__as_dbMaxInt(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  b "db_avg"          (fun a -> Printf.sprintf "__as_dbAvg(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  b "db_group_by"     (fun a -> Printf.sprintf "__as_dbGroupBy(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a));
+  b "db_group_count"  (fun a -> Printf.sprintf "__as_dbGroupCount(%s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a))
 
 (* ============================================================================
    Identifier sanitisation (JS reserved words -> trailing underscore)

--- a/lib/codegen_deno.ml
+++ b/lib/codegen_deno.ml
@@ -560,6 +560,20 @@ const __as_dbLastError     = (h) => {
   const v = globalThis.__as_sqlite.lastError(h);
   return v == null ? "" : String(v);
 };
+// ---- Sqlite transactions (db-theory #2) ----
+// `Tx` is an opaque handle; the host adapter is required to
+// invalidate it on `commit` / `rollback` so that subsequent calls
+// throw a host-side `Error` (the affine type system's
+// at-most-one-use guarantee is enforced statically on the AS side;
+// this host invariant catches FFI-side aliasing bugs in tests).
+const __as_txBegin       = (h) => globalThis.__as_sqlite.txBegin(h);
+const __as_txCommit      = (t) => { globalThis.__as_sqlite.txCommit(t); return 0; };
+const __as_txRollback    = (t) => { globalThis.__as_sqlite.txRollback(t); return 0; };
+const __as_txSavepoint   = (t, n) => { globalThis.__as_sqlite.txSavepoint(t, n); return 0; };
+const __as_txRelease     = (t, n) => { globalThis.__as_sqlite.txRelease(t, n); return 0; };
+const __as_txRollbackTo  = (t, n) => { globalThis.__as_sqlite.txRollbackTo(t, n); return 0; };
+const __as_txDb          = (t) => globalThis.__as_sqlite.txDb(t);
+const __as_txIsLive      = (t) => (globalThis.__as_sqlite.txIsLive(t) ? 1 : 0);
 const __as_httpFetch = async (url, method, headers, bodyOpt) => {
   const init = { method, headers: __as_httpHeadersToObject(headers) };
   if (bodyOpt && bodyOpt.tag === "Some") init.body = bodyOpt.value;
@@ -866,7 +880,16 @@ let () =
   b "db_table_exists"   (fun a -> Printf.sprintf "__as_dbTableExists(%s, %s)" (arg 0 a) (arg 1 a));
   b "db_import_csv"     (fun a -> Printf.sprintf "__as_dbImportCsv(%s, %s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a) (arg 3 a));
   b "db_export_csv"     (fun a -> Printf.sprintf "__as_dbExportCsv(%s, %s, %s, %s)" (arg 0 a) (arg 1 a) (arg 2 a) (arg 3 a));
-  b "db_last_error"     (fun a -> Printf.sprintf "__as_dbLastError(%s)" (arg 0 a))
+  b "db_last_error"     (fun a -> Printf.sprintf "__as_dbLastError(%s)" (arg 0 a));
+  (* ---- Sqlite transactions (db-theory #2 / stdlib/Transaction.affine) ---- *)
+  b "tx_begin"        (fun a -> Printf.sprintf "__as_txBegin(%s)" (arg 0 a));
+  b "tx_commit"       (fun a -> Printf.sprintf "__as_txCommit(%s)" (arg 0 a));
+  b "tx_rollback"     (fun a -> Printf.sprintf "__as_txRollback(%s)" (arg 0 a));
+  b "tx_savepoint"    (fun a -> Printf.sprintf "__as_txSavepoint(%s, %s)" (arg 0 a) (arg 1 a));
+  b "tx_release"      (fun a -> Printf.sprintf "__as_txRelease(%s, %s)" (arg 0 a) (arg 1 a));
+  b "tx_rollback_to"  (fun a -> Printf.sprintf "__as_txRollbackTo(%s, %s)" (arg 0 a) (arg 1 a));
+  b "tx_db"           (fun a -> Printf.sprintf "__as_txDb(%s)" (arg 0 a));
+  b "tx_is_live"      (fun a -> Printf.sprintf "__as_txIsLive(%s)" (arg 0 a))
 
 (* ============================================================================
    Identifier sanitisation (JS reserved words -> trailing underscore)

--- a/stdlib/Aggregate.affine
+++ b/stdlib/Aggregate.affine
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Aggregate.affine — SQL group-by + aggregation primitives (db-theory #3).
+//
+// Aggregation is a thin convenience layer over the existing Sqlite
+// extern surface. The runtime contract is: each aggregator extern
+// runs a SQL query that returns *exactly one row* with the aggregate
+// in column 0, and that result is unwrapped to a typed scalar
+// (`Int` / `Float`). The `db_group_by` extern returns the whole
+// grouped result-set as a JSON array — caller parses with `Json::parse`.
+//
+// **Proof obligation #DB-3.1 (aggregation-as-monoid-homomorphism)**
+//   Each scalar aggregator is a commutative monoid; group-by is the
+//   indexed sum. Formally, for any aggregator `M` (with identity `ε`
+//   and combine `⊕`) and any partition `{group_k}` of the row set:
+//     aggregate(SELECT M(v) FROM t GROUP BY k)
+//       = { k ↦ foldr ⊕ ε (map M.agg group_k) }
+//
+//   Concretely: COUNT is `(ℕ, 0, +)`, SUM is `(ℕ, 0, +)`, MIN is
+//   `(ℕ ∪ {∞}, ∞, min)`, MAX is `(ℕ ∪ {-∞}, -∞, max)`. AVG is *not*
+//   a monoid (no identity) — express as `SUM/COUNT`.
+//
+//   Status: pending against `hyperpolymath/echo-types#175` — proposes
+//   a new `EchoAggregation.agda` module with `Monoid` + `GroupAggregator`
+//   carriers reducing to the standard provenance-semiring framing
+//   (Green / Karvounarakis / Tannen). Cross-doc:
+//   `docs/academic/proofs/db-theory-3-aggregation-as-fold.md`.
+//
+// **Why this is the natural db-theory #3**
+//   Aggregation is the most-used non-trivial query shape outside
+//   selection/projection — every SQL report depends on it. Wiring
+//   aggregation through typed monoids (rather than ad-hoc strings)
+//   gives us the foundation for later db-theory items: #4 (selection
+//   distributivity over agg), #6 (agg over indexed scans), #9 (CRDTs
+//   as monoids with convergence).
+
+module Aggregate;
+
+// ── Scalar aggregators (single-row result) ─────────────────────────
+//
+// Each extern runs a SQL returning exactly one row with the aggregate
+// in column 0. `params_json` follows the same JSON-array contract as
+// the `db_query*` family. Empty result-sets degenerate to the
+// aggregator's identity (`0` for COUNT/SUM, runtime-defined for MIN/MAX).
+
+/// COUNT — returns the cardinality of the result-set. SQL form:
+/// `SELECT COUNT(*) FROM t WHERE ...` or `SELECT COUNT(col) FROM t ...`.
+/// Identity: 0. Monoid: `(ℕ, 0, +)`.
+pub extern fn db_count(d: Db, sql: String, params_json: String) -> Int;
+
+/// SUM — returns the sum of an integer-valued expression. SQL form:
+/// `SELECT SUM(col) FROM t WHERE ...`. Identity: 0. Monoid: `(ℕ, 0, +)`.
+pub extern fn db_sum(d: Db, sql: String, params_json: String) -> Int;
+
+/// MIN — returns the minimum integer value. SQL form:
+/// `SELECT MIN(col) FROM t WHERE ...`. Identity: ∞ (runtime: sentinel).
+/// Monoid: `(ℕ ∪ {∞}, ∞, min)`.
+pub extern fn db_min_int(d: Db, sql: String, params_json: String) -> Int;
+
+/// MAX — returns the maximum integer value. SQL form:
+/// `SELECT MAX(col) FROM t WHERE ...`. Identity: -∞. Monoid:
+/// `(ℕ ∪ {-∞}, -∞, max)`.
+pub extern fn db_max_int(d: Db, sql: String, params_json: String) -> Int;
+
+/// AVG — returns the average as a Float. **NOT a monoid** (no identity);
+/// implemented as `SUM/COUNT`. The host adapter rounds following IEEE 754.
+pub extern fn db_avg(d: Db, sql: String, params_json: String) -> Float;
+
+// ── Multi-row aggregation (GROUP BY) ───────────────────────────────
+//
+// `db_group_by` runs a SQL with a GROUP BY clause and returns the
+// entire result-set as a JSON array. Each element is itself a JSON
+// array of column values, in the order declared in the SELECT list.
+// Caller parses with `Json::parse` and pattern-matches the shape.
+//
+// Example:
+//   db_group_by(d, "SELECT dept, COUNT(*), SUM(salary) FROM e GROUP BY dept", "[]")
+//   -> '[["eng", 12, 1450000], ["sales", 5, 420000], ...]'
+//
+// The shape contract is *adapter-enforced*: a missing GROUP BY clause
+// still works (single-row result) but defeats the purpose. A future
+// typed `Group<K, V>` carrier would lift this to a parametric type;
+// blocked on the dependent-type story for parametric externs
+// (typed bindings #DB-3.2).
+
+pub extern fn db_group_by(d: Db, sql: String, params_json: String) -> String;
+
+// ── Group-bucket count (convenience over db_group_by) ──────────────
+//
+// `db_group_count` returns the count-per-group as a JSON array of
+// `[key, count]` pairs. Equivalent to:
+//   `db_group_by(d, "SELECT key, COUNT(*) FROM t GROUP BY key", ...)`
+// — but encapsulates the SELECT-list shape so callers don't need to
+// inline the COUNT(*) projection. The key column is referenced by
+// name (`key_col`), the table by name (`table`).
+
+pub extern fn db_group_count(d: Db, table: String, key_col: String) -> String;

--- a/stdlib/Transaction.affine
+++ b/stdlib/Transaction.affine
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Transaction.affine — affine-bounded transactional scope for the
+// Sqlite stdlib (db-theory #2).
+//
+// A `Tx` is an opaque, affine handle returned by `tx_begin(db)` and
+// consumed *exactly once* by either `tx_commit(t)` or `tx_rollback(t)`.
+// While a `Tx` is live, all `db_execute` / `db_prepare` calls against
+// the same `Db` participate in the open transaction; on `tx_commit`
+// they atomically become visible to subsequent reads, on `tx_rollback`
+// they leak no writes (the safety property — see proof obligation
+// below).
+//
+// Nested scopes use savepoints (`tx_savepoint(t, name)` / `tx_release`
+// / `tx_rollback_to`), which is the standard SQLite-flavoured nesting
+// model (savepoints are NOT separate `Tx` handles — they share the
+// outer affine lifetime).
+//
+// **Affine discipline (carrier-level)**
+//   Aliasing: `Tx` is `extern type`, opaque from the AffineScript side
+//   — there is no copy constructor and no way to clone it. The host
+//   adapter is required to invalidate the handle on commit / rollback
+//   so that a use-after-consume turns into a host-side `Error`.
+//   See `lib/codegen_deno.ml`'s `__as_txBegin` / `__as_txCommit` /
+//   `__as_txRollback` contract for the JS side of this invariant.
+//
+// **Safety property (proof obligation #DB-2.1)**
+//   `rollback-discards-writes` — for any `Tx t` returned by
+//   `tx_begin(d)` and any sequence of `db_execute(d, ...)` issued while
+//   `t` is live, if the lifetime ends with `tx_rollback(t)` then no
+//   row visible to a `db_query*(d, ...)` issued *after* the rollback
+//   reflects any of those executes.
+//
+//   Status: pending against `hyperpolymath/echo-types` (see
+//   `docs/proof-obligations/db-theory-2-transaction-safety.md`).
+//   The echo-types audit (2026-06-01) found `LEcho.weaken` +
+//   `EchoSecurity.Security` + `EchoNoSectionGeneric.no-section-of-
+//   collapsing-map` carry the right shape but require a
+//   `TransactionMutations.agda` instantiation upstream. Tracked at
+//   the echo-types issue linked from the cross-doc file.
+//
+// **Why this is the natural db-theory #2**
+//   Affine semantics maps directly to write-set isolation: an affine
+//   resource is consumed exactly once, and the consumption is *the*
+//   commit/abort decision. The same `(begin, commit, rollback)` shape
+//   covers RDBMS transactions, Haskell STM atomic blocks, Clojure refs,
+//   and Mnesia activities — picking SQLite as the first concrete
+//   backend is purely the most useful one to ship first.
+
+module Transaction;
+
+pub extern type Tx;
+
+// ── Top-level transaction lifecycle ────────────────────────────────
+//
+// `tx_begin` issues `BEGIN` on `d` and returns a fresh `Tx`. Exactly
+// one of `tx_commit` / `tx_rollback` must be called on the result;
+// the affine type system enforces "at most one", and host-side
+// invalidation enforces "use-after-consume is an error".
+
+pub extern fn tx_begin(d: Db) -> Tx;
+
+/// Issue `COMMIT`. Returns 0 on success. Invalidates `t` host-side.
+pub extern fn tx_commit(t: Tx) -> Int;
+
+/// Issue `ROLLBACK`. Returns 0 on success. Invalidates `t` host-side.
+/// **All writes issued during `t`'s lifetime are discarded** — this
+/// is the safety property formalised in proof obligation #DB-2.1.
+pub extern fn tx_rollback(t: Tx) -> Int;
+
+// ── Savepoints (nested scopes within a single Tx) ──────────────────
+//
+// Savepoints share the outer `Tx`'s affine lifetime. A savepoint is
+// named (string) and may be released (`tx_release`, forgets the
+// savepoint but keeps its writes within the outer scope) or rolled
+// back to (`tx_rollback_to`, discards writes issued since the
+// savepoint but keeps the outer `Tx` open). Both leave `t` valid.
+//
+// Naming convention is caller-controlled — SQLite uses string names,
+// and shadowing is per-name LIFO. Reusing a savepoint name is legal
+// but typically a programmer bug; the adapter does not guard it.
+
+pub extern fn tx_savepoint(t: Tx, name: String) -> Int;
+pub extern fn tx_release(t: Tx, name: String) -> Int;
+pub extern fn tx_rollback_to(t: Tx, name: String) -> Int;
+
+// ── Introspection ──────────────────────────────────────────────────
+//
+// `tx_db` returns the `Db` underlying `t` — useful for handing the
+// connection to a query function that takes `Db` (the type system
+// has no row-polymorphism over "Tx-or-Db", so this manual escape is
+// the pragmatic seam). The returned handle aliases the original
+// connection; calls against it participate in the open transaction.
+
+pub extern fn tx_db(t: Tx) -> Db;
+
+/// Returns 1 if `t` is still live (neither committed nor rolled back),
+/// 0 otherwise. Primarily for assertions and tests; production code
+/// should rely on the affine type system, not this runtime check.
+pub extern fn tx_is_live(t: Tx) -> Int;

--- a/stdlib/Transaction.affine
+++ b/stdlib/Transaction.affine
@@ -32,13 +32,13 @@
 //   row visible to a `db_query*(d, ...)` issued *after* the rollback
 //   reflects any of those executes.
 //
-//   Status: pending against `hyperpolymath/echo-types` (see
-//   `docs/proof-obligations/db-theory-2-transaction-safety.md`).
+//   Status: pending against `hyperpolymath/echo-types#174` (see
+//   `docs/academic/proofs/db-theory-2-transaction-safety.md`).
 //   The echo-types audit (2026-06-01) found `LEcho.weaken` +
 //   `EchoSecurity.Security` + `EchoNoSectionGeneric.no-section-of-
 //   collapsing-map` carry the right shape but require a
-//   `TransactionMutations.agda` instantiation upstream. Tracked at
-//   the echo-types issue linked from the cross-doc file.
+//   `TransactionMutations.agda` instantiation upstream — tracked at
+//   echo-types issue #174.
 //
 // **Why this is the natural db-theory #2**
 //   Affine semantics maps directly to write-set isolation: an affine

--- a/tests/codegen-deno/aggregate_smoke.affine
+++ b/tests/codegen-deno/aggregate_smoke.affine
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+// db-theory #3 — Aggregate codegen smoke.
+//
+// Seven smoke functions exercise the seven Aggregate.affine externs:
+//   - smoke_count          (COUNT(*) over inserted rows)
+//   - smoke_sum            (SUM(n) over inserted ints)
+//   - smoke_min_int        (MIN(n) over inserted ints)
+//   - smoke_max_int        (MAX(n) over inserted ints)
+//   - smoke_avg            (AVG(n) computed Float result)
+//   - smoke_group_by       (GROUP BY dept returning JSON array of buckets)
+//   - smoke_group_count    (db_group_count over (key, value) rows)
+
+use Sqlite::{db_open, db_close, db_execute};
+use Aggregate::{db_count, db_sum, db_min_int, db_max_int, db_avg, db_group_by, db_group_count};
+
+pub fn smoke_count(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (10), (20), (30), (40), (50)");
+  let c = db_count(d, "SELECT COUNT(*) FROM t", "[]");
+  let _id3 = db_close(d);
+  c
+}
+
+pub fn smoke_sum(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (1), (2), (3), (4), (5)");
+  let s = db_sum(d, "SELECT SUM(n) FROM t", "[]");
+  let _id3 = db_close(d);
+  s
+}
+
+pub fn smoke_min_int(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (7), (3), (9), (1), (5)");
+  let m = db_min_int(d, "SELECT MIN(n) FROM t", "[]");
+  let _id3 = db_close(d);
+  m
+}
+
+pub fn smoke_max_int(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (7), (3), (9), (1), (5)");
+  let m = db_max_int(d, "SELECT MAX(n) FROM t", "[]");
+  let _id3 = db_close(d);
+  m
+}
+
+pub fn smoke_avg(path: String) -> Float {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (10), (20), (30)");
+  let a = db_avg(d, "SELECT AVG(n) FROM t", "[]");
+  let _id3 = db_close(d);
+  a
+}
+
+pub fn smoke_group_by(path: String) -> String {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE e(dept TEXT, salary INTEGER)");
+  let _id2 = db_execute(d, "INSERT INTO e VALUES ('eng', 100), ('eng', 200), ('sales', 50), ('sales', 75)");
+  let j = db_group_by(d, "SELECT dept, COUNT(*), SUM(salary) FROM e GROUP BY dept", "[]");
+  let _id3 = db_close(d);
+  j
+}
+
+pub fn smoke_group_count(path: String) -> String {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(k TEXT, v INTEGER)");
+  let _id2 = db_execute(d, "INSERT INTO t VALUES ('a', 1), ('a', 2), ('b', 3), ('c', 4), ('a', 5), ('b', 6)");
+  let j = db_group_count(d, "t", "k");
+  let _id3 = db_close(d);
+  j
+}

--- a/tests/codegen-deno/aggregate_smoke.harness.mjs
+++ b/tests/codegen-deno/aggregate_smoke.harness.mjs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MPL-2.0
+// db-theory #3 — Node ESM harness for the Aggregate codegen smoke.
+//
+// Extends the #1a/#1b/#1c/#2 mock with aggregation surface:
+// aggCount / aggSum / aggMinInt / aggMaxInt / aggAvg / groupBy /
+// groupCount. The SQL parser handles a tiny subset sufficient for
+// the smoke (COUNT/SUM/MIN/MAX/AVG single-row + GROUP BY with
+// COUNT/SUM in the SELECT list).
+
+import assert from "node:assert/strict";
+
+let nextDbHandle = 1;
+const dbs = new Map();
+
+const parseRowLiteral = (s) => {
+  const out = [];
+  let buf = "";
+  let inStr = false;
+  for (const ch of s) {
+    if (ch === "'") { inStr = !inStr; buf += ch; }
+    else if (ch === "," && !inStr) { out.push(buf.trim()); buf = ""; }
+    else buf += ch;
+  }
+  if (buf.trim()) out.push(buf.trim());
+  return out.map((t) => (
+    t.startsWith("'") && t.endsWith("'") ? t.slice(1, -1) :
+    /^-?\d+$/.test(t) ? Number(t) :
+    t
+  ));
+};
+
+globalThis.__as_sqlite = {
+  open(path) {
+    const h = nextDbHandle++;
+    dbs.set(h, { path, tables: new Map(), schema: new Map() });
+    return h;
+  },
+  close(h) { dbs.delete(h); },
+
+  execute(h, sql) {
+    const db = dbs.get(h);
+    if (!db) throw new Error("invalid db handle " + h);
+    const create = sql.match(/CREATE TABLE (\w+)\s*\(([^)]+)\)/i);
+    if (create) {
+      const cols = create[2].split(",").map((c) => {
+        const parts = c.trim().split(/\s+/);
+        return { name: parts[0], type: parts[1] || "" };
+      });
+      db.tables.set(create[1], []);
+      db.schema.set(create[1], cols);
+      return;
+    }
+    const insert = sql.match(/INSERT INTO (\w+)\s+VALUES\s+(.+)/i);
+    if (insert) {
+      const tableName = insert[1];
+      const valuesPart = insert[2].replace(/;$/, "").trim();
+      const tupleRe = /\(([^)]+)\)/g;
+      let m;
+      while ((m = tupleRe.exec(valuesPart))) {
+        const cols = parseRowLiteral(m[1]);
+        const tbl = db.tables.get(tableName);
+        if (!tbl) throw new Error("no such table " + tableName);
+        tbl.push(cols);
+      }
+    }
+  },
+
+  // ── Aggregation (db-theory #3) ────────────────────────────────────
+
+  aggCount(h, sql /* , _params */) {
+    const db = dbs.get(h);
+    if (!db) return 0;
+    const m = sql.match(/FROM\s+(\w+)/i);
+    if (!m) return 0;
+    return (db.tables.get(m[1]) || []).length;
+  },
+
+  aggSum(h, sql) {
+    const db = dbs.get(h);
+    if (!db) return 0;
+    const fromM = sql.match(/FROM\s+(\w+)/i);
+    const colM  = sql.match(/SUM\(\s*(\w+)\s*\)/i);
+    if (!fromM || !colM) return 0;
+    const rows = db.tables.get(fromM[1]) || [];
+    const cols = db.schema.get(fromM[1]) || [];
+    const idx  = cols.findIndex((c) => c.name === colM[1]);
+    if (idx === -1) return 0;
+    return rows.reduce((acc, r) => acc + Number(r[idx]), 0);
+  },
+
+  aggMinInt(h, sql) {
+    const db = dbs.get(h);
+    if (!db) return 0;
+    const fromM = sql.match(/FROM\s+(\w+)/i);
+    const colM  = sql.match(/MIN\(\s*(\w+)\s*\)/i);
+    if (!fromM || !colM) return 0;
+    const rows = db.tables.get(fromM[1]) || [];
+    const cols = db.schema.get(fromM[1]) || [];
+    const idx  = cols.findIndex((c) => c.name === colM[1]);
+    if (idx === -1) return 0;
+    if (rows.length === 0) return 0;
+    return rows.reduce((acc, r) => Math.min(acc, Number(r[idx])), Number(rows[0][idx]));
+  },
+
+  aggMaxInt(h, sql) {
+    const db = dbs.get(h);
+    if (!db) return 0;
+    const fromM = sql.match(/FROM\s+(\w+)/i);
+    const colM  = sql.match(/MAX\(\s*(\w+)\s*\)/i);
+    if (!fromM || !colM) return 0;
+    const rows = db.tables.get(fromM[1]) || [];
+    const cols = db.schema.get(fromM[1]) || [];
+    const idx  = cols.findIndex((c) => c.name === colM[1]);
+    if (idx === -1) return 0;
+    if (rows.length === 0) return 0;
+    return rows.reduce((acc, r) => Math.max(acc, Number(r[idx])), Number(rows[0][idx]));
+  },
+
+  aggAvg(h, sql) {
+    const db = dbs.get(h);
+    if (!db) return 0;
+    const fromM = sql.match(/FROM\s+(\w+)/i);
+    const colM  = sql.match(/AVG\(\s*(\w+)\s*\)/i);
+    if (!fromM || !colM) return 0;
+    const rows = db.tables.get(fromM[1]) || [];
+    const cols = db.schema.get(fromM[1]) || [];
+    const idx  = cols.findIndex((c) => c.name === colM[1]);
+    if (idx === -1 || rows.length === 0) return 0;
+    const sum = rows.reduce((acc, r) => acc + Number(r[idx]), 0);
+    return sum / rows.length;
+  },
+
+  groupBy(h, sql /* , _params */) {
+    const db = dbs.get(h);
+    if (!db) return "[]";
+    const fromM = sql.match(/FROM\s+(\w+)/i);
+    const grpM  = sql.match(/GROUP\s+BY\s+(\w+)/i);
+    if (!fromM || !grpM) return "[]";
+    const rows = db.tables.get(fromM[1]) || [];
+    const cols = db.schema.get(fromM[1]) || [];
+    const keyIdx = cols.findIndex((c) => c.name === grpM[1]);
+    if (keyIdx === -1) return "[]";
+
+    // Bucket rows by key.
+    const buckets = new Map();
+    for (const r of rows) {
+      const k = r[keyIdx];
+      if (!buckets.has(k)) buckets.set(k, []);
+      buckets.get(k).push(r);
+    }
+
+    // SELECT list parse: pull the comma-separated expressions out of
+    // `SELECT ... FROM`. Each expr is either a column-name or an
+    // aggregate function call.
+    const selM = sql.match(/SELECT\s+(.+?)\s+FROM/i);
+    const selectExprs = selM[1].split(",").map((e) => e.trim());
+
+    const evalExpr = (expr, bucket) => {
+      // Aggregate? e.g. COUNT(*) | SUM(col)
+      const fn = expr.match(/^(COUNT|SUM|MIN|MAX|AVG)\(\s*([\w*]+)\s*\)$/i);
+      if (fn) {
+        const op = fn[1].toUpperCase();
+        if (op === "COUNT") return bucket.length;
+        const colName = fn[2];
+        const ci = cols.findIndex((c) => c.name === colName);
+        if (ci === -1) return 0;
+        const vals = bucket.map((r) => Number(r[ci]));
+        if (op === "SUM") return vals.reduce((a, b) => a + b, 0);
+        if (op === "MIN") return Math.min(...vals);
+        if (op === "MAX") return Math.max(...vals);
+        if (op === "AVG") return vals.reduce((a, b) => a + b, 0) / vals.length;
+      }
+      // Plain column: pick from any bucket row (group key is uniform within bucket).
+      const ci = cols.findIndex((c) => c.name === expr);
+      if (ci === -1) return null;
+      return bucket[0][ci];
+    };
+
+    const out = [...buckets.entries()].map(([_k, bucket]) =>
+      selectExprs.map((e) => evalExpr(e, bucket))
+    );
+    return JSON.stringify(out);
+  },
+
+  groupCount(h, table, keyCol) {
+    const db = dbs.get(h);
+    if (!db) return "[]";
+    const rows = db.tables.get(table) || [];
+    const cols = db.schema.get(table) || [];
+    const idx = cols.findIndex((c) => c.name === keyCol);
+    if (idx === -1) return "[]";
+    const buckets = new Map();
+    for (const r of rows) {
+      const k = r[idx];
+      buckets.set(k, (buckets.get(k) ?? 0) + 1);
+    }
+    return JSON.stringify([...buckets.entries()].map(([k, n]) => [k, n]));
+  },
+
+  // Compat stubs for stack-sibling harnesses.
+  query() { return []; }, queryOne() { return null; }, queryInt() { return 0; },
+  prepare() { throw new Error("prepare not used here"); },
+  bindInt() {}, bindText() {}, bindNull() {},
+  step() { return false }, columnCount() { return 0 },
+  columnInt() { return 0 }, columnText() { return "" },
+  reset() {}, finalize() {},
+  schemaTables() { return "[]"; }, schemaColumns() { return "[]"; },
+  tableExists() { return false; }, importCsv() { return 0; },
+  exportCsv() { return 0; }, lastError() { return ""; },
+  txBegin() { return 0; }, txCommit() {}, txRollback() {},
+  txSavepoint() {}, txRelease() {}, txRollbackTo() {},
+  txDb() { return 0; }, txIsLive() { return false; },
+};
+
+const mod = await import("./aggregate_smoke.deno.js");
+
+// ── COUNT ───────────────────────────────────────────────────────────
+assert.equal(mod.smoke_count(":memory:"), 5, "smoke_count: 5 rows inserted");
+
+// ── SUM ─────────────────────────────────────────────────────────────
+assert.equal(mod.smoke_sum(":memory:"), 15, "smoke_sum: 1+2+3+4+5 = 15");
+
+// ── MIN / MAX ──────────────────────────────────────────────────────
+assert.equal(mod.smoke_min_int(":memory:"), 1, "smoke_min_int: min(7,3,9,1,5) = 1");
+assert.equal(mod.smoke_max_int(":memory:"), 9, "smoke_max_int: max(7,3,9,1,5) = 9");
+
+// ── AVG ────────────────────────────────────────────────────────────
+assert.equal(mod.smoke_avg(":memory:"), 20.0, "smoke_avg: avg(10,20,30) = 20.0");
+
+// ── GROUP BY ────────────────────────────────────────────────────────
+const groupJson = mod.smoke_group_by(":memory:");
+const groups = JSON.parse(groupJson);
+assert.equal(groups.length, 2, "smoke_group_by: 2 dept buckets");
+// Sort to make assertion order-independent.
+groups.sort((a, b) => String(a[0]).localeCompare(String(b[0])));
+assert.deepEqual(groups[0], ["eng", 2, 300], "eng bucket: 2 rows / sum salary = 300");
+assert.deepEqual(groups[1], ["sales", 2, 125], "sales bucket: 2 rows / sum salary = 125");
+
+// ── GROUP COUNT ─────────────────────────────────────────────────────
+const gcJson = mod.smoke_group_count(":memory:");
+const gc = JSON.parse(gcJson);
+gc.sort((a, b) => String(a[0]).localeCompare(String(b[0])));
+assert.deepEqual(gc, [["a", 3], ["b", 2], ["c", 1]], "smoke_group_count: a×3, b×2, c×1");
+
+console.log("aggregate_smoke OK");

--- a/tests/codegen-deno/transaction_smoke.affine
+++ b/tests/codegen-deno/transaction_smoke.affine
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+// db-theory #2 — Transaction codegen smoke.
+//
+// Six smoke functions exercise the eight Transaction.affine externs:
+//   - smoke_commit_persists      (tx_begin → execute → tx_commit; row visible after)
+//   - smoke_rollback_discards    (tx_begin → execute → tx_rollback; row NOT visible after) ← key safety property
+//   - smoke_savepoint_release    (savepoint → execute → release; writes kept within outer tx)
+//   - smoke_savepoint_rollback_to (savepoint → execute → rollback_to; writes discarded, outer tx still live)
+//   - smoke_tx_db_aliasing       (tx_db returns a Db handle that participates in the open tx)
+//   - smoke_is_live_lifecycle    (live=1 between begin/commit; live=0 after)
+
+use Sqlite::{db_open, db_close, db_execute, db_query_int};
+use Transaction::{tx_begin, tx_commit, tx_rollback, tx_savepoint, tx_release, tx_rollback_to, tx_db, tx_is_live};
+
+pub fn smoke_commit_persists(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let t = tx_begin(d);
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (42)");
+  let _id3 = tx_commit(t);
+  let v = db_query_int(d, "SELECT n FROM t LIMIT 1", "[]");
+  let _id4 = db_close(d);
+  v
+}
+
+pub fn smoke_rollback_discards(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (1)");
+  let t = tx_begin(d);
+  let _id3 = db_execute(d, "INSERT INTO t VALUES (999)");
+  let _id4 = db_execute(d, "INSERT INTO t VALUES (1000)");
+  let _id5 = tx_rollback(t);
+  // After rollback only the pre-tx row should remain.
+  let count = db_query_int(d, "SELECT COUNT(*) FROM t", "[]");
+  let _id6 = db_close(d);
+  count
+}
+
+pub fn smoke_savepoint_release(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let t = tx_begin(d);
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (1)");
+  let _id3 = tx_savepoint(t, "sp1");
+  let _id4 = db_execute(d, "INSERT INTO t VALUES (2)");
+  let _id5 = tx_release(t, "sp1");
+  let _id6 = db_execute(d, "INSERT INTO t VALUES (3)");
+  let _id7 = tx_commit(t);
+  let count = db_query_int(d, "SELECT COUNT(*) FROM t", "[]");
+  let _id8 = db_close(d);
+  count
+}
+
+pub fn smoke_savepoint_rollback_to(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let t = tx_begin(d);
+  let _id2 = db_execute(d, "INSERT INTO t VALUES (1)");
+  let _id3 = tx_savepoint(t, "sp1");
+  let _id4 = db_execute(d, "INSERT INTO t VALUES (2)");
+  let _id5 = db_execute(d, "INSERT INTO t VALUES (3)");
+  let _id6 = tx_rollback_to(t, "sp1");
+  // Outer tx still live; only the pre-savepoint insert should persist.
+  let _id7 = tx_commit(t);
+  let count = db_query_int(d, "SELECT COUNT(*) FROM t", "[]");
+  let _id8 = db_close(d);
+  count
+}
+
+pub fn smoke_tx_db_aliasing(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let t = tx_begin(d);
+  // Aliased connection participates in the open transaction.
+  let d2 = tx_db(t);
+  let _id2 = db_execute(d2, "INSERT INTO t VALUES (7)");
+  let _id3 = tx_commit(t);
+  let v = db_query_int(d, "SELECT n FROM t LIMIT 1", "[]");
+  let _id4 = db_close(d);
+  v
+}
+
+pub fn smoke_is_live_lifecycle(path: String) -> Int {
+  let d = db_open(path);
+  let _id1 = db_execute(d, "CREATE TABLE t(n INTEGER)");
+  let t = tx_begin(d);
+  let live_during = tx_is_live(t);
+  let _id2 = tx_commit(t);
+  // Cannot ask tx_is_live(t) after commit — affine: handle consumed.
+  // Smoke returns the during-witness; harness asserts == 1.
+  let _id3 = db_close(d);
+  live_during
+}

--- a/tests/codegen-deno/transaction_smoke.harness.mjs
+++ b/tests/codegen-deno/transaction_smoke.harness.mjs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MPL-2.0
+// db-theory #2 — Node ESM harness for the Transaction codegen smoke.
+//
+// Extends the #1a/#1b/#1c mock with the full transaction surface:
+// txBegin / txCommit / txRollback / txSavepoint / txRelease /
+// txRollbackTo / txDb / txIsLive.
+//
+// The mock implements WRITE-SET ISOLATION at the JS level by deep-
+// cloning the affected table on `txBegin`, accumulating mutations
+// in the cloned shadow, and either promoting on commit or
+// discarding on rollback. This is enough to witness the
+// rollback-discards-writes invariant from the AffineScript side —
+// the formal proof of this invariant is the pending obligation
+// tracked at `docs/proof-obligations/db-theory-2-transaction-safety.md`.
+
+import assert from "node:assert/strict";
+
+let nextDbHandle = 1;
+let nextTxHandle = 1000;
+const dbs = new Map();
+const txs = new Map();   // tx handle -> { db, savepoints: [{name, snapshot}], live: bool, snapshot }
+
+const parseRowLiteral = (s) => {
+  const out = [];
+  let buf = "";
+  let inStr = false;
+  for (const ch of s) {
+    if (ch === "'") { inStr = !inStr; buf += ch; }
+    else if (ch === "," && !inStr) { out.push(buf.trim()); buf = ""; }
+    else buf += ch;
+  }
+  if (buf.trim()) out.push(buf.trim());
+  return out.map((t) => (
+    t.startsWith("'") && t.endsWith("'") ? t.slice(1, -1) :
+    /^-?\d+$/.test(t) ? Number(t) :
+    t
+  ));
+};
+
+const snapshotTables = (db) => {
+  const snap = new Map();
+  for (const [k, v] of db.tables.entries()) snap.set(k, v.map((row) => [...row]));
+  return snap;
+};
+
+const restoreTables = (db, snap) => {
+  db.tables = new Map();
+  for (const [k, v] of snap.entries()) db.tables.set(k, v.map((row) => [...row]));
+};
+
+globalThis.__as_sqlite = {
+  open(path) {
+    const h = nextDbHandle++;
+    dbs.set(h, { path, tables: new Map(), schema: new Map() });
+    return h;
+  },
+  close(h) { dbs.delete(h); },
+
+  execute(h, sql) {
+    const db = dbs.get(h);
+    if (!db) throw new Error("invalid db handle " + h);
+
+    const create = sql.match(/CREATE TABLE (\w+)\s*\(([^)]+)\)/i);
+    if (create) {
+      const cols = create[2].split(",").map((c) => {
+        const parts = c.trim().split(/\s+/);
+        return { name: parts[0], type: parts[1] || "" };
+      });
+      db.tables.set(create[1], []);
+      db.schema.set(create[1], cols);
+      return;
+    }
+
+    const insert = sql.match(/INSERT INTO (\w+)\s+VALUES\s+(.+)/i);
+    if (insert) {
+      const tableName = insert[1];
+      const valuesPart = insert[2].replace(/;$/, "").trim();
+      const tupleRe = /\(([^)]+)\)/g;
+      let m;
+      while ((m = tupleRe.exec(valuesPart))) {
+        const cols = parseRowLiteral(m[1]);
+        const tbl = db.tables.get(tableName);
+        if (!tbl) throw new Error("no such table " + tableName);
+        tbl.push(cols);
+      }
+    }
+  },
+
+  query(h, sql /* , params */) {
+    const db = dbs.get(h);
+    if (!db) return [];
+    const m = sql.match(/FROM\s+(\w+)/i);
+    if (!m) return [];
+    return db.tables.get(m[1]) || [];
+  },
+
+  queryOne(h, sql, params) { return this.query(h, sql, params)[0] ?? null; },
+
+  queryInt(h, sql) {
+    const db = dbs.get(h);
+    if (!db) return 0;
+    // COUNT(*) FROM <table>
+    const count = sql.match(/SELECT\s+COUNT\(\*\)\s+FROM\s+(\w+)/i);
+    if (count) return (db.tables.get(count[1]) || []).length;
+    // SELECT <expr> FROM <table> [WHERE ...] LIMIT 1 — return the first
+    // row's first-column-relevant arithmetic. The smoke uses only `n`
+    // and `a + b`, so handle both shapes.
+    const fromM = sql.match(/FROM\s+(\w+)/i);
+    if (!fromM) return 0;
+    const rows = db.tables.get(fromM[1]) || [];
+    if (rows.length === 0) return 0;
+    if (/SELECT\s+a\s*\+\s*b/i.test(sql)) return Number(rows[0][0]) + Number(rows[0][1]);
+    return Number(rows[0][0]);
+  },
+
+  // ── Transactions (db-theory #2) ───────────────────────────────────
+
+  txBegin(h) {
+    const db = dbs.get(h);
+    if (!db) throw new Error("invalid db handle " + h);
+    const t = nextTxHandle++;
+    txs.set(t, { db, savepoints: [], live: true, snapshot: snapshotTables(db) });
+    return t;
+  },
+
+  txCommit(t) {
+    const tx = txs.get(t);
+    if (!tx || !tx.live) throw new Error("invalid or already-consumed tx handle " + t);
+    // Commit: drop the snapshot, leave current tables in place.
+    tx.live = false;
+    txs.delete(t);
+  },
+
+  txRollback(t) {
+    const tx = txs.get(t);
+    if (!tx || !tx.live) throw new Error("invalid or already-consumed tx handle " + t);
+    // Rollback: restore the snapshot — discards every write since txBegin.
+    restoreTables(tx.db, tx.snapshot);
+    tx.live = false;
+    txs.delete(t);
+  },
+
+  txSavepoint(t, name) {
+    const tx = txs.get(t);
+    if (!tx || !tx.live) throw new Error("invalid or already-consumed tx handle " + t);
+    tx.savepoints.push({ name, snapshot: snapshotTables(tx.db) });
+  },
+
+  txRelease(t, name) {
+    const tx = txs.get(t);
+    if (!tx || !tx.live) throw new Error("invalid or already-consumed tx handle " + t);
+    // Release: forget the savepoint (LIFO match) but keep writes.
+    const idx = [...tx.savepoints].reverse().findIndex((sp) => sp.name === name);
+    if (idx === -1) throw new Error("no such savepoint " + name);
+    tx.savepoints.splice(tx.savepoints.length - 1 - idx, 1);
+  },
+
+  txRollbackTo(t, name) {
+    const tx = txs.get(t);
+    if (!tx || !tx.live) throw new Error("invalid or already-consumed tx handle " + t);
+    // Rollback to: restore from named savepoint; outer tx remains live.
+    const idx = [...tx.savepoints].reverse().findIndex((sp) => sp.name === name);
+    if (idx === -1) throw new Error("no such savepoint " + name);
+    const realIdx = tx.savepoints.length - 1 - idx;
+    restoreTables(tx.db, tx.savepoints[realIdx].snapshot);
+    // SQLite semantics: rollback_to keeps the savepoint itself.
+  },
+
+  txDb(t) {
+    const tx = txs.get(t);
+    if (!tx) throw new Error("invalid tx handle " + t);
+    // Aliasing: return the same db handle the user already has.
+    // We don't carry the original handle ID, so retrieve it by
+    // matching the db object reference.
+    for (const [k, v] of dbs.entries()) if (v === tx.db) return k;
+    throw new Error("tx_db: db not found for tx " + t);
+  },
+
+  txIsLive(t) { const tx = txs.get(t); return !!(tx && tx.live); },
+
+  // Convenience surface methods retained for compat with other harnesses.
+  prepare() { throw new Error("prepare not used in this smoke"); },
+  bindInt() {}, bindText() {}, bindNull() {},
+  step() { return false }, columnCount() { return 0 },
+  columnInt() { return 0 }, columnText() { return "" },
+  reset() {}, finalize() {},
+  schemaTables() { return "[]"; }, schemaColumns() { return "[]"; },
+  tableExists() { return false; }, importCsv() { return 0; },
+  exportCsv() { return 0; }, lastError() { return ""; },
+};
+
+const mod = await import("./transaction_smoke.deno.js");
+
+// ── commit_persists ────────────────────────────────────────────────
+assert.equal(
+  mod.smoke_commit_persists(":memory:"), 42,
+  "smoke_commit_persists: inserted-then-committed row visible afterward",
+);
+
+// ── rollback_discards (the key safety witness) ─────────────────────
+assert.equal(
+  mod.smoke_rollback_discards(":memory:"), 1,
+  "smoke_rollback_discards: only pre-tx row remains after rollback (writes during tx discarded)",
+);
+
+// ── savepoint_release ──────────────────────────────────────────────
+assert.equal(
+  mod.smoke_savepoint_release(":memory:"), 3,
+  "smoke_savepoint_release: release keeps savepoint writes within outer tx",
+);
+
+// ── savepoint_rollback_to ──────────────────────────────────────────
+assert.equal(
+  mod.smoke_savepoint_rollback_to(":memory:"), 1,
+  "smoke_savepoint_rollback_to: rollback_to discards writes since savepoint; outer tx commits remaining",
+);
+
+// ── tx_db aliasing ─────────────────────────────────────────────────
+assert.equal(
+  mod.smoke_tx_db_aliasing(":memory:"), 7,
+  "smoke_tx_db_aliasing: tx_db returns Db handle participating in open tx",
+);
+
+// ── is_live lifecycle ──────────────────────────────────────────────
+assert.equal(
+  mod.smoke_is_live_lifecycle(":memory:"), 1,
+  "smoke_is_live_lifecycle: tx_is_live returns 1 while tx open",
+);
+
+console.log("transaction_smoke OK");


### PR DESCRIPTION
## Summary

- New `stdlib/Transaction.affine` module exposing SQL transactions as an affine-bounded resource: `Tx` opaque handle from `tx_begin(d)`, consumed exactly once by `tx_commit(t)` or `tx_rollback(t)`. Savepoint surface (`tx_savepoint` / `tx_release` / `tx_rollback_to`), `tx_db` aliasing, and `tx_is_live` introspection round out the 8-extern API.
- Deno-ESM codegen wires `__as_txBegin` / `Commit` / `Rollback` / `Savepoint` / `Release` / `RollbackTo` / `Db` / `IsLive` JS prelude helpers + 8 `deno_builtins` lowerings. Host adapter contract documented inline.
- Six-function smoke (`tests/codegen-deno/transaction_smoke.{affine,harness.mjs}`) witnesses all lifecycle shapes — **including the rollback-discards-writes safety property** (an `INSERT` issued during a `Tx` consumed by `tx_rollback` leaves only the pre-tx rows visible).

## Proof obligation cross-doc

Per owner directive 2026-06-01 — every proof in AffineScript must first audit `hyperpolymath/echo-types`, reuse if applicable, extend upstream **with proofs** if not, then cross-document.

- New `docs/academic/proofs/db-theory-2-transaction-safety.md` states three safety obligations:
  - **#DB-2.1** rollback-discards-writes (key invariant)
  - **#DB-2.2** commit-promotes-writes
  - **#DB-2.3** savepoint locality
- Audit finding: echo-types carries `EchoLinear.LEcho` + `weaken`, `EchoSecurity.Security` record, and `EchoNoSectionGeneric.no-section-of-collapsing-map` — the latter is precisely the generic lemma the Transaction proof reduces to. **Upstream extension required**: a new `TransactionMutations.agda` module instantiating the generic no-section lemma. Issue to be filed on echo-types separately and back-linked here.

## Test plan

- [x] `dune runtest test/test_main.exe` — 367 tests green, including the new AOT smoke for `stdlib/Transaction.affine` (row #15 in the AOT smoke output) and the regression test enforcing `codegen ⊆ stdlib decls` (no drift introduced).
- [x] `tools/run_codegen_deno_tests.sh` — `transaction_smoke.harness.mjs` passes all 6 assertions.
- [x] Mock adapter implements write-set isolation by snapshotting tables on `txBegin` and restoring on `txRollback`. Production adapter contract (Deno `jsr:@db/sqlite` / Node `better-sqlite3`) maps each extern to native `BEGIN` / `COMMIT` / `ROLLBACK` / `SAVEPOINT` / `RELEASE` / `ROLLBACK TO`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)