### PR TITLE
docs(changelog): append PRs #525/#526/#527 db-theory triplet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat(stdlib): Aggregate.affine — SQL group-by + aggregation primitives — db-theory #3 (7 externs) (PR #527)
+- feat(stdlib): Transaction.affine — affine-bounded write-set isolation — db-theory #2 (8 externs) (PR #526)
+- feat(stdlib): Sqlite schema introspection + bulk I/O + error inspection — db-theory #1c (6 externs) (PR #525)
 - feat(res-to-affine): partial-port mode #488 slice 3 — `--partial` now translates array literals (`[a, b]`) and record literals (`{x, y}` → `Rec #{ x: x, y: y }`, with a nominal placeholder type + field-punning expansion) (Refs #488)
 - feat(res-to-affine): partial-port mode #488 slice 2 — `--partial` now desugars ReScript pipe-first `->` (`a->f(b)` → `f(a, b)`, chained left-to-right), and translates `if`/`else` and blocks with `let` statements (Refs #488)
 - feat(res-to-affine): partial-port mode (#488) — new `--partial` flag renders module-top-level functions as AffineScript `fn` skeletons with `switch`→`match` and best-effort expression translation (literals / idents / calls / binary ops with float-op + identity-equality normalisation / `++` / member + qualified access / ternary / variant + tuple + literal patterns); un-translatable forms become `() /* TODO */` / `_ /* TODO */` holes. Output deliberately does NOT type-check but parses (verified). Distinct model from `--translate` (Refs #488)


### PR DESCRIPTION
Appends today's three db-theory stdlib PRs to the [Unreleased] section. Repo's changelog-reusable.yml automation isn't wired yet (manual append per the file's own header pointer).