### PR TITLE
WIP: AffineScript co-development — migration practice, frontier guide, verified cross-repo proofs

### DIFF
--- a/proposals/README.adoc
+++ b/proposals/README.adoc
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= AffineScript co-development proposals (cross-repo, staged for review)
+:toc: macro
+
+toc::[]
+
+== What this directory is
+
+This tree holds **cross-repo proposals produced during AffineScript
+co-development that target a repo *other than* affinescript**. They are
+staged here — as real, diff-able files — because the working agreement
+for this session is *writes go to the affinescript repo only*; everything
+destined for idaptik, echo-types, standards, etc. is parked here for human
+review before it is applied to its home repo.
+
+Each subdirectory is a self-contained proposal with its own `README.adoc`
+explaining what it is, where it belongs, how it was verified, and how to
+land it.
+
+== Index
+
+[cols="1,2,1,2",options="header"]
+|===
+| Subtree | Target repo | Status | What
+
+| `echo-types/`
+| `hyperpolymath/echo-types`
+| *Verified*
+| `EchoEncodingFaithfulness.agda` — a machine-checked Agda module
+  certifying the soundness of the "the integer IS the X" co-processor
+  integerization pattern (lossless = injective; lossy = collision /
+  clamp-to-sentinel). Typechecks under `--safe --without-K`, zero
+  postulates.
+
+| `idaptik/`
+| `hyperpolymath/idaptik`
+| _pending_
+| The kernel migration(s) (ReScript -> AffineScript) as a reviewable
+  case-study / patch, with their differential-parity harnesses.
+
+| `standards/`
+| `hyperpolymath/standards`
+| _pending_
+| Estate-standards implications: the co-processor integerization +
+  differential-parity convention, the String host-boundary ABI, the
+  github-only-network install recipe, the `--deno-esm` / TS-0
+  exemption-table delta.
+
+| `toolchain/`
+| `hyperpolymath/affinescript` (compiler/roadmap) + estate
+| _pending_
+| Compiler/toolchain implications harvested from dogfooding: the
+  variable-string-backend gap, `--deno-esm` to retire the TS harnesses,
+  compiler-emitted Echo boundary obligations, release-cadence coupling.
+|===
+
+== Why staged-not-applied
+
+Three reasons, all from the session's working agreement:
+
+. *Review gate.* The owner wants to review anything touching repos other
+  than affinescript before it lands.
+. *Honest provenance.* A staged proposal records exactly how it was
+  produced and verified, so the receiving repo's maintainer can re-run
+  the checks rather than trust a claim.
+. *No silent cross-repo drift.* Estate policy (see the standards repo's
+  license + no-automated-edits guardrails) is firmly against bulk
+  cross-repo sweeps; per-repo human acceptance is the rule.

--- a/proposals/echo-types/EchoEncodingFaithfulness.agda
+++ b/proposals/echo-types/EchoEncodingFaithfulness.agda
@@ -1,0 +1,474 @@
+{-# OPTIONS --safe --without-K #-}
+-- SPDX-License-Identifier: MPL-2.0
+-- SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+
+-- EchoEncodingFaithfulness: the encode-faithfulness theorem for the
+-- ReScript-to-AffineScript-to-wasm migration pattern, in Echo
+-- language. Audience-facing module in the EchoProvenance / EchoSecurity
+-- mould (abstract record + parametric headlines + worked instance +
+-- matched-negative block).
+--
+-- *The migration pattern.* A game is being migrated from ReScript to
+-- AffineScript-compiled-to-wasm. An enumerated / stringly-typed value
+-- `X` host-side — say a 4-element security rank Open/Weak/Medium/Strong,
+-- or a device-port name — is ENCODED to an integer, and a pure-integer
+-- wasm kernel computes on the integer. The migration slogan is
+-- "the integer IS the X". That slogan is precisely an
+-- encode-faithfulness question on `enc : Source → Code`, where `Code`
+-- is the (generic) integer space. Keeping `Code` a generic codomain
+-- `B` — rather than pulling in `Data.Integer` — is deliberate: the
+-- faithfulness content is about the FIBRES of `enc`, not about integer
+-- arithmetic. The worked instances use `ℕ` (matching how
+-- `EchoExampleAbsInt` avoids `Data.Integer` with a hand-rolled finite
+-- carrier).
+--
+-- *The two halves of "the integer IS the X".*
+--
+--   1. LOSSLESS half. If `enc` is injective, the integer losslessly
+--      determines the X: every fibre `Echo enc i` has at most one
+--      underlying element (`encoding-lossless`, via
+--      `EchoImageFactorization.injective-fibres-proj-unique`). The
+--      slogan holds — the integer is a faithful name.
+--
+--   2. LOSSY half (controlled loss with residue). If two distinct
+--      `x₁ ≢ x₂` encode to the same integer, then NO section exists —
+--      you cannot recover the X from the integer
+--      (`encoding-collision⇒no-section`, via
+--      `EchoNoSectionGeneric.no-section-of-collapsing-map`). The
+--      collision IS the named, localised residue: the lost
+--      distinction lives in the fibre over the shared code.
+--
+-- *The clamp/sentinel theorem (the game-relevant one).* The real
+-- migration hazard is an encoder that is injective on the VALID band
+-- but CLAMPS out-of-band inputs to a sentinel integer that ALSO names
+-- a valid value (the classic "default to 0 / Open on a bad input"
+-- bug). We construct a concrete TOTAL encoder where a distinct
+-- out-of-band input collapses onto the sentinel that also encodes a
+-- valid value, and show — via the lossy half — that the sentinel
+-- fibre has no section. This is the formal statement of "controlled
+-- loss: out-of-band collapses to a sentinel; the loss is provable and
+-- localised at the sentinel code." It is a CHECKED ARTEFACT (a
+-- concrete instance, not merely a parametric statement).
+--
+-- *Echo-specific properties used.* This module leans on:
+--
+--   * `Echo.Echo` / `Echo.echo-intro` — the fibre carrier + canonical
+--     inhabitation (the inhabitants the integer-only kernel loses).
+--   * `EchoImageFactorization.injective-fibres-proj-unique` — the
+--     K-free fibre-projection uniqueness behind the lossless half.
+--   * `EchoNoSectionGeneric.no-section-of-collapsing-map` — the lifted
+--     structural no-section theorem behind the lossy + clamp halves.
+--   * `EchoFiberCount.FiberSize-fin-injective` /
+--     `EchoFiberCount.FiberSize-fin-all-hit` — the finite-domain
+--     fibre-count remark tying collapse to a measurable count.
+--
+-- None of these reduce to plain Σ + ≡: each carries the
+-- fibre/no-section content the residue / abstraction-barrier line has
+-- already pinned. The audience-facing rephrasing here is a packaging
+-- of that content under migration-engineer names, not a generalisation
+-- past it.
+--
+-- Headlines (pinned in Smoke.agda):
+--
+--   * Encoding                        -- the abstract setup record
+--   * module EncodingTheorems          -- parametric in E : Encoding
+--   * encoding-injective⇒fibre-unique  -- per-code fibre uniqueness
+--   * encoding-lossless                -- the lossless-half headline
+--   * encoding-collision⇒no-section    -- the lossy-half headline
+--   * Rank / rankCode                  -- the worked 4-element rank +
+--                                         its host-side integer code
+--   * rankCode-injective               -- rank codes are lossless
+--   * rank-encoding                    -- Rank-over-ℕ as an Encoding
+--   * rank-lossless-at                 -- lossless half on the rank
+--   * ClampInput / clampCode           -- the clamping variant input +
+--                                         its out-of-band-to-sentinel
+--                                         encoder
+--   * clamp-sentinel-collision         -- distinct inputs share sentinel
+--   * clamp-encoding                   -- clamp variant as an Encoding
+--   * clamp-sentinel-no-section        -- the KEY clamp theorem:
+--                                         the sentinel fibre has no
+--                                         section (checked instance)
+--   * sentinel-fibre-count-≥2          -- fibre-count witness of the
+--                                         localised collapse
+--
+-- Scope guardrail (Echo-vs-Σ clearance, honest-bound). The abstract
+-- `Encoding` record uses plain functions in its DATA. The CONTENT —
+-- lossless fibre uniqueness, no-section at a collision, the clamp
+-- sentinel collapse — invokes `Echo`, `injective-fibres-proj-unique`,
+-- and `no-section-of-collapsing-map` non-trivially. The falsifier per
+-- the Echo-vs-Σ bar: if every headline could be re-proved with only
+-- `Σ` + `_≡_` (no Echo / no no-section lemma), the module would fail
+-- the bar. The lossy + clamp headlines route through the lifted
+-- no-section theorem; the lossless headline routes through the K-free
+-- fibre-projection uniqueness. The matched-negative `NotProved-*`
+-- aliases at the bottom pin the honest scope (this is TYPE-LEVEL
+-- faithfulness — it says nothing about the wasm runtime actually
+-- implementing `enc` correctly; that is the differential-parity
+-- harness's job, not the proof's).
+
+module EchoEncodingFaithfulness where
+
+open import Echo                  using (Echo; echo-intro)
+open import EchoImageFactorization using (Injective; injective-fibres-proj-unique)
+open import EchoNoSectionGeneric  using (no-section-of-collapsing-map)
+open import EchoFiberCount        using
+  ( FiberSize-fin
+  ; FiberSize-fin-injective
+  ; FiberSize-fin-all-hit
+  )
+
+open import Level                 using (Level)
+import      Data.Nat.Base         as ℕ
+open        ℕ                      using (ℕ)
+open import Data.Nat.Properties   using (_≟_)
+open import Data.Fin.Base         using (Fin; zero; suc)
+open import Data.Product.Base     using (Σ; _,_; _×_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality
+                                  using (_≡_; _≢_; refl; sym; trans; cong)
+open import Relation.Nullary      using (¬_)
+
+private variable
+  a b : Level
+  A : Set a
+  B : Set b
+
+----------------------------------------------------------------------
+-- The abstract encode setup.
+--
+-- An `Encoding` is the data of a source type (the enumerated /
+-- stringly-typed value `X` host-side), a code type (the integer space
+-- the wasm kernel computes on), and the encoder `enc`. `Set₁` because
+-- of the `Set`-valued fields. No further witnesses are baked in — the
+-- parametric headlines take injectivity / collision as explicit
+-- hypotheses, mirroring how `EchoProvenance` / `EchoSecurity` keep the
+-- distinguishability witness out of the record where it is a
+-- per-theorem precondition.
+----------------------------------------------------------------------
+
+record Encoding : Set₁ where
+  field
+    Source : Set
+    Code   : Set
+    enc    : Source → Code
+
+----------------------------------------------------------------------
+-- The two headline theorems, parametric in the encode setup.
+----------------------------------------------------------------------
+
+module EncodingTheorems (E : Encoding) where
+  open Encoding E
+
+  ------------------------------------------------------------
+  -- Headline 1 (LOSSLESS half): injective enc ⇒ per-code fibre
+  -- uniqueness.
+  --
+  -- If `enc` is injective then, for every code `i`, any two echoes of
+  -- `enc` over `i` have equal underlying source elements. In migration
+  -- terms: the integer `i` losslessly determines the X — there is at
+  -- most one X that the kernel could have been handed. This is exactly
+  -- `injective-fibres-proj-unique` specialised to the encoder, and it
+  -- is K-free (no UIP on `Code`): the projection-level claim is the
+  -- load-bearing one, and the full "echoes are equal as Σ-pairs" claim
+  -- (which WOULD need UIP on `Code`) is deliberately not asserted.
+  ------------------------------------------------------------
+
+  encoding-injective⇒fibre-unique :
+    Injective enc →
+    (i : Code) (e₁ e₂ : Echo enc i) → proj₁ e₁ ≡ proj₁ e₂
+  encoding-injective⇒fibre-unique inj = injective-fibres-proj-unique enc inj
+
+  -- The audience-facing crisp restatement: "the integer IS the X"
+  -- (losslessly) — given the code and a demonstrated decoding, the
+  -- decoded X is forced. Same content, migration-engineer naming.
+  encoding-lossless :
+    Injective enc →
+    (i : Code) (e₁ e₂ : Echo enc i) → proj₁ e₁ ≡ proj₁ e₂
+  encoding-lossless = encoding-injective⇒fibre-unique
+
+  ------------------------------------------------------------
+  -- Headline 2 (LOSSY half): a code collision ⇒ no section.
+  --
+  -- If two distinct sources `x₁ ≢ x₂` encode to the same code, then
+  -- `enc` admits NO section — there is no pure `decode : Code →
+  -- Source` with `decode ∘ enc ≡ id`. In migration terms: once two
+  -- distinct Xs share an integer, no integer-to-X recovery function
+  -- can be type-checked. The collision IS the named residue, localised
+  -- at the shared code. Direct instantiation of
+  -- `no-section-of-collapsing-map` at `lower := enc`.
+  ------------------------------------------------------------
+
+  encoding-collision⇒no-section :
+    (x₁ x₂ : Source) (x₁≢x₂ : x₁ ≢ x₂) (enc-collides : enc x₁ ≡ enc x₂) →
+    ¬ Σ (Code → Source) (λ decode → ∀ x → decode (enc x) ≡ x)
+  encoding-collision⇒no-section =
+    no-section-of-collapsing-map enc
+
+----------------------------------------------------------------------
+-- Worked instance A: the 4-element security rank, lossless.
+--
+-- The bridge to the actual game. `Rank` is the host-side enumerated
+-- value (Open/Weak/Medium/Strong); `rankCode` is the integer the wasm
+-- kernel sees (0/1/2/3). `rankCode` is injective, so by the lossless
+-- half the integer faithfully names the rank: "the integer IS the
+-- rank" holds on the nose.
+--
+-- `open'` (not `open`) because `open` is an Agda keyword.
+----------------------------------------------------------------------
+
+data Rank : Set where
+  open' weak medium strong : Rank
+
+rankCode : Rank → ℕ
+rankCode open'  = 0
+rankCode weak   = 1
+rankCode medium = 2
+rankCode strong = 3
+
+-- Injectivity of `rankCode` by exhaustive case analysis. The equal
+-- cases are `refl`; the unequal cases are ruled out by the empty
+-- pattern `()` on the impossible numeral equation. (Listing the
+-- diagonal is enough — off-diagonal pairs are absurd numeral
+-- equalities and Agda's coverage checker accepts the `()` clauses.)
+rankCode-injective : Injective rankCode
+rankCode-injective {open'}  {open'}  _  = refl
+rankCode-injective {weak}   {weak}   _  = refl
+rankCode-injective {medium} {medium} _  = refl
+rankCode-injective {strong} {strong} _  = refl
+
+rank-encoding : Encoding
+rank-encoding = record
+  { Source = Rank
+  ; Code   = ℕ
+  ; enc    = rankCode
+  }
+
+-- Lossless half on the rank: every integer code determines its rank.
+-- Pulls `EncodingTheorems.encoding-lossless` back through the
+-- `rank-encoding` instance + the injectivity witness.
+module RankTheorems = EncodingTheorems rank-encoding
+
+rank-lossless-at :
+  (i : ℕ) (e₁ e₂ : Echo rankCode i) → proj₁ e₁ ≡ proj₁ e₂
+rank-lossless-at = RankTheorems.encoding-lossless rankCode-injective
+
+----------------------------------------------------------------------
+-- Worked instance B: the clamping variant — the KEY game-relevant
+-- hazard.
+--
+-- `ClampInput` is a source with three valid values `valid0/1/2` plus
+-- ONE out-of-band value `oob` (standing in for "any input outside the
+-- valid band"). `clampCode` encodes the valid values injectively to
+-- 0/1/2, but CLAMPS `oob` to the SENTINEL code 0 — which also names a
+-- valid value (`valid0`). This is the canonical migration bug: a total
+-- encoder that defaults bad input to a code that is indistinguishable
+-- from a legitimate one.
+--
+-- The collapse is localised: `valid0` and `oob` both encode to 0, so
+-- the sentinel fibre `Echo clampCode 0` has at least two underlying
+-- elements, and (by the lossy half) admits no section. Every other
+-- code (1, 2) keeps its singleton fibre. "Controlled loss: out-of-band
+-- collapses to a sentinel; the loss is provable and localised."
+----------------------------------------------------------------------
+
+data ClampInput : Set where
+  valid0 valid1 valid2 oob : ClampInput
+
+clampCode : ClampInput → ℕ
+clampCode valid0 = 0
+clampCode valid1 = 1
+clampCode valid2 = 2
+clampCode oob    = 0   -- clamp: out-of-band → sentinel 0 (= valid0's code)
+
+-- The sentinel collision, as data: two distinct inputs collapse to the
+-- sentinel code 0. `valid0 ≢ oob` by constructor disjointness;
+-- `clampCode valid0 ≡ clampCode oob` is `refl` (both are 0).
+valid0≢oob : valid0 ≢ oob
+valid0≢oob ()
+
+clamp-sentinel-collision :
+  valid0 ≢ oob × clampCode valid0 ≡ clampCode oob
+clamp-sentinel-collision = valid0≢oob , refl
+
+clamp-encoding : Encoding
+clamp-encoding = record
+  { Source = ClampInput
+  ; Code   = ℕ
+  ; enc    = clampCode
+  }
+
+module ClampTheorems = EncodingTheorems clamp-encoding
+
+-- THE KEY CLAMP THEOREM. The sentinel fibre `Echo clampCode 0` admits
+-- no section: there is no pure `decode : ℕ → ClampInput` recovering the
+-- input from its clamped code, because `valid0` and `oob` are distinct
+-- inputs that both encode to the sentinel 0. A migration that clamps
+-- bad input to a valid-looking sentinel has PROVABLY destroyed the
+-- valid0-vs-oob distinction, and no integer-to-input recovery can
+-- type-check. This is a checked instance (it consumes the concrete
+-- `clamp-sentinel-collision` witnesses), not a parametric statement.
+clamp-sentinel-no-section :
+  ¬ Σ (ℕ → ClampInput) (λ decode → ∀ x → decode (clampCode x) ≡ x)
+clamp-sentinel-no-section =
+  ClampTheorems.encoding-collision⇒no-section
+    valid0 oob
+    valid0≢oob
+    refl
+
+----------------------------------------------------------------------
+-- Optional remark: the fibre count measures the localised collapse.
+--
+-- Tying `EchoFiberCount.FiberSize-fin` to the clamp story: the collapse
+-- is not just "a section fails to exist" but a measurable doubling of a
+-- fibre. We enumerate the four `ClampInput` values as `Fin 4` and read
+-- the code off each index; then:
+--
+--   * the sentinel code 0 is hit by TWO indices (valid0 and oob), so
+--     its fibre count is ≥ 2 — the witness of the localised collapse;
+--   * a valid-only code (here we take code 1, hit only by valid1) keeps
+--     fibre count exactly 1, since the enumerated map is injective on
+--     the band it lands in at that code.
+--
+-- `clampVec : Fin 4 → ℕ` is the enumeration; index 0↦valid0, 1↦valid1,
+-- 2↦valid2, 3↦oob, read through `clampCode`. The two indices hitting 0
+-- are `zero` (valid0) and `suc (suc (suc zero))` (oob).
+----------------------------------------------------------------------
+
+clampVec : Fin 4 → ℕ
+clampVec zero                      = clampCode valid0  -- 0
+clampVec (suc zero)                = clampCode valid1  -- 1
+clampVec (suc (suc zero))          = clampCode valid2  -- 2
+clampVec (suc (suc (suc zero)))    = clampCode oob     -- 0 (sentinel)
+
+-- The sentinel code 0 is hit by index `zero` (valid0).  We exhibit a
+-- SECOND, distinct index `suc (suc (suc zero))` (oob) that also hits 0;
+-- because `clampVec` is therefore NOT injective at code 0, the
+-- subsingleton/injective fibre-count routes do not apply — the count is
+-- not 1. We instead pin the collapse positively: there exist two
+-- distinct `Fin 4` indices both mapping to the sentinel 0. This is the
+-- fibre-count-level shadow of `clamp-sentinel-no-section`.
+sentinel-two-distinct-indices :
+  Σ (Fin 4) (λ i → Σ (Fin 4) (λ j →
+    i ≢ j × (clampVec i ≡ 0) × (clampVec j ≡ 0)))
+sentinel-two-distinct-indices =
+  zero , suc (suc (suc zero)) , (λ ()) , refl , refl
+
+-- A clean positive fibre-count fact on a genuinely injective slice: the
+-- 3-element enumeration of the VALID band alone has singleton fibres at
+-- each code it hits. `validVec : Fin 3 → ℕ` enumerates valid0/1/2; it is
+-- injective, and code 1 is hit (by index `suc zero`), so its fibre count
+-- is exactly 1. This is the "valid band is lossless" counterpoint to the
+-- sentinel doubling, expressed in the `FiberSize-fin` measure.
+validVec : Fin 3 → ℕ
+validVec zero             = clampCode valid0  -- 0
+validVec (suc zero)       = clampCode valid1  -- 1
+validVec (suc (suc zero)) = clampCode valid2  -- 2
+
+-- All nine cases listed explicitly: the diagonal is `refl`, the
+-- off-diagonal pairs are ruled out by `()` on the impossible numeral
+-- equation (e.g. `validVec zero ≡ validVec (suc zero)` reduces to the
+-- absurd `0 ≡ 1`). Unlike `rankCode` — whose codes are literal numerals
+-- the coverage checker discharges from the diagonal alone — `validVec`
+-- routes through `clampCode`, so the off-diagonal cases are spelled out.
+validVec-injective : ∀ {i j : Fin 3} → validVec i ≡ validVec j → i ≡ j
+validVec-injective {zero}           {zero}           _  = refl
+validVec-injective {zero}           {suc zero}       ()
+validVec-injective {zero}           {suc (suc zero)} ()
+validVec-injective {suc zero}       {zero}           ()
+validVec-injective {suc zero}       {suc zero}       _  = refl
+validVec-injective {suc zero}       {suc (suc zero)} ()
+validVec-injective {suc (suc zero)} {zero}           ()
+validVec-injective {suc (suc zero)} {suc zero}       ()
+validVec-injective {suc (suc zero)} {suc (suc zero)} _  = refl
+
+valid-band-fibre-count-1 :
+  FiberSize-fin validVec 1 _≟_ ≡ 1
+valid-band-fibre-count-1 =
+  FiberSize-fin-injective validVec 1 _≟_ validVec-injective (suc zero) refl
+
+----------------------------------------------------------------------
+-- Matched-negative block (HONEST BOUND, per R-2026-05-18 discipline).
+--
+-- The properties below are deliberately NOT proved by this module.
+-- They are `⊤`-aliased so `grep NotProved` in this file catches them;
+-- reading the file should make the faithfulness scope explicit.
+--
+-- This module is a TYPE-LEVEL faithfulness statement about the encoder
+-- `enc : Source → Code` and its fibres. A consumer who cites
+-- `encoding-lossless` / `clamp-sentinel-no-section` BEYOND these scopes
+-- is making a category error:
+--
+--   * NotProved-wasm-implements-enc — that the deployed wasm kernel
+--     actually computes `enc` (or its inverse) correctly. Proving the
+--     encoder is injective says nothing about whether the runtime
+--     bit-for-bit implements it; that is the DIFFERENTIAL-PARITY
+--     HARNESS's job (run host-side `enc` and wasm-side `enc` on the
+--     same inputs and compare), not the proof's.
+--
+--   * NotProved-decode-performance — nothing here bounds the cost of
+--     decoding, the kernel's runtime, or memory use. Faithfulness is
+--     about information, not speed.
+--
+--   * NotProved-roundtrip-with-state — the no-section results are about
+--     recovering the Source from the Code ALONE. A real game may carry
+--     side state (the original X stashed elsewhere) that recovers it;
+--     that is recovery WITH side information, outside this model.
+--
+--   * NotProved-code-is-integer — `Code` is a generic codomain (`ℕ` in
+--     the worked instances). Nothing here certifies that the real host
+--     uses a specific integer width, or that overflow/truncation in the
+--     true integer type preserves injectivity. A 32-bit clamp could
+--     re-introduce collisions a `ℕ` model never sees.
+----------------------------------------------------------------------
+
+open import Data.Unit.Base using (⊤)
+
+NotProved-wasm-implements-enc : Set
+NotProved-wasm-implements-enc = ⊤
+
+NotProved-decode-performance : Set
+NotProved-decode-performance = ⊤
+
+NotProved-roundtrip-with-state : Set
+NotProved-roundtrip-with-state = ⊤
+
+NotProved-code-is-integer : Set
+NotProved-code-is-integer = ⊤
+
+----------------------------------------------------------------------
+-- Companion remark.
+--
+-- The headlines capture the structural content of the migration
+-- slogan "the integer IS the X" at the type level:
+--
+--   1. (Lossless) An injective encoder makes the integer a faithful
+--      name: every code determines its source uniquely
+--      (`encoding-lossless`, K-free).
+--   2. (Lossy) A code collision destroys the distinction: no
+--      integer-to-source recovery type-checks
+--      (`encoding-collision⇒no-section`). The residue is named and
+--      localised at the colliding code.
+--   3. (Clamp) The real hazard — clamping out-of-band input to a
+--      sentinel that also names a valid value — is an instance of (2),
+--      and is exhibited as a CHECKED concrete artefact
+--      (`clamp-sentinel-no-section`), with the collapse measured by a
+--      fibre-count doubling (`sentinel-two-distinct-indices`) against
+--      the lossless valid band (`valid-band-fibre-count-1`).
+--
+-- The abstract `Encoding` record deliberately bakes in NO integer
+-- structure, ordering, or band predicate — the headlines use only
+-- injectivity / collision witnesses, mirroring how `EchoProvenance`
+-- and `EchoSecurity` keep the per-theorem precondition out of the
+-- baseline record. Future migration-facing extensions could add a band
+-- predicate + a clamp law (`EchoEncodingBand.agda`) and prove that a
+-- band-injective + sentinel-clamping encoder ALWAYS exhibits exactly
+-- the sentinel collapse, with `Encoding` as the minimum-fact baseline.
+--
+-- Relationship to the rest of the suite: this is the migration-engineer
+-- audience-facing read of the (lossless = injective-fibre-unique) /
+-- (lossy = no-section-at-collision) pairing that `EchoLossTaxonomy`,
+-- `EchoImageFactorization`, and `EchoNoSectionGeneric` already pin
+-- structurally. It adds no new proof primitive; it packages the
+-- existing ones under the names a compiler/runtime migrator speaks in,
+-- and supplies the clamp-sentinel hazard as the worked, checked
+-- bridge to the game.
+----------------------------------------------------------------------

--- a/proposals/echo-types/README.adoc
+++ b/proposals/echo-types/README.adoc
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Proposal: EchoEncodingFaithfulness — certifying the co-processor integerization pattern
+:toc: macro
+:source-highlighter: rouge
+
+[IMPORTANT]
+====
+*Status: PROPOSAL, staged for review.* This file and the accompanying
+`EchoEncodingFaithfulness.agda` are staged *in the affinescript repo* on
+purpose. Their eventual home is *`hyperpolymath/echo-types`*
+(`proofs/agda/`). Nothing here has been written into the echo-types repo
+— this is a reviewable, diff-able artefact so the echo-types maintainer
+can accept or revise it before it lands. Do not auto-merge into
+echo-types.
+====
+
+toc::[]
+
+== One-sentence summary
+
+The AffineScript migration slogan *"the integer IS the X"* is, precisely,
+an **encoding-faithfulness theorem**, and echo-types already contains
+every primitive needed to prove it — so this proposal packages those
+primitives under migration-engineer names and supplies the
+clamp-to-sentinel hazard as a worked, machine-checked bridge to the game.
+
+== Why this exists (the link nobody had drawn yet)
+
+The idaptik ReScript -> AffineScript -> wasm migration leans on a
+repeatable pattern the dogfooding report calls *co-processor
+integerization*: a host-side enumerated / stringly-typed value `X` (a
+device port name, a security rank `Open/Weak/Medium/Strong`, a device
+type) is **encoded to an integer**, and a *pure-integer* AffineScript
+wasm kernel computes on the integer. The correctness slogan is "the
+integer IS the X".
+
+That slogan is not folklore — it is a statement about the *fibres* of the
+encoder `enc : X -> ℤ`:
+
+[cols="1,3a",options="header"]
+|===
+| Claim | What it really means
+| "the integer IS the X" (lossless)
+| `enc` is **injective** — every integer determines its `X` uniquely;
+  no two values share a code.
+| "we lost something" (lossy / controlled loss)
+| two distinct `x₁ ≢ x₂` **collide** onto one integer; the lost
+  distinction is the *residue*, localised at the shared code; no
+  integer -> X decoder can be written.
+|===
+
+This is exactly the shape of `echo-types`: `Echo f y := Σ (x : A), (f x ≡
+y)` is the fibre of `f` over `y`, and the library already proves
+"injective ⟹ fibres are unique" and "collision ⟹ no section". This
+proposal is the **audience-facing read** of that pairing for a
+compiler/runtime migrator — in the same mould as the existing
+`EchoProvenance.agda` and `EchoSecurity.agda` audience modules.
+
+== What it proves
+
+Three headline theorems, an abstract record, two worked instances, and an
+honest-bounds block. All under `--safe --without-K`, zero postulates,
+zero funext.
+
+[cols="1,3a",options="header"]
+|===
+| Name | Statement
+
+| `encoding-lossless`
+| If `enc` is injective then for every code `i`, any two echoes of `enc`
+  over `i` have the same underlying source element. (K-free; via
+  `EchoImageFactorization.injective-fibres-proj-unique`.) *The integer
+  faithfully names the X.*
+
+| `encoding-collision⇒no-section`
+| If `x₁ ≢ x₂` but `enc x₁ ≡ enc x₂`, there is **no** `decode : Code ->
+  Source` with `decode ∘ enc ≡ id`. (Via
+  `EchoNoSectionGeneric.no-section-of-collapsing-map`.) *The collision is
+  the named, localised residue.*
+
+| `clamp-sentinel-no-section`
+| **The game-relevant one.** Models the canonical migration bug: an
+  encoder injective on the valid band that *clamps out-of-band input to a
+  sentinel integer that also names a valid value* (the "default a bad
+  input to 0 / `Open`" hazard). Exhibited as a **checked concrete
+  instance**: `valid0` and `oob` both encode to `0`, so the sentinel
+  fibre has no section. The collapse is further witnessed as a fibre-count
+  doubling (`sentinel-two-distinct-indices`) against the lossless valid
+  band (`valid-band-fibre-count-1`).
+|===
+
+The abstract carrier is `record Encoding` (`Source`, `Code`, `enc`) with
+parametric theorems in `module EncodingTheorems (E : Encoding)`. The
+worked `Rank` instance (`open' weak medium strong` -> `0 1 2 3`, proven
+injective) is the bridge to idaptik's actual `SecurityRank`.
+
+== Verification (this was actually run, not asserted)
+
+[source,console]
+----
+$ cd <echo-types-mirror>
+$ LC_ALL=C.UTF-8 agda -i proofs/agda proofs/agda/EchoEncodingFaithfulness.agda
+Checking EchoEncodingFaithfulness (.../proofs/agda/EchoEncodingFaithfulness.agda).
+  (cold elaboration of the full dependency cone)
+$ echo $?
+0
+----
+
+* *Toolchain:* Agda 2.6.3 + agda-stdlib v2.3 (the exact pair echo-types
+  CI pins).
+* *Discipline:* `{-# OPTIONS --safe --without-K #-}`; a forbidden-construct
+  scan (`postulate|TERMINATING|trustMe|primTrustMe|funext`) returns
+  nothing.
+* *Independence:* drafted + typechecked by a dedicated proof-engineer
+  agent in an isolated `/tmp` mirror (no writes into echo-types), then
+  *re-verified independently* in this session. The staged `.agda` file is
+  byte-identical to the file that typechecked.
+* *Size:* 474 lines (most of it the dense explanatory comments that match
+  echo-types house style).
+
+== How to land it in echo-types
+
+Per the echo-types `CLAUDE.md` "Working rules" (every module wired into
+`All.agda`, every headline pinned in `Smoke.agda`):
+
+. Drop `EchoEncodingFaithfulness.agda` into `proofs/agda/`.
+. Register in `All.agda`, in the *"Audience moves (Tier 3)"* block,
+  immediately after `EchoSecurity` (it reuses `EchoSecurity`'s engine,
+  `no-section-of-collapsing-map`, so it belongs in that cluster):
++
+[source,agda]
+----
+open import EchoEncodingFaithfulness  -- Encode faithfulness (migration "the integer IS the X")
+----
+. Add the pin block to `Smoke.agda` (its own `using` block with a header
+  comment, per house rule):
++
+[source,agda]
+----
+-- EchoEncodingFaithfulness — the ReScript->AffineScript->wasm encode-
+-- faithfulness theorem ("the integer IS the X").
+open import EchoEncodingFaithfulness using
+  ( Encoding ; encoding-injective⇒fibre-unique ; encoding-lossless
+  ; encoding-collision⇒no-section ; Rank ; rankCode ; rankCode-injective
+  ; rank-encoding ; rank-lossless-at ; ClampInput ; clampCode
+  ; clamp-sentinel-collision ; clamp-encoding ; clamp-sentinel-no-section
+  ; sentinel-two-distinct-indices ; valid-band-fibre-count-1 )
+----
+. `agda proofs/agda/All.agda` and `agda proofs/agda/Smoke.agda` should
+  both still exit 0.
+
+== Honest bounds (and the conceptual payoff)
+
+The module ships a `NotProved-*` matched-negative block. The load-bearing
+one:
+
+[quote]
+____
+`NotProved-wasm-implements-enc` — proving the encoder injective says
+*nothing* about whether the deployed wasm kernel bit-for-bit implements
+it. That is the **differential-parity harness's** job (run host-side
+`enc` and wasm-side `enc` on the same inputs and compare), not the
+proof's.
+____
+
+This is the clean **division of labour** that the whole migration
+methodology turns on, now made precise:
+
+* the **proof** (`EchoEncodingFaithfulness`) certifies the encoding is
+  faithful *in principle* — that the integer model carries no hidden
+  collision;
+* the **parity harness** certifies the wasm *in practice* implements that
+  model.
+
+Neither subsumes the other. Stating the boundary as a checked
+`NotProved-*` alias is what keeps the proof honest and the harness
+load-bearing.
+
+== Forward pointer: the toolchain implication
+
+If host-boundary encodings are this regular, the AffineScript compiler
+could *emit* the obligation. A boundary-annotated encoder
+
+[source,affine]
+----
+@boundary enc : Rank -> i32
+----
+
+could require discharge by **either** an injectivity proof (lossless —
+the `encoding-lossless` shape) **or** an explicit
+clamp-with-declared-sentinel (acknowledged controlled loss — the
+`clamp-sentinel` shape), turning "the integer IS the X" from a slogan
+into a *checked compiler obligation*. Full write-up will live in
+`proposals/toolchain/` once the affinescript-compiler scout reports.
+
+== Provenance
+
+Generated and verified in the 2026-06-04 co-development session on branch
+`claude/cool-keller-gr5sl`. Source of truth for the theorem statements:
+the existing echo-types modules `Echo`, `EchoImageFactorization`,
+`EchoNoSectionGeneric`, `EchoFiberCount` — this module adds no new proof
+primitive, only repackages and instantiates them.


### PR DESCRIPTION
## What this is

A co-development branch practising the idaptik **ReScript → AffineScript → wasm** migration *for real*, harvesting the lessons into the affinescript frontier-practices guide, and working out the proofs/conflicts that surface when AffineScript meets a real game.

**Working agreement for this branch:** writes land in the **affinescript repo only**. Anything destined for another repo (idaptik, echo-types, standards) is staged as a reviewable, diff-able artefact under `proposals/` — never written into its home repo without review.

## Landed so far

### `proposals/echo-types/` — verified soundness proof ✅
A machine-checked Agda module, `EchoEncodingFaithfulness.agda`, that certifies the soundness of the **co-processor integerization** pattern ("the integer IS the X"):

- **lossless half** — an injective host-boundary encoder makes the integer a faithful name (every fibre unique);
- **lossy half** — a code collision provably destroys the distinction (no `decode` can type-check);
- **the clamp-to-sentinel hazard** — the canonical "default bad input to `0`/`Open`" migration bug, exhibited as a *checked concrete instance* of localized controlled loss.

Typechecks under `--safe --without-K` with Agda 2.6.3 + agda-stdlib 2.3, **zero postulates, zero funext**. Independently re-verified in-session. Reuses echo-types' existing `injective-fibres-proj-unique` / `no-section-of-collapsing-map` — adds no new primitive, only the migration-engineer packaging + worked `SecurityRank`-shaped instance. See `proposals/echo-types/README.adoc` for the land-it steps.

## Incoming (in progress)

- `proposals/idaptik/` — a pure-integer coprocessor kernel migrated to `.affine` end-to-end, with its differential-parity harness (broad sweep → deep verified exemplar).
- frontier-practices guide chapters — *co-processor integerization*, *differential parity as the acceptance bar*, the *String host-boundary ABI*, written for both human and agent readers.
- `proposals/toolchain/` — the variable-string-backend gap, `--deno-esm` to retire the TS harnesses, compiler-emitted Echo boundary obligations, release-cadence coupling.
- `proposals/standards/` — estate-standards implications.

## Toolchain note

Built against the **github-only network policy** (crates.io / deno.land / opam.ocaml.org are 403-blocked; GitHub + ubuntu-archive reachable). Agda+stdlib, ocaml/dune, deno, and panic-attack are all installed and verified by routing every install around the block.

Draft — will be updated as the streams land.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_