### PR TITLE
docs: refresh status after db-theory PRs #525/#526/#527/#528

### DIFF
--- a/.machine_readable/6a2/STATE.a2ml
+++ b/.machine_readable/6a2/STATE.a2ml
@@ -4,7 +4,7 @@
 [metadata]
 project = "affinescript"
 version = "0.1.1"
-last-updated = "2026-05-31"
+last-updated = "2026-06-02"
 status = "active"
 authoritative-status-doc = "docs/CAPABILITY-MATRIX.adoc"
 drift-flag = "STALE as of 2026-05-23 PM: this file's [components]/[features]/[project-context] still predate landed PRs since 2026-05-19. It MIRRORS, it does not LEAD. Authoritative sources by topic — readiness: docs/CAPABILITY-MATRIX.adoc; spine + AS↔typed-wasm contract: docs/ECOSYSTEM.adoc; coordination ledger / critical path: docs/TECH-DEBT.adoc; test taxonomy + PR-level gates: docs/standards/TESTING.adoc (added 2026-05-23); panic-attack SOP: docs/standards/PANIC-ATTACK.adoc (added 2026-05-23). Gate baseline: CAPABILITY-MATRIX records 260/260 at 2026-05-19 reconstruction; subsequent borrow-checker work has lifted it (#240 → 263, return-escape → 271/274, &mut surface → 278/281). The exact live number for any given commit comes from `dune runtest --force` — do not hard-code it here. (DOC-05, issue #176.)"

--- a/docs/CAPABILITY-MATRIX.adoc
+++ b/docs/CAPABILITY-MATRIX.adoc
@@ -199,10 +199,14 @@ no `FnExtern` story raises `Match_failure` at runtime by design (correct
 
 == Standard library
 
-`stdlib` ~95%; 19/19 stdlib files compile resolve→typecheck→codegen with the
-AOT CI gate (`test/test_stdlib_aot.ml`) since Stage C closed 2026-05-18.
-Portable primitives Http (#160) / Json (#161) / Dict-Map (#162) are the
-current authoring frontier. A few primitives remain `extern` builtins.
+`stdlib` ~95%; all `stdlib/*.affine` files compile resolve→typecheck→codegen
+with the AOT CI gate (`test/test_stdlib_aot.ml`) — file list is discovered
+dynamically, so new modules are gated on landing. Stage C closed 2026-05-18.
+Portable primitives Http (#160) / Json (#161) / Dict-Map (#162) plus the
+db-theory triplet — `Sqlite.affine` (#522 / #524 / #525), `Transaction.affine`
+(#526; affine-bounded write-set isolation), `Aggregate.affine` (#527;
+group-by + aggregation primitives) — are the current authoring frontier.
+A few primitives remain `extern` builtins.
 
 == What AffineScript is NOT (anti-over-claim)
 

--- a/docs/TECH-DEBT.adoc
+++ b/docs/TECH-DEBT.adoc
@@ -333,6 +333,21 @@ trap STDLIB-04c removed). Now the typed-alias of `parse_int` in interp
 + Deno codegen + resolve/typecheck seeds. 4 hermetic tests in "E2E
 STDLIB-04e Pure #332" lock the round-trip semantics. |S3 |DONE
 2026-05-24 (Refs #332)
+|STDLIB-05 |db-theory triplet (`Sqlite` / `Transaction` / `Aggregate`)
+— *LANDED* 2026-06-01..02. Sqlite.affine progressed across #522
+(codegen foundation, 6 externs wired Deno-ESM end-to-end), #524
+(prepared statements — `Stmt` opaque + 10 typed externs), and #525
+(schema introspection + bulk I/O + error inspection — 6 externs).
+Transaction.affine (#526) ships an affine-bounded `Tx` handle
+(consumed exactly once by commit/rollback) + savepoint surface — 8
+externs; companion proof
+`docs/academic/proofs/db-theory-2-transaction-safety.md`.
+Aggregate.affine (#527) ships SQL group-by + aggregation primitives —
+7 externs; companion proof
+`docs/academic/proofs/db-theory-3-aggregation-as-fold.md`. All three
+modules picked up by the dynamic AOT gate; each ships its own
+Deno-ESM smoke harness under `tests/codegen-deno/`. CHANGELOG sync
+landed via #528. |S3 |DONE 2026-06-02 (PRs #522/#524/#525/#526/#527/#528)
 |===
 
 == Section D — INT (ecosystem integration)

--- a/docs/stdlib-roadmap.adoc
+++ b/docs/stdlib-roadmap.adoc
@@ -65,7 +65,9 @@ tracked in the main ROADMAP. Such items are flagged `tracked-by-main`.
 |`Crypto.affine`      |`◑` partial |Should consume `hpm-crypto-rsr` C-ABI.
 |`Http.affine`        |`◑` partial |Client-side; rewire to `hpm-http-client-rsr`.
 |`Network.affine`     |`◐` scaffold|Sockets / DNS coverage unclear.
-|`Sqlite.affine`      |`◑` partial |Coverage audit needed.
+|`Sqlite.affine`      |`●` usable  |db-theory #1a/#1b/#1c landed (PRs #522/#524/#525): Deno-ESM codegen foundation + prepared `Stmt` (10 externs) + schema introspection + bulk I/O + error inspection (6 externs).
+|`Transaction.affine` |`●` usable  |db-theory #2 landed (PR #526): affine-bounded `Tx` handle consumed exactly once by commit/rollback, savepoint surface, 8 externs; proof at `docs/academic/proofs/db-theory-2-transaction-safety.md`.
+|`Aggregate.affine`   |`●` usable  |db-theory #3 landed (PR #527): SQL group-by + aggregation primitives, 7 externs; proof at `docs/academic/proofs/db-theory-3-aggregation-as-fold.md`.
 |`Grammy.affine`      |`◑` partial |Telegram bot coverage.
 |`Ajv.affine`         |`◑` partial |Schema validation; estate-wide a2ml use.
 |`Deno.affine`        |`●` usable  |`WasmExports` + `wasmInstance` + `readFile`; calling individual exports is a binding gap (see bindings #5).


### PR DESCRIPTION
## Summary

Refresh the authoritative status surfaces in this repo to reflect the
stdlib **db-theory triplet** that landed yesterday and today:

- PR #525 — `Sqlite.affine` schema introspection + bulk I/O + error inspection (db-theory #1c, 6 externs)
- PR #526 — `Transaction.affine` (db-theory #2, affine-bounded write-set isolation, 8 externs)
- PR #527 — `Aggregate.affine` (db-theory #3, SQL group-by + aggregation primitives, 7 externs)
- PR #528 — CHANGELOG sync (already merged)

`CHANGELOG.md` is already up to date via #528, so this PR touches only
the four files that ledger that work as status, not as history.

## What changed

- `docs/CAPABILITY-MATRIX.adoc` — replace the stale "19/19 stdlib files" sentence (the AOT gate now discovers files dynamically) and call out the db-theory triplet as the current authoring frontier alongside Http / Json / Dict-Map.
- `docs/TECH-DEBT.adoc` §C STDLIB — add a `STDLIB-05` row capturing the full Sqlite arc (#522 / #524 / #525), Transaction (#526), and Aggregate (#527), with pointers to the two academic proofs the PRs already shipped (`docs/academic/proofs/db-theory-{2,3}-*.md`).
- `docs/stdlib-roadmap.adoc` — promote `Sqlite.affine` from `partial / Coverage audit needed` to `usable`, and add `Aggregate.affine` + `Transaction.affine` rows to the inventory snapshot.
- `.machine_readable/6a2/STATE.a2ml` — bump `last-updated` to `2026-06-02` (this file mirrors, it does not lead — per its own drift-flag).

## What was deliberately *not* touched

- `docs/ROADMAP.adoc` — language/compiler progress; the db-theory PRs are stdlib-side and don't move the language roadmap.
- A `TEST-NEEDS` file — none exists at repo root; the three PRs each shipped their own Deno-ESM smoke harness under `tests/codegen-deno/` (`sqlite_introspect_bulk` / `transaction_smoke` / `aggregate_smoke`) and the AOT gate auto-picked the new modules up.
- License / SPDX headers — per the estate's no-automated-licence-edits rule.

## Test plan

- [x] `bash tools/check-doc-truthing.sh` passes locally — banner / primacy / mirror invariants intact, over-claim ratchet unchanged (no new baseline entry needed).
- [x] Commit GPG-signed; verified `gpg: Good signature`.

Generated with [Claude Code](https://claude.com/claude-code)