### PR TITLE
chore(license): PMPL → MPL-2.0 sweep (5 files)

### DIFF
--- a/spec/ARG-PROFILE.adoc
+++ b/spec/ARG-PROFILE.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = ARG-PROFILE — AffineScript

--- a/spec/CRG-PROFILE.adoc
+++ b/spec/CRG-PROFILE.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = CRG-PROFILE — AffineScript

--- a/spec/FRG-PROFILE.adoc
+++ b/spec/FRG-PROFILE.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = FRG-PROFILE — AffineScript

--- a/spec/TRG-PROFILE.adoc
+++ b/spec/TRG-PROFILE.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = TRG-PROFILE — AffineScript

--- a/stdlib/future.affine
+++ b/stdlib/future.affine
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0-or-later
+// SPDX-License-Identifier: MPL-2.0
 // SPDX-FileCopyrightText: 2025 hyperpolymath
 //
 // Future - async sequencing combinators (echidna#62)


### PR DESCRIPTION
Sole-owner repo. Per the 2026-06-02 canonical license policy, PMPL is restricted to palimpsest-license / palimpsest-plasma / consent-aware-http; this repo gets MPL-2.0.

Files: 5 SPDX headers flipped + NOTICE rewrite (if applicable) + orphan PMPL license file delete (if applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)