### PR TITLE
AffineScript co-development (round 2): verified Kernel_IO/SecurityRank migration + frontier guide + cross-repo proposals

### DIFF
--- a/docs/guides/frontier-guide.adoc
+++ b/docs/guides/frontier-guide.adoc
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 = AffineScript Frontier Guide: The Unveiling
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
-v1.0, 2026-04-11
+v1.2, 2026-06-04
 :toc:
 :icons: font
 :source-highlighter: rouge
-:revnumber: 1.0
-:revdate: 2026-04-11
+:revnumber: 1.2
+:revdate: 2026-06-04
 
 [NOTE]
 ====
@@ -444,6 +444,141 @@ A practical implication for translators: identify your target's tier
 writing kernel-shaped code from the first line; sum types and effects
 won't be available, and that should drive the design.
 
+== Chapter 9: The Co-processor and the Integer
+
+You already know the problem, even if you have not named it. You have a
+working ReScript or JavaScript program — a game, a simulator, a tool — and
+you want the *logic* to run with AffineScript's guarantees, compiled to
+wasm, without rewriting the rendering, the input handling, or the network.
+The instinct is to port the whole thing. The better move is to split it.
+
+**AffineScript is the brain; JS/Pixi are the senses.** The wasm core does
+logic, physics, decisions, state machines; the host does rendering, input,
+strings, and dispatch. The two halves communicate by passing **raw
+primitives** — Ints, Floats, Arrays — across the wasm boundary. Nothing
+stringly-typed crosses; nothing stateful crosses; only numbers.
+
+This chapter unveils the mental model. The systematic, verified
+re-decomposition patterns live in the
+link:migration-playbook.adoc#coprocessor-integerization[Migration Playbook's
+co-processor section] — read that when you are actually carrying a codebase
+across.
+
+=== The integer IS the X
+
+The keystone idea: a value drawn from a small, named domain — a security
+rank `Open/Weak/Medium/Strong`, a device-port name, a tile kind — is
+**encoded to a canonical integer on the host side**, and the wasm core
+computes on that integer. The host keeps the names; the core gets the code.
+
+[source,affine]
+----
+// The encoding IS the rank.  0 = Open, 1 = Weak, 2 = Medium, 3 = Strong.
+// The host owns "Open" <-> 0; this core owns the arithmetic.
+pub fn rank_security_level(v: Int) -> Int {
+  if v < 0 { 0 } else { if v > 3 { 3 } else { v } }
+}
+
+pub fn passes_min_security(actual: Int, required: Int) -> Bool {
+  rank_security_level(actual) >= rank_security_level(required)
+}
+----
+
+There is no `String` here, and no sum type crossing the boundary. The four
+rank *names* never enter wasm; only their codes do. Compiled host-native,
+this is a tiny module — in idaptik's case **454 bytes**, whose only WASI
+import is `fd_write`. Every decision the host used to phrase in terms of
+rank *names* is re-phrased as integer arithmetic on rank *codes*. That is
+the whole pattern, and its slogan is _"the integer IS the X."_
+
+=== Why a co-processor, and not a rewrite
+
+Three things fall out of the split that a full rewrite would not give you:
+
+. **The boundary is narrow and auditable.** Only primitives cross. You can
+  enumerate exactly what passes between brain and senses, because it is a
+  short list of Ints and Floats — not an open-ended graph of objects.
+. **The core is small and verifiable.** A pure-integer kernel has no
+  strings to allocate, no state to corrupt, no effects to handle. It
+  compiles to a handful of kilobytes and its behaviour is a function of its
+  inputs — which is exactly what makes <<chapter-9-parity,differential
+  parity>> (below) a usable acceptance test.
+. **The senses stay where they are good.** Rendering, input, and the DOM
+  remain in the host, which already does them well. You are not reimplementing
+  Pixi in AffineScript; you are giving Pixi a verified brain to call.
+
+[NOTE]
+====
+This is the operational form of the WASM Co-processor Model described in the
+link:frontier-programming-practices/Human_Programming_Guide.adoc[Frontier
+Programming Practices] guide. That guide states the posture; this chapter and
+the Playbook show you how to *port into it*.
+====
+
+[#chapter-9-parity]
+=== How you know it worked: differential parity
+
+A co-processor port has a crisp acceptance bar, and it is *not* "the compiler
+accepted it." It is two conditions, both required:
+
+* **Build-green** — the `.affine` compiles to wasm, host-native
+  (`affinescript compile FILE -o OUT.wasm`).
+* **Parity-green** — the wasm output matches an **independent oracle** — a
+  separate implementation written from the *contract*, not from the
+  `.affine` — across a sweep of inputs, including out-of-band ones.
+
+idaptik's `SecurityRank` core cleared this bar at **78/78** against a JS
+oracle of the documented `0..3` contract: every input, in-band and
+out-of-band, agreed. Build-green alone would only have proved the compiler
+ran; parity-green proves the kernel is *right*.
+
+=== The honest edges
+
+The co-processor model is sharp because its limits are sharp, and the limits
+are teaching points, not apologies:
+
+* **Strings have an ABI, so avoid crossing them.** When a string genuinely
+  must cross, there is a real wire format (`[len: i32 little-endian][utf8]`)
+  and an exported allocator to honour — see the Playbook. The cheapest way
+  to handle a string at the boundary is to keep it host-side and send a code
+  instead (the integerization above). Sometimes the data was *never* a
+  string — idaptik's `Kernel_IO` does a sandbox prefix check on bytes that
+  are already an `Int` array, so it compares integer arrays directly and
+  never builds a `String` at all.
+* **No code runs at module load.** AffineScript modules have no load-time
+  side effect to hook. ReScript that mutates a module-level cell, reads
+  `Date.now()`, or calls `Console.log` ambiently has nowhere to put that
+  after the port — those capabilities must be *threaded in as parameters*
+  (or supplied by `extern` host functions) until effect-handling codegen
+  lands. A kernel that relies on module-load effects will not compile to
+  wasm today; that is the compiler telling you to make the dependency
+  explicit.
+* **The faithfulness is provable.** "The integer IS the X" is not folklore —
+  it is an encoding-faithfulness theorem, machine-checked in
+  link:../../proposals/echo-types/README.adoc[`EchoEncodingFaithfulness.agda`].
+  An *injective* encoder is lossless; a *clamp* is provable, localised loss
+  with no decoder. SecurityRank's clamp is exactly that certified hazard —
+  and which *direction* it clamps (garbage up to `Strong` is fail-open;
+  garbage down to `Open` is fail-closed) is a security decision the proof
+  surfaces but does not make for you.
+
+=== Try it
+
+Sketch the boundary for a different domain before reading the Playbook.
+Suppose the host has tile kinds `Empty | Wall | Door | Water`:
+
+. Choose the integer encoding (`Empty = 0`, `Wall = 1`, …). Write it down —
+  that table is the contract.
+. Write a pure-integer AffineScript function `is_passable(tile: Int) -> Bool`
+  that the host can call per tile. No `String`, no sum type crosses.
+. Name one out-of-band input (a negative code, or `99`) and decide — *as a
+  game-design question* — what `is_passable` should return for it, and
+  whether that default is fail-open or fail-closed.
+
+You have just done the three hardest parts of a co-processor port: the
+encoding, the pure kernel, and the out-of-band policy. The Playbook turns
+the sketch into a compiled, parity-checked module.
+
 == Putting It Together: A Complete Program
 
 [source,affinescript]
@@ -590,5 +725,9 @@ This document is intended to evolve. When you change it — adding a chapter, sh
   (4) New Chapter 8 — *What Every Backend Gets vs. What Some Get* — introduces the A/B/C tier taxonomy so users know which backends accept full AS and which are kernel sublanguages by design.
   (5) New Appendix — *Bringing in Target Intrinsics* — documents the stub-as-intrinsic pattern that lets user code call CUDA / ONNX / Faust / Verilog runtime ops without extending the language.
   No removals; existing v1.0 content unchanged.
+
+| 1.2
+| 2026-06-04
+| New Chapter 9 — *The Co-processor and the Integer* — unveils the ReScript → AffineScript → wasm co-processor mental model ("AffineScript is the brain; JS/Pixi the senses; only primitives cross the boundary") and the "the integer IS the X" encoding idea, grounded in idaptik's verified 454-byte `SecurityRank` core (78/78 differential-parity). The chapter introduces the model and the honest edges (String ABI, no module-load effects, machine-checked faithfulness via `EchoEncodingFaithfulness.agda`); the systematic re-decomposition patterns live in the link:migration-playbook.adoc#coprocessor-integerization[Migration Playbook §Co-processor Integerization] (playbook v1.4). No removals; existing v1.1 content unchanged.
 
 |===

--- a/docs/guides/frontier-programming-practices/AI.a2ml
+++ b/docs/guides/frontier-programming-practices/AI.a2ml
@@ -1,12 +1,15 @@
 (a2ml
   (metadata
     (name "Frontier Programming Practices in AffineScript — AI Edition")
-    (version "2.0.0")
-    (date "2026-04-10")
+    (version "2.1.0")
+    (date "2026-06-04")
     (audience "Bot / LLM / Agent")
     (status "authoritative-scope-statement")
     (supersedes "v1.0.0 (defensive draft)")
     (companion "Human_Programming_Guide.adoc")
+    (changelog
+      (entry (version "2.1.0") (date "2026-06-04")
+        (note "Added (coprocessor-integerization) stanza — six verified ReScript->AffineScript->wasm co-processor patterns from the in-flight idaptik migration (the-integer-is-the-X, re-decompose-not-transliterate, differential-parity-acceptance-bar, string-host-boundary-abi, no-module-load-side-effects, certifying-the-boundary) + named codegen gaps. Added agent-behavior/coprocessor-port-discipline. Human companions: migration-playbook.adoc §Co-processor Integerization (v1.4) + frontier-guide.adoc Chapter 9 (v1.2).")))
   )
 
   (thesis
@@ -168,6 +171,72 @@
       (sketch "type DeviceStatus = Compromised | Clean | Suspect | Unknown\nfn dispatch(d: DeviceId, s: DeviceStatus)"))
   )
 
+  (coprocessor-integerization
+    (note "Six verified, named patterns for the ReScript -> AffineScript -> wasm co-processor port. The human companion is migration-playbook.adoc §'Co-processor Integerization' (#coprocessor-integerization) and frontier-guide.adoc Chapter 9. Grounded ONLY in the in-flight idaptik migration; every claim below is observed, not aspirational. Load at session start before any .res -> .affine kernel translation.")
+    (mental-model
+      (one-sentence "AffineScript is the brain (logic, physics, decisions, integer math in wasm); JS/Pixi are the senses (rendering, input, strings, dispatch); only raw primitives (Int, Float, Array) cross the wasm boundary.")
+      (source "Human_Programming_Guide.adoc §'The WASM Co-processor Model'"))
+
+    (pattern
+      (name "the-integer-is-the-X")
+      (slogan "the integer IS the X")
+      (composition "host-side encoder + pure-integer wasm kernel")
+      (purpose "Encode a host-side enumerated/stringly value to a canonical integer; compute on the integer in a pure-Int AffineScript wasm core; keep strings, state, and dispatch host-side.")
+      (verified-example "idaptik SecurityRank.affine — header says 'the encoding IS the rank'; ranks Open/Weak/Medium/Strong map to canonical 0/1/2/3; rank_security_level clamps out-of-band into the band; passes_min_security is an integer comparison. Compiled host-native to a 454-byte wasm; exports rank_security_level + passes_min_security; only WASI import is fd_write.")
+      (split-rule "Host keeps: string literals + name<->code table + mutable state + dispatch on the decoded value (the senses). Wasm gets: integer codes + arithmetic + pure decision logic (the brain). idaptik PortNames states it: 'The host keeps the port string literals and the suffix concatenation; only integers cross the boundary… Host-side string layer (the senses half).'")
+      (sketch "pub fn rank_security_level(v: Int) -> Int { if v < 0 { 0 } else { if v > 3 { 3 } else { v } } }\npub fn passes_min_security(actual: Int, required: Int) -> Bool { rank_security_level(actual) >= rank_security_level(required) }"))
+
+    (pattern
+      (name "re-decompose-not-transliterate")
+      (composition "the Cardinal Rule at co-processor scale")
+      (purpose "The .affine shape differs from the .res shape even for 'the same' function; re-decompose around what the wasm boundary and current codegen support, never 1:1 port.")
+      (verified-example "Kernel_Compute.affine is a real re-decomposition of Kernel_Compute.res. Six deltas: (a) incidental promise<executionResult> collapsed to settled ExecutionResult; (b) service-locator global ResourceAccounting.getDeviceState replaced by threading the one consumed slice (activeCalls) as an explicit parameter; (c) process-global backend registry replaced by an explicitly-passed Registry; (d) option<string> replaced by a closed ResultMessage enum; (e) Int.toString (NO wasm intrinsic) replaced by a hand-laddered divmod integer renderer; (f) wire-message strings kept byte-identical.")
+      (second-verified-example "Kernel_IO decodes ASCII bytes to a String then String.startsWith for a sandbox check. Re-decomposition keeps the data as an Int array and does an integer-array prefix comparison — the decode-to-String step is DELETED, not ported, sidestepping the string-backend gap (the data already IS an int array).")
+      (reframing-rule "When a stdlib function has no wasm lowering (e.g. Int.toString), do not ask 'how do I make it work'; ask 'what is the integer computation underneath it' and emit that. The externally observable output (wire bytes) must NOT move — only the internal shape changes."))
+
+    (pattern
+      (name "differential-parity-acceptance-bar")
+      (composition "host-native compile + independent oracle sweep")
+      (purpose "Acceptance = build-green AND parity-green. Build-green alone (compiler accepted it) is NOT acceptance.")
+      (procedure "1. Compile host-native: affinescript compile FILE -o OUT.wasm (or dune exec affinescript -- compile …). 2. Instantiate (WASI fd_write stub). 3. For each input in a sweep INCLUDING out-of-band values, compare wasm output against an INDEPENDENT oracle written from the documented contract (not from the .affine). Any mismatch fails.")
+      (verified-example "SecurityRank harness ran 78/78 green against a JS oracle of the documented 0..3 contract.")
+      (host-native-warning "CRITICAL: existing idaptik harnesses (vm/tests/*_diff.ts) still shell out to a RETIRED idaptik-affinescript-build:latest podman container. The 2026-06-03 reanchor went host-native (guix/nix dev shell + affinescript on PATH). NEW harnesses must call the host compiler directly — do NOT copy the container invocation. Replace it with the host-native form.")
+      (why-independent "An oracle generated from the same .affine only proves the compiler is deterministic, not that the kernel is correct. The oracle must encode the human-readable contract so disagreement localises a real bug (wrong .affine, wrong oracle, or ambiguous spec)."))
+
+    (pattern
+      (name "string-host-boundary-abi")
+      (composition "wire format + exported allocator + host helpers + extern/pub")
+      (purpose "When a string MUST cross the wasm boundary (rare — prefer integerization), honour this ABI. Reach for it only when integerization genuinely cannot avoid it.")
+      (wire-format "[len: i32 little-endian][utf8 bytes]. No trailing NUL; the length is authoritative.")
+      (allocator "Codegen exports __affine_alloc(n: i32) -> i32, a bump allocator, so the host reserves space correctly. This REPLACED an earlier fixed scratch offset of 8192 that could collide with literal/heap storage. If you see 8192 hard-coded as a scratch base in an older harness, that is the superseded pattern.")
+      (host-helpers "readString(mem, ptr) / writeString(mem, at, s); instantiate with a WASI fd_write stub.")
+      (callbacks-and-exports "extern fn host_x(s: String) -> String;  lets wasm call back into the host (wasm->host). pub fn exports an AffineScript function to the host (host->wasm). Same extern machinery as effects-migration-stance.adoc, carrying strings rather than effects.")
+      (sketch "extern fn host_x(s: String) -> String;\npub fn handle(s: String) -> String { /* … */ }"))
+
+    (pattern
+      (name "no-module-load-side-effects")
+      (composition "explicit threading / registration")
+      (purpose "AffineScript modules do not run code at load time; there is no implicit module-load hook in wasm. Thread state/time/log as explicit parameters (or registration functions) until extensible-effect codegen lands; do NOT rely on module-load side effects.")
+      (verified-counter-example "Kernel_Quantum carries module-level mutable Dict state (lastQuantumOp), Date.now, and Console.log. All three hit the EFFECT-CODEGEN WALL: Kernel_Compute.affine documents that effect codegen 'references an unbound binding' and cannot yet lower to wasm. A faithful port of Kernel_Quantum therefore does not compile to wasm.")
+      (re-decomposition "Module-level mutable Dict -> pass state in and return updated state out (own QuantumState). Date.now() -> a now: Int parameter supplied by the host. Console.log(…) -> an extern fn host_log(s: String); the host implements, or a returned log payload. Do not log from inside the kernel.")
+      (cross-ref "Mirrors agent-behavior/no-side-effect-imports and effects-migration-stance.adoc. Forward-compatible: threaded parameters become the obvious State/IO handler sites when effect handling ships.")
+      (anti-pattern "let _ = X.foo() at module scope; ambient Date.now()/Console.log inside a kernel intended for wasm."))
+
+    (pattern
+      (name "certifying-the-boundary")
+      (composition "machine-checked encoding-faithfulness theorem")
+      (purpose "The integerization is not just convention — it is a theorem. 'the integer IS the X' is precisely an encoding-faithfulness theorem, machine-checked.")
+      (proof-artefact "echo-types module EchoEncodingFaithfulness.agda, staged at proposals/echo-types/ in THIS repo. Under --safe --without-K, zero postulates. Proves: an INJECTIVE host-boundary encoder is lossless ('the integer IS the X'); a COLLISION/CLAMP is provable, localised loss with no decoder (clamp-sentinel-no-section).")
+      (security-nuance "SecurityRank's Invalid(v) => if v<0 {0} else {3} clamp is exactly that certified hazard. The clamp DIRECTION is a real security decision for a min-security filter: clamping high garbage UP to Strong (3) is FAIL-OPEN (malformed privileged input treated as maximally privileged); clamping low garbage DOWN to Open (0) is FAIL-CLOSED (malformed input treated as least privileged). For passes_min_security, fail-closed is the safe default. The proof tells you the loss is localised and decoderless; the security review tells you which direction it must go.")
+      (division-of-labour "The proof certifies the encoding model carries no hidden collision (faithful IN PRINCIPLE). It says NOTHING about whether the deployed wasm bit-for-bit implements the encoding — that is the differential-parity harness's job (faithful IN PRACTICE). Neither subsumes the other; stated in the module as a checked NotProved-wasm-implements-enc alias.")
+      (cross-ref "proposals/echo-types/README.adoc"))
+
+    (codegen-gaps-named
+      (note "These are LOAD-BEARING teaching points surfaced by the verified migration, not embarrassments. Do not paper over them; re-decompose around them.")
+      (gap (name "Int.toString-no-wasm-intrinsic") (workaround "hand-laddered divmod integer renderer, per Kernel_Compute.affine delta (e)"))
+      (gap (name "String-backend-incomplete-on-wasm") (workaround "keep data as Int arrays where possible (Kernel_IO int-array prefix check); honour the String ABI only when a string must genuinely cross"))
+      (gap (name "effect-codegen-references-unbound-binding") (workaround "thread state/time/log as explicit parameters; do not rely on effect handling lowering to wasm yet (Kernel_Quantum counter-example)"))))
+
   (agent-behavior
     (session-startup
       (rule "Read this document at the start of every AffineScript session. It is the authoritative scope statement."))
@@ -191,6 +260,9 @@
       (rule "When a function has named pi-binders ((name : Type) -> ...), prefer eta-expanded definitions over point-free. Point-free is a parser-cascade trigger when the eta-rewrite's argument name disagrees with the declared signature's name."))
     (no-side-effect-imports
       (rule "AffineScript modules do not run code at load time. Migrating ReScript/JS code that uses `let _ = X.foo` for module-load side effects must be rewritten to call an explicit registration function. There is no implicit module-load-time side effect to hook in wasm."))
+    (coprocessor-port-discipline
+      (rule "Before any .res -> .affine kernel translation aimed at wasm, load the (coprocessor-integerization) stanza above. Apply the integerization patterns: encode host values to integers and keep strings/state/dispatch host-side; re-decompose (do not transliterate); gate on differential parity against an INDEPENDENT oracle compiled HOST-NATIVE (not the retired podman container); thread state/time/log explicitly because modules have no load-time side effect; honour the String ABI only when a string must genuinely cross.")
+      (anti-pattern "1:1 porting a ReScript kernel; copying vm/tests/*_diff.ts container invocations; calling Int.toString or relying on module-load mutation / Date.now / Console.log inside a wasm-targeted kernel; treating build-green as acceptance.")))
   )
 
   (relationship-with-typed-wasm-project

--- a/docs/guides/migration-playbook.adoc
+++ b/docs/guides/migration-playbook.adoc
@@ -2,13 +2,13 @@
 // SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = AffineScript Migration Playbook: Re-decomposition Patterns
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
-v1.1, 2026-05-02
+v1.4, 2026-06-04
 :sectnums:
 :toc: left
 :icons: font
 :source-highlighter: rouge
-:revnumber: 1.1
-:revdate: 2026-05-02
+:revnumber: 1.4
+:revdate: 2026-06-04
 
 [NOTE]
 ====
@@ -20,6 +20,7 @@ This guide is the **systematic companion** to link:frontier-guide.adoc[`frontier
 The machine-readable companion for AI agents is link:frontier-programming-practices/AI.a2ml[`AI.a2ml`].
 ====
 
+[#the-cardinal-rule]
 == The Cardinal Rule
 
 **Re-decompose. Do not transliterate.**
@@ -337,6 +338,431 @@ What changed:
 
 The two versions are roughly the same number of lines. They are different programs.
 
+[#coprocessor-integerization]
+== Co-processor Integerization (ReScript → AffineScript → wasm)
+
+The largest-scale pattern surfacing from the in-flight idaptik migration is
+not a single rule but a *shape for the whole port*: the host language keeps
+the strings, the state, and the dispatch; AffineScript becomes a
+**pure-integer wasm co-processor** that the host calls across a primitives-only
+boundary. The Human Programming Guide names the deployment posture — _"AffineScript
+serves as the 'brain'… while the frontend serves as the 'senses'… the two
+communicate by passing raw primitives across the WASM boundary."_ This section
+is the migration-engineering companion to that posture: six named, verified
+patterns for carrying real ReScript across the boundary.
+
+The patterns are independent but reinforce each other. Read them in order the
+first time; thereafter <<integerization-pattern-index>> indexes them for
+lookup.
+
+[#integerization-pattern-index]
+[cols="1,3,2"]
+|===
+| Pattern | One-line | Where it bites
+
+| <<p-integer-is-x>>
+| The integer IS the X — encode the host's stringly/enumerated value to an integer; compute on the integer in wasm.
+| Any value that crosses the boundary.
+
+| <<p-redecompose>>
+| Re-decompose, don't transliterate — the `.affine` shape differs from the `.res` shape, even for "the same" function.
+| Every non-leaf translation.
+
+| <<p-parity>>
+| Differential parity is the acceptance bar — build-green AND parity-green against an independent oracle.
+| Sign-off; CI.
+
+| <<p-string-abi>>
+| The String host-boundary ABI — `[len][utf8]`, exported allocator, host read/write helpers.
+| The few times strings must actually cross.
+
+| <<p-no-load-effects>>
+| No module-load side-effects — thread state/time/log explicitly until effect-handling codegen lands.
+| Singletons, registries, `Date.now`, `Console.log`.
+
+| <<p-certify>>
+| Certifying the boundary — the integerization is a machine-checked theorem, not just convention.
+| Sign-off; security-relevant encoders.
+|===
+
+[#p-integer-is-x]
+=== Pattern 1 — Co-processor integerization: "the integer IS the X"
+
+A host-side value drawn from a small enumerated or stringly-typed domain — a
+security rank `Open/Weak/Medium/Strong`, a device-port name, a device type — is
+**encoded to a canonical integer** on the host side. The AffineScript wasm core
+receives only that integer, computes on it with ordinary `Int` arithmetic, and
+returns an integer (or `Bool`). The strings, the dispatch table, and the mutable
+state stay on the host. _AffineScript is the brain; JS/Pixi are the senses; only
+primitives cross the wasm boundary._
+
+The correctness slogan is **"the integer IS the X"**: the encoding is chosen so
+that the integer faithfully names the value, and every operation the host used to
+express in terms of the value is re-expressed as integer arithmetic on the code.
+
+==== The verified worked example — idaptik `SecurityRank.affine`
+
+The canonical instance is idaptik's `SecurityRank.affine`, whose own header
+states the thesis directly: *"the encoding IS the rank."* The four ranks map to
+the canonical `0..3` integer encoding:
+
+[cols="1,1"]
+|===
+| Rank | Integer code
+
+| `Open`   | `0`
+| `Weak`   | `1`
+| `Medium` | `2`
+| `Strong` | `3`
+|===
+
+The core exports two pure-integer functions — `rank_security_level` (which
+normalises an arbitrary input into the `0..3` band) and `passes_min_security`
+(an integer comparison). Compiled host-native, it is a **454-byte wasm module**
+whose only WASI import is `fd_write`; everything else is integer arithmetic.
+
+[source,affine]
+----
+// SecurityRank.affine (shape) — the encoding IS the rank.
+// 0 = Open, 1 = Weak, 2 = Medium, 3 = Strong.
+
+// Clamp any input integer into the valid 0..3 band.
+pub fn rank_security_level(v: Int) -> Int {
+  if v < 0 { 0 } else { if v > 3 { 3 } else { v } }
+}
+
+// Does `actual` meet `required`?  Pure integer comparison.
+pub fn passes_min_security(actual: Int, required: Int) -> Bool {
+  rank_security_level(actual) >= rank_security_level(required)
+}
+----
+
+Note what is *not* here: there is no `String`, no `Rank` sum type crossing the
+boundary, no dictionary of rank names. Those live host-side. The host owns
+`"Open" ↔ 0`; the core owns `0 ≥ 1`.
+
+==== The split, stated outright
+
+idaptik's `PortNames` work states the division of labour without euphemism:
+_"The host keeps the port string literals and the suffix concatenation; only
+integers cross the boundary… Host-side string layer (the senses half)."_ Read
+that as the general rule:
+
+[cols="1,1"]
+|===
+| Stays host-side (the senses) | Crosses to wasm (the brain)
+
+| String literals and their concatenation | Integer codes
+| The enum-name ↔ code table | Integer arithmetic and comparison
+| Mutable session/game state | Pure functions of the codes
+| Dispatch on the decoded value | The band-normalisation / decision logic
+|===
+
+When you can keep a value's *identity* host-side and send only its *code*, do
+so. The wasm core gets smaller, the boundary gets narrower, and — see
+<<p-string-abi>> — you avoid the String ABI entirely for that value.
+
+[#p-redecompose]
+=== Pattern 2 — Re-decompose, don't transliterate
+
+This is the <<the-cardinal-rule,Cardinal Rule>> applied at co-processor scale.
+A 1:1 port of a ReScript kernel into AffineScript reproduces the ReScript design;
+the integerization only pays off if the `.affine` is re-decomposed around what
+the wasm boundary and the current codegen actually support. The verified example
+is `Kernel_Compute.affine`, a genuine re-decomposition of `Kernel_Compute.res`.
+Six concrete deltas:
+
+[cols="1,2,2"]
+|===
+| # | ReScript shape | Re-decomposed AffineScript shape
+
+| (a)
+| `promise<executionResult>` — an incidental Promise wrapper around a value that is, at the kernel boundary, already settled.
+| Collapsed to its settled `ExecutionResult`. The Promise was async-ness the kernel never actually needed; carrying it into wasm would have invented an effect to handle.
+
+| (b)
+| A service-locator global — `ResourceAccounting.getDeviceState` reached for ambiently inside the function.
+| The one consumed slice (`activeCalls`) threaded in as an **explicit parameter**. The hidden dependency becomes a visible argument. (Same move as the service-locator row in <<source-pattern-index>>.)
+
+| (c)
+| A process-global backend registry, mutated and read at module scope.
+| An explicitly-passed `Registry` value. No module-load mutation; the caller supplies the registry. (See <<p-no-load-effects>>.)
+
+| (d)
+| `option<string>` for the result message.
+| A closed `ResultMessage` enum. The "maybe a string, maybe not, and the string means something" triple becomes one exhaustive sum type the `match` must cover.
+
+| (e)
+| `Int.toString` to render the result.
+| A **hand-laddered divmod integer renderer** — there is no wasm intrinsic for `Int.toString`, so the digits are produced explicitly. (This is a real codegen gap, named honestly; see the note below.)
+
+| (f)
+| Wire-message strings.
+| Kept **byte-identical**. The re-decomposition changes the *internal* shape, never the bytes that go out on the wire — parity (<<p-parity>>) depends on the externally observable output not moving.
+|===
+
+[NOTE]
+====
+Delta (e) is load-bearing, not an embarrassment. `Int.toString` has no wasm
+intrinsic, so a faithful port that called it would fail at codegen. The
+re-decomposition turns "call a stdlib function that doesn't lower" into "compute
+the digits with `/` and `%`" — integer arithmetic the wasm backend *does* emit.
+When you hit a stdlib function with no wasm lowering, the question is not "how do
+I make the stdlib function work" but "what is the integer computation underneath
+it." That reframing is the whole pattern.
+====
+
+==== Second verified example — `Kernel_IO`: keep the data as it already is
+
+`Kernel_IO` does a sandbox check: in ReScript it decodes ASCII bytes to a
+`String` and then calls `String.startsWith` for a prefix test. The naïve port
+inherits the String backend — which AffineScript's wasm target does not yet
+fully provide (see <<p-string-abi>>). The re-decomposition observes that **the
+data already IS an `Int` array** (the bytes), and does an **integer-array prefix
+comparison** directly:
+
+[source,affine]
+----
+// Sandbox prefix check, re-decomposed: the bytes never become a String.
+// Compare the first `prefix.length` elements of `data` against `prefix`.
+fn has_prefix(data: ref Array[Int], prefix: ref Array[Int]) -> Bool {
+  if Array.length(prefix) > Array.length(data) {
+    false
+  } else {
+    let mut i: Int = 0;
+    let mut ok: Bool = true;
+    // (loop omitted) compare data[i] == prefix[i] for i in 0..prefix.length
+    ok
+  }
+}
+----
+
+The decode-to-String + `String.startsWith` step is *deleted*, not ported. This
+sidesteps the string-backend gap entirely — which is exactly the point: the
+cheapest String ABI is the one you never invoke because the data was integers
+all along. This is Pattern 1 in reverse: rather than encode a value down to an
+integer, you *notice it was never anything but integers* and stop lifting it to
+a String.
+
+[#p-parity]
+=== Pattern 3 — Differential parity as the acceptance bar
+
+A co-processor port is *done* when two conditions both hold:
+
+. **Build-green** — the `.affine` compiles to wasm host-native.
+. **Parity-green** — the wasm output matches an *independent oracle* across a
+  sweep of inputs, including out-of-band ones.
+
+Build-green alone is not acceptance. A module that compiles but computes the
+wrong band has passed the compiler and failed the contract. The oracle is a
+*separate* implementation of the documented contract — written from the spec,
+not from the `.affine` — so that agreement is evidence and not tautology.
+
+==== The host-native compile + parity loop
+
+[source,bash]
+----
+# 1. Compile .affine to wasm, host-native (no container):
+affinescript compile SecurityRank.affine -o SecurityRank.wasm
+#    or, from a compiler checkout:
+# dune exec affinescript -- compile SecurityRank.affine -o SecurityRank.wasm
+
+# 2. Instantiate the wasm (WASI fd_write stub) and call the exports.
+# 3. For each input in a sweep (incl. out-of-band: -5, 4, 9999, ...),
+#    compare wasm rank_security_level(v) against an INDEPENDENT oracle
+#    implementing the documented 0..3 contract. Any mismatch fails.
+----
+
+The verified result: the `SecurityRank` parity harness ran **78/78 green**
+against a JS oracle of the documented `0..3` contract — every input, in-band and
+out-of-band, agreed.
+
+[IMPORTANT]
+====
+**Host-native, not containerized — the 2026-06-03 reanchor.** The existing
+idaptik harnesses (`vm/tests/*_diff.ts`) still shell out to a *retired*
+`idaptik-affinescript-build:latest` podman container. That container was retired
+in the 2026-06-03 reanchor in favour of running the toolchain host-native
+(guix/nix dev shell + `affinescript` on `PATH`). **New harnesses must call the
+host compiler directly** — `affinescript compile …` (or `dune exec affinescript
+-- compile …`) — not the container. If you are copying an older `*_diff.ts`
+harness, replace the container invocation with the host-native form above before
+relying on it.
+====
+
+==== Why an *independent* oracle
+
+If the oracle were generated from the same `.affine`, parity would only prove the
+compiler is deterministic — not that the kernel is correct. The oracle's job is to
+encode the *contract* (here: "clamp to `0..3`, fail-... see <<p-certify>> for the
+direction") from the human-readable spec. Disagreement then localises a real bug:
+either the `.affine` is wrong, the oracle is wrong, or the spec is ambiguous —
+all three are worth discovering, and all three are invisible to a build-green-only
+gate.
+
+[#p-string-abi]
+=== Pattern 4 — The String host-boundary ABI
+
+Patterns 1 and 2 work hard to keep strings host-side precisely because, when a
+string *must* cross the wasm boundary, there is a concrete ABI to honour. Document
+it once; reach for it only when integerization genuinely cannot avoid it.
+
+==== Wire format
+
+A string crossing the boundary is laid out in linear memory as:
+
+----
+[ len : i32, little-endian ][ utf8 bytes … ]
+----
+
+The 4-byte little-endian length prefix precedes the raw UTF-8 bytes. There is no
+trailing NUL; the length is authoritative.
+
+==== The exported bump allocator
+
+So the host can reserve the right amount of linear memory (and not collide with
+the module's own literal/heap storage), the codegen **exports a bump allocator**:
+
+[source,affine]
+----
+// Exported by codegen; the host calls this to reserve `n` bytes and
+// gets back the offset to write into.
+__affine_alloc(n: i32) -> i32
+----
+
+[NOTE]
+====
+`__affine_alloc` **replaced an earlier fixed scratch offset of `8192`**. The
+fixed offset could collide with literal or heap storage once a module grew past
+it — a silent corruption hazard. The exported allocator lets the host ask the
+module where it is safe to write, instead of guessing. If you see `8192` hard-coded
+as a scratch base in an older harness, that is the superseded pattern; use
+`__affine_alloc`.
+====
+
+==== Host helpers and instantiation
+
+The host side supplies two helpers and a WASI stub:
+
+[source]
+----
+readString(mem, ptr)      // read [len][utf8] at `ptr` out of wasm memory
+writeString(mem, at, s)   // lay s out as [len][utf8] at offset `at`
+// Instantiate with a WASI fd_write stub (the only import SecurityRank needs).
+----
+
+==== Calling back into the host, and exporting
+
+Two declaration forms complete the boundary:
+
+[source,affine]
+----
+// Let the wasm core call back into a host-provided string function:
+extern fn host_x(s: String) -> String;
+
+// Export an AffineScript function to the host:
+pub fn handle(s: String) -> String { /* … */ }
+----
+
+`extern fn host_x(s: String) -> String;` is the wasm→host call (the host
+implements `host_x`); `pub fn` is the host→wasm export. This is the same
+`extern` machinery the link:effects-migration-stance.adoc[Effects Migration
+Stance] uses for its interim FFI posture — here it carries strings rather than
+effects, but the mechanism is identical.
+
+[#p-no-load-effects]
+=== Pattern 5 — No module-load side-effects → explicit threading / registration
+
+AffineScript modules **do not run code at load time**. There is no implicit
+module-load-time hook in wasm to attach a side effect to. ReScript/JS code that
+relies on `let _ = X.foo()` at module scope, or that reads `Date.now()` /
+`Console.log` ambiently, has nowhere to put that behaviour after the port — *until*
+extensible-effect handling codegen lands.
+
+==== The verified counter-example — `Kernel_Quantum`
+
+`Kernel_Quantum` is the cautionary case. It carries module-level mutable `Dict`
+state (`lastQuantumOp`), and reaches for `Date.now` and `Console.log` directly.
+All three hit the **effect-codegen wall**: `Kernel_Compute.affine` documents that
+effect codegen currently *"references an unbound binding"* and cannot yet lower to
+wasm. A faithful port of `Kernel_Quantum` therefore does not compile to wasm at
+all.
+
+==== The pattern
+
+Until extensible-effect codegen lands, thread the three offending capabilities as
+**explicit parameters** (or supply them through explicit registration functions):
+
+[cols="1,2"]
+|===
+| Module-load side-effect | Re-decomposition
+
+| Module-level mutable `Dict` (`lastQuantumOp`)
+| Pass the state in and return the updated state out — `fn step(state: own QuantumState, …) -> own QuantumState`. The caller owns the cell. (Same logic as `mut` vs `State` in <<decision-criteria>>, pushed to its threaded extreme.)
+
+| `Date.now()`
+| A `now: Int` parameter supplied by the host (the senses read the clock; the brain receives the reading).
+
+| `Console.log(…)`
+| Either an `extern fn host_log(s: String);` the host implements, or a returned log payload the host emits. Do not log from inside the kernel.
+|===
+
+This mirrors the link:effects-migration-stance.adoc[Effects Migration Stance]'s
+interim posture and the AI companion's `no-side-effect-imports` rule:
+_"There is no implicit module-load-time side effect to hook in wasm."_ The
+threaded form is also forward-compatible — when effect handling ships, the
+threaded parameters become the obvious sites for `State` / `IO` handlers.
+
+[#p-certify]
+=== Pattern 6 — Certifying the boundary
+
+[sidebar]
+.The integerization is a theorem, not just a convention
+****
+"The integer IS the X" reads like a slogan, but it is precisely an
+**encoding-faithfulness theorem**, and it has been machine-checked. The
+echo-types module `EchoEncodingFaithfulness.agda` — staged in this repo at
+link:../../proposals/echo-types/README.adoc[`proposals/echo-types/`] — proves
+the two halves of the slogan under `--safe --without-K`, zero postulates:
+
+* **Lossless** — if the host-boundary encoder `enc : X → Int` is **injective**,
+  the integer faithfully names the X (every code determines its `X` uniquely).
+  This is the "the integer IS the X" half, proved.
+* **Controlled loss** — a **collision / clamp** is *provable, localised loss
+  with no decoder* (`clamp-sentinel-no-section`): when two distinct values share
+  a code, no `decode : Int → X` can recover the lost distinction.
+
+SecurityRank's clamp — `Invalid(v) => if v < 0 { 0 } else { 3 }` (the band-normalisation
+in `rank_security_level`) — is **exactly that certified hazard**: out-of-band
+inputs collide onto a code that also names a valid rank, so the sentinel fibre
+provably has no section.
+
+**The security nuance the clamp direction encodes.** For a *minimum-security
+filter*, the clamp direction is a real security decision, not a cosmetic one:
+
+* Clamping high garbage **up to `Strong` (3)** is **fail-open** — a malformed
+  "very privileged" input is treated as maximally privileged.
+* Clamping low garbage **down to `Open` (0)** is **fail-closed** — a malformed
+  input is treated as least privileged.
+
+For a `passes_min_security` gate, fail-closed is the safe default; fail-open lets
+garbage through. The clamp direction is therefore a teaching point: the proof
+tells you the loss is *localised and decoderless*, and the security review tells
+you *which direction the loss must go*. Cross-link:
+link:../../proposals/echo-types/README.adoc[`proposals/echo-types/README.adoc`].
+****
+
+[NOTE]
+====
+**Division of labour — what the proof does NOT cover.** The faithfulness theorem
+certifies the *encoding model* carries no hidden collision. It says *nothing*
+about whether the deployed wasm kernel bit-for-bit implements that encoding —
+that is <<p-parity>>'s job. The proof and the parity harness are complementary:
+the proof certifies the integer model is faithful *in principle*; the harness
+certifies the wasm implements that model *in practice*. Neither subsumes the
+other.
+====
+
 == Lessons from Real Migrations
 
 Case studies from in-flight migrations land in link:lessons/migrations/[`docs/guides/lessons/migrations/`]. (The sibling `lessons/` folder is the 10-lesson tutorial track for new AffineScript users — different audience.)
@@ -351,9 +777,11 @@ If you complete a non-trivial `.res → .affine` translation and the re-decompos
 
 == See Also
 
-* link:frontier-guide.adoc[Frontier Guide: The Unveiling] — the *what* and *why* of AffineScript's design.
-* link:frontier-programming-practices/Human_Programming_Guide.adoc[Frontier Programming Practices] — the wider design philosophy.
-* link:frontier-programming-practices/AI.a2ml[`AI.a2ml`] — machine-readable companion, read by AI agents at session start.
+* link:frontier-guide.adoc[Frontier Guide: The Unveiling] — the *what* and *why* of AffineScript's design; Chapter 9 introduces the co-processor mental model that <<coprocessor-integerization>> operationalises.
+* link:frontier-programming-practices/Human_Programming_Guide.adoc[Frontier Programming Practices] — the wider design philosophy, including the WASM Co-processor Model (the "brain / senses" framing).
+* link:frontier-programming-practices/AI.a2ml[`AI.a2ml`] — machine-readable companion, read by AI agents at session start; carries the machine-readable stanzas for the <<coprocessor-integerization>> patterns.
+* link:effects-migration-stance.adoc[Effects Migration Stance] — the interim `extern fn` FFI posture used by the String ABI (<<p-string-abi>>) and the threaded-effects pattern (<<p-no-load-effects>>).
+* link:../../proposals/echo-types/README.adoc[`proposals/echo-types/` — EchoEncodingFaithfulness] — the machine-checked proof that certifies the boundary (<<p-certify>>).
 * link:../specs/SETTLED-DECISIONS.adoc[Settled Decisions] — architectural choices and why they were made.
 * link:../specs/SPEC.adoc[Language Specification] — authoritative grammar and semantics.
 
@@ -379,4 +807,8 @@ If you complete a non-trivial `.res → .affine` translation and the re-decompos
 | 1.3
 | 2026-05-18
 | New `<<portable-http>>` recipe for the C-spine `Http` stdlib primitive (issue #160): ReScript `fetch`/`Js.Promise` → typed `Request`/`Response` with a `/ { Net, Async }` effect row. Deno-ESM target landed and exercised end-to-end; typed-wasm target tracked as the next slice (convergence ABI shared with Ephapax). No existing guidance changed.
+
+| 1.4
+| 2026-06-04
+| New `<<coprocessor-integerization>>` section — six verified, named patterns for the ReScript → AffineScript → wasm co-processor port, grounded in the in-flight idaptik migration: (1) *the integer IS the X* (verified: `SecurityRank.affine`, 454-byte wasm, `0..3` rank encoding); (2) *re-decompose, don't transliterate* (verified deltas from `Kernel_Compute.affine` + the `Kernel_IO` int-array prefix-check); (3) *differential parity as the acceptance bar* (verified: 78/78 green; host-native compile per the 2026-06-03 reanchor, not the retired podman container); (4) *the String host-boundary ABI* (`[len][utf8]`, `__affine_alloc` replacing the fixed `8192` scratch offset, host read/write helpers, `extern fn`/`pub fn`); (5) *no module-load side-effects* (verified counter-example: `Kernel_Quantum` hits the effect-codegen wall; thread state/time/log explicitly); (6) *certifying the boundary* (the `EchoEncodingFaithfulness.agda` faithfulness theorem + the clamp-direction fail-open/fail-closed security nuance). The `<<the-cardinal-rule>>` heading gains an explicit anchor. No existing guidance changed.
 |===

--- a/proposals/README.adoc
+++ b/proposals/README.adoc
@@ -35,25 +35,43 @@ land it.
 
 | `idaptik/`
 | `hyperpolymath/idaptik`
-| _pending_
-| The kernel migration(s) (ReScript -> AffineScript) as a reviewable
-  case-study / patch, with their differential-parity harnesses.
+| *Verified*
+| Two worked, verified coprocessor ports + one honest non-port:
+  `Kernel_IO` (fresh re-decomposition, compiles to wasm, logic 6/6 green),
+  `SecurityRank` (existing port, differential parity 78/78 green + proof
+  tie-in), `Kernel_Quantum` (documented effect-codegen-wall non-migration).
 
 | `standards/`
 | `hyperpolymath/standards`
-| _pending_
-| Estate-standards implications: the co-processor integerization +
-  differential-parity convention, the String host-boundary ABI, the
-  github-only-network install recipe, the `--deno-esm` / TS-0
-  exemption-table delta.
+| *Drafted*
+| Estate-standards implications with drafted normative text: the
+  integerization + differential-parity acceptance bar (AS-MIG-1/2), the
+  String host-boundary ABI spec (AS-ABI-STR-1), the github-only install
+  recipe (EST-CI-NET-1), the `--deno-esm`/TS-0 exemption-table amendment,
+  and a release-cadence-coupling note (EST-REL-PIN-1).
 
 | `toolchain/`
 | `hyperpolymath/affinescript` (compiler/roadmap) + estate
-| _pending_
-| Compiler/toolchain implications harvested from dogfooding: the
-  variable-string-backend gap, `--deno-esm` to retire the TS harnesses,
-  compiler-emitted Echo boundary obligations, release-cadence coupling.
+| *Drafted*
+| Six compiler/toolchain findings: the variable-string-backend gap (#1
+  leverage), compiler-emitted `@boundary` Echo obligations, `--deno-esm`
+  to retire the TS harnesses, the stale-harness finding, github-only
+  portability, release-cadence coupling — plus the interpreter/codegen
+  divergence bonus finding.
 |===
+
+== Not staged here (landed directly in affinescript)
+
+The **frontier-practices guide** development is first-class affinescript
+content, so it landed directly (not under `proposals/`):
+
+* `docs/guides/migration-playbook.adoc` — the systematic *Co-processor
+  Integerization* chapter (six named, verified patterns + pattern index).
+* `docs/guides/frontier-guide.adoc` — conceptual *Chapter 9: The
+  Co-processor and the Integer*.
+* `docs/guides/frontier-programming-practices/AI.a2ml` — the
+  machine-readable companion stanza (the bot-loaded session-start file),
+  so AI agents get the same patterns humans do.
 
 == Why staged-not-applied
 

--- a/proposals/idaptik/README.adoc
+++ b/proposals/idaptik/README.adoc
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Proposal: idaptik coprocessor migration — two worked, verified ports + one honest non-port
+:toc: macro
+:source-highlighter: rouge
+
+[IMPORTANT]
+====
+*Status: PROPOSAL, staged for review.* This document lives in the
+affinescript repo (MPL-2.0). Its subject — the `.affine` source below — is
+destined for *`hyperpolymath/idaptik`*, which is *AGPL-3.0-or-later*
+(shared-with-son). To keep the affinescript tree license-clean, the AGPL
+source is *embedded here in code blocks* (carrying its AGPL header) rather
+than dropped in as standalone `.affine` files; on acceptance it lands in
+`idaptik/shared/src/` with that header intact. Everything below was
+compiled and run *host-native* this session (no retired container).
+====
+
+toc::[]
+
+== What this is
+
+Practising the idaptik ReScript -> AffineScript -> wasm migration for real,
+end to end, with the host-native toolchain. Three artefacts:
+
+[cols="1,3a",options="header"]
+|===
+| Artefact | Outcome
+| **A. `Kernel_IO`** — a *fresh* re-decomposition migration | Compiles to wasm; logic verified 6/6 through the wasm. A clean win that *deletes* the string step rather than porting it.
+| **B. `SecurityRank`** — verify the *existing* migration + tie it to the proof | Differential parity **78/78 green**; the clamp it performs is certified by the echo-types module as controlled loss.
+| **C. `Kernel_Quantum`** — an honest *non*-migration | Documented as blocked on the effect-codegen wall, with the re-decomposition path it needs.
+|===
+
+The through-line: the migration front has advanced *exactly* as far as the
+compiler's current capabilities reach (Compute, Crypto, SecurityRank,
+PortNames — done) and stalled *exactly* where they don't (IO needs the
+string backend, Quantum needs effect codegen). That boundary is the story.
+
+== A. `Kernel_IO` — re-decompose, don't transliterate
+
+=== The problem
+
+`shared/src/Kernel_IO.res` enforces a per-device path sandbox. Its check
+*decodes* the ASCII byte array into a `String` and then uses
+`String.length` + `String.startsWith`:
+
+[source,rescript]
+----
+let path = decodePathForCheck(data)            // [int] -> String, byte by byte
+String.length(path) == 0 || path == root || String.startsWith(path, root ++ "/")
+----
+
+AffineScript's variable-string backend cannot lower `String.fromCharCode`
+/ `String.length` / `String.startsWith` to wasm today. A 1:1
+transliteration is therefore *stuck*.
+
+=== The re-decomposition
+
+The data already *is* an `Int` array, and "is this path inside the
+sandbox?" is a statement about byte sequences, not Strings. So we keep
+everything as `Int` arrays and compute the prefix relationship
+arithmetically. The host (which holds the `deviceId` string) computes the
+root bytes `"/sandbox/<deviceId>"` once and passes them in; *only integers
+cross the boundary*. No String op is needed anywhere. This is the
+"brain/senses" split made concrete: the senses (string) stay host-side;
+the brain (the prefix arithmetic) is the wasm.
+
+The load-bearing subtlety — kept byte-identical to the `.res` — is the
+separator clause: `path == root OR startsWith(path, root ++ "/")`. A raw
+prefix test would wrongly admit `/sandbox/dev10` into device `dev1`'s
+sandbox; the explicit "next byte is `/` (47)" check keeps it out.
+
+=== The source (drops into `idaptik/shared/src/Kernel_IO.affine`)
+
+[source,affine]
+----
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Kernel_IO.affine -- pure-integer device sandbox check, re-decomposed from
+// shared/src/Kernel_IO.res. The .res decoded ASCII bytes to a String then used
+// String.startsWith; AffineScript's variable-string backend can't lower that.
+// But the data already IS an Int array, so we compare Int arrays directly --
+// no String op crosses the boundary. The host computes "/sandbox/<deviceId>"
+// and passes the bytes; only integers cross.
+
+fn array_len(xs: [Int]) -> Int {
+  let mut n = 0;
+  for x in xs { n = n + 1; }
+  n
+}
+
+// Path length = bytes before the first 0 (write packs [path, 0, content];
+// other commands' data IS the bare path). Same thing decodePathForCheck did.
+fn path_len(data: [Int]) -> Int {
+  let mut i = 0;
+  let mut live = 1;
+  for b in data {
+    let isnull = if b == 0 { 1 } else { 0 };
+    let inc = if live == 1 { if isnull == 1 { 0 } else { 1 } } else { 0 };
+    i = i + inc;
+    live = if isnull == 1 { 0 } else { live };
+  }
+  i
+}
+
+// k-th byte (guarded callers keep k in range; the 0 default is never observed).
+fn nth(xs: [Int], k: Int) -> Int {
+  let mut out = 0;
+  let mut i = 0;
+  for x in xs {
+    out = if i == k { x } else { out };
+    i = i + 1;
+  }
+  out
+}
+
+// Do the first n bytes of path equal the first n bytes of root? (No startsWith.)
+fn prefix_eq(path: [Int], root: [Int], n: Int) -> Int {
+  let mut bad = 0;
+  let mut i = 0;
+  for r in root {
+    let mism = if i < n { if r == nth(path, i) { 0 } else { 1 } } else { 0 };
+    bad = bad + mism;
+    i = i + 1;
+  }
+  if bad == 0 { 1 } else { 0 }
+}
+
+// 1 = inside the device sandbox, 0 = forbidden (403). data = command payload,
+// root = host-computed "/sandbox/<deviceId>" bytes.
+pub fn in_sandbox(data: [Int], root: [Int]) -> Int {
+  let pl = path_len(data);
+  let rl = array_len(root);
+  if pl == 0 {
+    1
+  } else {
+    if pl < rl {
+      0
+    } else {
+      if prefix_eq(data, root, rl) == 1 {
+        if pl == rl {
+          1
+        } else {
+          if nth(data, rl) == 47 { 1 } else { 0 }
+        }
+      } else {
+        0
+      }
+    }
+  }
+}
+----
+
+(The full artefact also carries a `pub fn main()` that runs six scenarios
+against their expected verdicts and returns the pass count — the embedded
+self-check used for verification below.)
+
+=== Verification (host-native, this session)
+
+[source,console]
+----
+$ dune exec affinescript -- compile Kernel_IO.affine -o kernel_io.wasm
+Compiled Kernel_IO.affine -> kernel_io.wasm (WASM)          # 2262 bytes
+$ deno eval '...instantiate kernel_io.wasm; print main()...'
+main() = 6   -- ALL 6 SANDBOX SCENARIOS GREEN
+----
+
+The six scenarios (oracle baked into `main`): exact root -> IN; `root +
+"/file"` -> IN; different device `dev2` -> OUT; `/etc/passwd` -> OUT;
+empty path -> IN; **`/sandbox/dev10` (prefix without separator) -> OUT**.
+All six match. The logic is verified through the *wasm* — the deployment
+target — not merely argued.
+
+[WARNING]
+====
+*Compiler-quality finding (interpreter vs codegen divergence).* The same
+source, run through `affinescript -- eval` (the interpreter), raised
+`Runtime error: Type mismatch: Expected mutable reference` on the
+`x = if c { a } else { x }` self-referential `let mut` reassignment — while
+`affinescript -- compile` (the wasm codegen) accepted it and produced a
+correct module. The interpreter and the wasm backend disagree on this
+shape. Filed as a toolchain finding (`proposals/toolchain/`, bonus
+finding) with a suggested regression test feeding the shape to
+`Interp.eval_program`.
+====
+
+=== Re-decomposition deltas (what changed, and why)
+
+[cols="1,2a",options="header"]
+|===
+| ReScript shape | AffineScript re-decomposition
+| `decodePathForCheck : [int] -> String` then `String.startsWith` | *deleted*; compare `Int` arrays directly (`prefix_eq`), so no variable-string op is needed.
+| `String.length(path)` | `path_len` (scan to the first 0 byte) over the `Int` array.
+| `path == root \|\| startsWith(path, root ++ "/")` | `prefix_eq` + an explicit separator check `nth(data, rl) == 47`.
+| host holds `deviceId`; kernel re-derives root | host computes the root bytes once and passes them; only integers cross.
+| `let root = ...` reused freely | each call constructs its own root — an owned `[Int]` is an *affine resource* and cannot be casually aliased (a real lesson the type system enforces).
+|===
+
+== B. `SecurityRank` — verified parity + the proof made flesh
+
+`vm/coprocessor/SecurityRank.affine` is already migrated. Its own header
+says *"the encoding IS the rank"*: the 4 ranks Open/Weak/Medium/Strong map
+to the canonical `0..3` integer encoding, and `rank_security_level` clamps
+out-of-band input to the band (`Invalid(v) => if v < 0 { 0 } else { 3 }`).
+It compiles host-native to a 454-byte wasm (exports `rank_security_level`,
+`passes_min_security`; only WASI import is `fd_write`).
+
+=== The differential parity harness (host-native; drops into idaptik tests)
+
+[source,javascript]
+----
+// SecurityRank differential parity: independent JS oracle vs AffineScript wasm.
+const bytes = await Deno.readFile("securityrank.wasm");
+const stub = () => 0;
+const { instance } = await WebAssembly.instantiate(bytes, { wasi_snapshot_preview1: {
+  fd_write: () => 0, proc_exit: () => {}, fd_close: stub, fd_seek: stub, fd_read: stub,
+  environ_sizes_get: stub, environ_get: stub, args_sizes_get: stub, args_get: stub, clock_time_get: stub,
+}});
+const rank = instance.exports.rank_security_level;
+const passes = instance.exports.passes_min_security;
+// Oracle = the documented contract: 0..3 identity; out-of-band clamps (v<0 -> 0 else -> 3).
+const oracleRank = (lv) => (lv===0?0:lv===1?1:lv===2?2:lv===3?3:(lv<0?0:3));
+const oraclePasses = (dl, th) => (oracleRank(dl) >= oracleRank(th) ? 1 : 0);
+let pass = 0, fail = 0;
+const check = (n, got, exp) => { got===exp ? pass++ : (fail++, console.log(`FAIL ${n}`)); };
+for (let lv = -5; lv <= 8; lv++) check(`rank(${lv})`, rank(lv), oracleRank(lv));
+for (let dl = -2; dl <= 5; dl++) for (let th = -2; th <= 5; th++)
+  check(`passes(${dl},${th})`, passes(dl, th), oraclePasses(dl, th));
+console.log(`SecurityRank parity: ${pass}/${pass+fail}` + (fail ? ` FAILED` : "  -- ALL GREEN"));
+----
+
+Result this session: **78/78 checks pass, ALL GREEN.**
+
+=== The clamp is the proof's clamp-sentinel (certified)
+
+`SecurityRank`'s clamp is exactly the hazard `EchoEncodingFaithfulness.agda`
+(`proposals/echo-types/`) certifies as `clamp-sentinel-no-section`.
+Demonstrated live:
+
+----
+rank(-5) = 0 = rank(0)    -> Open and an out-of-band negative both collapse to 0
+rank(99) = 3 = rank(3)    -> Strong and an out-of-band high value both collapse to 3
+=> the integer alone cannot distinguish in-band from clamped input: provable, localised loss.
+----
+
+=== Security nuance (a refactoring observation, not a bug claim)
+
+The clamp is *asymmetric*: low-garbage clamps DOWN to `Open(0)` (a device
+with a garbage-low level fails a min-security filter — *fail-closed*),
+while high-garbage clamps UP to `Strong(3)` (a device with a garbage-high
+level *passes* a `Strong` threshold — *fail-open*). For the
+`passes_min_security` predicate, the fail-open direction is the one worth a
+second look: a malformed-high `device_level` reads as maximally secure. If
+the intended posture is fail-closed on *any* malformed input, the
+high-garbage arm should clamp to `Open`, not `Strong`. This is precisely
+the kind of decision the `@boundary(clamp = …)` annotation
+(`proposals/toolchain/` Finding 2) would force an author to make
+explicitly rather than inherit silently.
+
+== C. `Kernel_Quantum` — the honest non-migration (the effect-codegen wall)
+
+`shared/src/Kernel_Quantum.res` cannot be migrated today, and pretending
+otherwise would be dishonest. It carries:
+
+* *module-level mutable state* — `let lastQuantumOp: Dict.t<float> = Dict.make()` (per-device cooldown timestamps);
+* *a wall-clock effect* — `Date.now` (cooldown elapsed-time);
+* *a logging effect* — `Console.log` (the quantum audit line).
+
+`Kernel_Compute.affine` documents the wall directly: effect codegen
+"references an unbound binding" and cannot lower to wasm. So the
+re-decomposition path is known but *blocked on the compiler*:
+
+. thread the cooldown state and the current timestamp as *explicit
+  parameters* (`activeCooldownMs`, `nowMs`) the way `Kernel_Compute`
+  threaded `activeCalls` — the pure decision (decohered? in cooldown?)
+  becomes a pure-integer function;
+. surface the audit line as a *returned value* the host logs, not an
+  in-kernel `Console.log`;
+. promote (1) and (2) to true extensible effects once effect codegen
+  lands.
+
+Until then the honest status is **compiler-gated, not effort-gated**.
+
+== Lessons learned (the point of the exercise)
+
+. **Re-decompose, don't transliterate — and sometimes that means
+  *deleting*.** The best `Kernel_IO` move was not porting `String.startsWith`
+  but removing the String entirely. The gap forced a *better* design (the
+  data was always an `Int` array).
+. **Affine types forbid casual aliasing.** An owned `[Int]` can't be reused
+  across calls the way a ReScript `let root = …` can; you construct per use.
+  Surprising at first, correct on reflection.
+. **Verify through the wasm, not the interpreter.** The interpreter has at
+  least one `let mut` self-reassignment bug the codegen doesn't; the wasm is
+  the deployment target and the source of truth for acceptance.
+. **Host-native, not the retired container.** Every compile here was
+  `affinescript -- compile` directly, per the 2026-06-03 reanchor. The
+  in-tree idaptik harnesses still shell out to the retired
+  `idaptik-affinescript-build` podman image and need updating
+  (`proposals/toolchain/` Finding 4).
+. **The two compiler walls *are* the migration frontier.** IO is gated on
+  the variable-string backend; Quantum on effect codegen. Naming the walls
+  turns "two kernels left" into a precise, schedulable roadmap.
+
+== Reproduce it
+
+[source,console]
+----
+# compiler (host-native, github-only network): apt OCaml deps, no opam (see proposals/toolchain/)
+$ dune exec --root <affinescript> affinescript -- compile Kernel_IO.affine -o kernel_io.wasm
+$ deno eval '...instantiate; main()...'        # -> 6
+$ dune exec --root <affinescript> affinescript -- compile SecurityRank.affine -o securityrank.wasm
+$ deno run --allow-read sr_parity.mjs          # -> 78/78 ALL GREEN
+----
+
+== Provenance
+
+Produced in the 2026-06-04 AffineScript co-development session. The
+`Kernel_IO.affine` re-decomposition is new work authored this session; the
+`SecurityRank` parity harness and proof tie-in are new; `Kernel_Quantum`'s
+non-migration is a documented finding. Target repo: `hyperpolymath/idaptik`
+(AGPL-3.0-or-later). Nothing was written into idaptik.

--- a/proposals/standards/README.adoc
+++ b/proposals/standards/README.adoc
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Proposal: estate-standards implications of the AffineScript dogfooding run
+:toc: macro
+:source-highlighter: rouge
+
+[IMPORTANT]
+====
+*Status: PROPOSAL for owner review. NOT an edit.* This document is staged
+*in the affinescript repo* (`proposals/standards/`, MPL-2.0) even though
+its subject matter targets *`hyperpolymath/standards`*. It is deliberately
+*not* written into the standards repo: estate policy forbids automated
+cross-repo sweeps and requires per-repo human acceptance (see the standards
+repo's license-policy + no-automated-edits guardrails). Every normative
+paragraph below is *drafted* for the owner to lift, revise, or reject — it
+is not in force anywhere. Nothing here changes any repo's behaviour until
+the owner manually applies it to the standards repo.
+====
+
+toc::[]
+
+== One-paragraph summary
+
+The idaptik AffineScript migration exercised five things that are
+currently per-repo folklore but read like *estate standards*: (1) the
+co-processor integerization + differential-parity acceptance bar; (2) the
+String host-boundary ABI (one ABI, not reinvented per repo); (3) the
+github-only install recipe as CI guidance; (4) the `--deno-esm` / TS-0
+implication and its interaction with the TypeScript exemption tables; and
+(5) a release-cadence-coupling note. Each section below states the
+*proposed normative text* in standards-repo voice, plus where it belongs.
+
+== Item 1 — Co-processor integerization + the differential-parity acceptance bar
+
+=== Should this be estate standard guidance?
+
+*Yes, as guidance (SHOULD), scoped to AffineScript-compiled-to-wasm
+migrations.* The pattern is now backed by a machine-checked proof
+(`proposals/echo-types/EchoEncodingFaithfulness.agda`, `--safe
+--without-K`, zero postulates), so it is no longer a convention resting on
+intuition — the soundness of "the integer IS the X" and the
+clamp-to-sentinel hazard are both certified.
+
+=== Where it belongs
+
+`hyperpolymath/standards`, in a new *AffineScript migration practices*
+section of the language-policy / migration guidance (adjacent to the
+existing ReScript/TS exemption material, since it governs the same
+RS/TS -> AffineScript -> typed-wasm pipeline).
+
+=== Proposed normative text
+
+[quote]
+____
+*AS-MIG-1 (Co-processor integerization).* When migrating a host-side
+enumerated or stringly-typed value `X` to an AffineScript wasm kernel that
+computes on an integer encoding (`enc : X -> i32`), the encoding SHOULD be
+*either* provably injective (lossless — the integer faithfully names the
+X) *or* an explicitly declared clamp-with-sentinel (acknowledged,
+localised, controlled loss). A *silent* collapse of out-of-band input onto
+a sentinel that also names a valid value (e.g. defaulting a bad input to
+`0`) is a defect, not a design choice. The soundness of this dichotomy is
+certified by `EchoEncodingFaithfulness` in `hyperpolymath/echo-types`.
+
+*AS-MIG-2 (Differential-parity acceptance bar).* A kernel migration is NOT
+"done" on the strength of an injectivity/loss argument alone. Acceptance
+REQUIRES a *differential-parity harness*: run the host-side reference and
+the deployed wasm on the same input vectors and assert identical output.
+The proof certifies the *model* (no hidden collision); the harness
+certifies the *lowering* (the wasm bit-for-bit implements the model).
+Neither subsumes the other; both are required for sign-off.
+____
+
+[NOTE]
+====
+AS-MIG-2 has a direct toolchain consequence covered in
+`proposals/toolchain/` Findings 3-4: parity harnesses SHOULD be authored
+in AffineScript and compiled via `--deno-esm` (not TypeScript), and MUST
+NOT depend on the retired `idaptik-affinescript-build` podman container
+(host-native `affinescript` only, per the 2026-06-03 idaptik reanchor).
+====
+
+== Item 2 — The String host-boundary ABI as a blessed estate spec
+
+=== The problem it solves
+
+Every repo that crosses the AffineScript/host string boundary will
+otherwise invent its own marshalling. The dogfooding run already settled
+on *one* working ABI; blessing it estate-wide means *one spec, not N
+divergent ones*.
+
+=== The ABI (verified this session)
+
+* *Wire format:* `[len:i32 LE][utf8]` — a 4-byte little-endian length
+  prefix followed by the UTF-8 bytes.
+* *Allocation:* a wasm-exported bump allocator `__affine_alloc(n) ->
+  i32` returns an offset for `n` bytes. This *replaced* an earlier fixed
+  `8192` scratch offset that risked colliding with literal/heap storage —
+  so the allocator is the correct, collision-safe form and the fixed
+  offset is the anti-pattern.
+
+=== Where it belongs
+
+`hyperpolymath/standards`, as a short normative *ABI spec* under the
+AffineScript/typed-wasm interop material (it is a peer of, and feeds, the
+typed-wasm target spec). It should be the *single* referent for any repo
+doing String boundary marshalling.
+
+=== Proposed normative text
+
+[quote]
+____
+*AS-ABI-STR-1 (String host-boundary ABI).* AffineScript wasm modules that
+exchange strings with a host MUST use the canonical wire format
+`[len:i32 LE][utf8]`: a 32-bit little-endian byte-length immediately
+followed by the UTF-8 payload. Host-side buffers for strings passed *into*
+wasm MUST be obtained from the module's exported bump allocator,
+`__affine_alloc(n: i32) -> i32`, which returns a byte offset for `n` bytes
+of scratch. Modules MUST NOT use a hard-coded scratch offset (the
+historical fixed `8192` offset is deprecated: it can collide with literal
+and heap storage). Repos crossing the String boundary SHOULD reference
+this spec rather than re-deriving a marshalling convention.
+____
+
+[NOTE]
+====
+This ABI is the *read-side* prerequisite for the variable-string backend
+(`proposals/toolchain/` Finding 1): once `String.length`/indexing land,
+they consume strings already laid out in this format, and
+`String.fromCharCode` is the first primitive to *write* one via
+`__affine_alloc`. Blessing the ABI now de-risks that compiler work.
+====
+
+== Item 3 — The github-only install recipe as estate CI guidance
+
+=== The constraint (verified this session)
+
+The build network is *github-only*: `crates.io`, `deno.land`,
+`opam.ocaml.org`, and launchpad PPAs return *403*; `github.com` and
+`archive.ubuntu.com` are reachable. CI that assumes registry reachability
+will fail estate-wide, not just here.
+
+=== Where it belongs
+
+`hyperpolymath/standards`, in the CI/build guidance (peer to the existing
+"package management: Guix primary, Nix fallback, Deno for JS deps"
+material).
+
+=== Proposed normative text
+
+[quote]
+____
+*EST-CI-NET-1 (Registry-independent install).* Estate CI runs on a
+*github-only* network: package registries (`crates.io`, `deno.land`,
+`opam.ocaml.org`, launchpad PPAs) are unreachable (HTTP 403); only
+`github.com` and the OS package archive (`archive.ubuntu.com`) are
+reachable. CI workflows MUST NOT depend on language-registry reachability.
+Toolchains SHOULD be installed from the OS package manager (apt universe)
+or vendored/git-submoduled from `github.com`. The AffineScript compiler is
+the reference instance: it builds host-native from apt OCaml universe
+packages (`ocaml`, `dune`, `menhir`, `ocaml-findlib`, `libsedlex`/`yojson`/
+`fmt`/`cmdliner`/`ppx_deriving`/`ppx_sexp_conv`/`sexplib0`/`menhir`
+`-ocaml-dev`) with *no opam*, and `dune exec affinescript -- compile FILE
+-o OUT` emits valid wasm.
+
+*EST-CI-NET-1a (build-target narrowing).* Where a project's full default
+build pulls an optional registry-only dependency, CI SHOULD build the
+specific required target rather than the full default. Reference instance:
+the affinescript full `dune build` stops only on `js/playground.bc.js`
+(which needs the `js_of_ocaml` *binary*); building the compiler target
+directly avoids the stop with no loss of the shippable artefact.
+____
+
+== Item 4 — `--deno-esm` / TS-0 and the TypeScript exemption tables
+
+=== The implication
+
+`--deno-esm` (affinescript issue #122) emits a standalone Deno/Node ES
+module directly from the AST, lowering `extern fn` to direct host calls.
+That means *test harnesses and Deno-facing shims currently exempted as
+TypeScript could be authored in AffineScript and compiled to Deno-ESM* —
+which would let those exemptions reach a real unblock condition instead of
+sitting open indefinitely.
+
+=== Interaction with the existing exemption tables
+
+The standards repo's TypeScript-exemptions table (and the mirrored
+per-repo tables) carry a structural carve-out:
+
+* `affinescript-deno-test/**`, `affinescript-cli/**` — *"bootstrap shim:
+  bootstrap the AffineScript toolchain itself; unblock: when AffineScript
+  self-hosts these."*
+
+Today that unblock condition is *vague* ("when AffineScript self-hosts").
+`--deno-esm` makes it *concrete and testable*.
+
+=== Proposed amendment (exemption-table unblock condition)
+
+Replace the open-ended unblock condition on the
+`affinescript-deno-test/**` (and the affinescript repo's
+`affinescript-deno-test/*.ts`) TypeScript-exemption row with:
+
+[cols="1,3a",options="header"]
+|===
+| Path | Proposed unblock condition
+
+| `affinescript-deno-test/**`, `affinescript-cli/**`
+| *Tied to `--deno-esm` (affinescript issue #122).* The carve-out closes
+  when the AffineScript test harness / CLI shim is re-authored in
+  AffineScript and compiled via `affinescript ... --deno-esm`, producing
+  the Deno ES module these `.ts` files currently provide. The
+  `proposals/toolchain/` Finding 3 spike (re-author *one* migrated
+  kernel's parity harness in AffineScript -> Deno-ESM and reproduce the TS
+  verdict) is the *gating experiment*: a green spike converts this from
+  "indefinite carve-out" to "scheduled removal".
+|===
+
+[quote]
+____
+*AS-TS0-1 (TS-0 reachability).* Where a repo's only remaining TypeScript
+is differential-parity harnesses or Deno-facing shims, the repo SHOULD
+treat `--deno-esm` re-authoring as the path to *TypeScript = 0* rather
+than grandfathering the TS indefinitely. The idaptik migration is the
+reference case: ~17.6k LOC of TS parity harness is removable in principle
+via this route, which is the difference between a declared TS-0 and a real
+one.
+____
+
+[NOTE]
+====
+This is an *amendment proposal to existing tables*, not a new sweep.
+Per estate policy it requires explicit owner approval and a recorded
+unblock condition (which the text above supplies). The `.d.ts`
+declaration-file exemptions and the runtime carve-outs
+(`affinescript-cli/mod.js` distribution shim, `editors/vscode/test/**`
+smoke harness) are *unaffected* — they have permanent rationales and are
+not reachable by `--deno-esm`.
+====
+
+== Item 5 — Release-cadence-coupling note
+
+=== The fact
+
+The idaptik migration pins *affinescript v0.1.1*. The two unmigrated
+coprocessor kernels (*IO*, *Quantum*) are gated on *specific compiler
+capabilities*, not on migration effort: IO on the variable-string backend,
+Quantum on effect codegen (module-level mutable state / `Date.now` /
+`Console.log` cannot yet lower to wasm).
+
+=== Where it belongs
+
+`hyperpolymath/standards`, as a short *cross-repo release-coordination*
+note (peer to whatever version-pinning guidance the estate keeps).
+
+=== Proposed normative text
+
+[quote]
+____
+*EST-REL-PIN-1 (capability-gated migration honesty).* When a downstream
+repo pins a specific AffineScript compiler version for a migration, work
+that is blocked by an *absent compiler capability* (rather than by effort)
+MUST be recorded as *compiler-gated*, naming the capability and the
+gated unit. The pinned-version changelog is the coordination surface: the
+affinescript release that lands a gating capability SHOULD name the
+downstream unit it unblocks. Reference instance: idaptik pins affinescript
+v0.1.1 with 2/4 kernels migrated; `Kernel_IO` is gated on the
+variable-string backend and `Kernel_Quantum` on effect codegen — these are
+*compiler-gated, not stalled*, and SHOULD be labelled as such so a reader
+does not mistake a compiler wall for abandoned work.
+____
+
+== Cross-references
+
+* Toolchain-side companion: `proposals/toolchain/README.adoc` (this
+  session) — Findings 1 (string backend), 2 (`@boundary`), 3-4
+  (`--deno-esm` + stale harness), 5 (github-only build), 6 (cadence).
+* Soundness artefact: `proposals/echo-types/EchoEncodingFaithfulness.agda`
+  + its `README.adoc` — certifies AS-MIG-1's lossless/controlled-loss
+  dichotomy.
+* Worked migration: `proposals/idaptik/README.adoc` — `Kernel_IO`
+  re-decomposition + `SecurityRank` verified parity (the AS-MIG-1/2
+  reference instances).
+
+== Standing reminder (why these are proposals, not edits)
+
+Estate policy is firmly against bulk cross-repo sweeps; per-repo human
+acceptance is the rule, and license/normalisation findings are *flag-only*.
+This document is therefore a *flag with drafted text*: it gives the owner
+ready-to-lift normative paragraphs for `hyperpolymath/standards` but
+applies nothing. The owner reviews, edits, and lands each item manually
+into the standards repo.
+
+== Provenance
+
+Produced in the 2026-06-04 AffineScript co-development session by the
+estate-standards analyst, READ-ONLY, from session-verified facts. No repo
+was modified. This file is MPL-2.0 (it lives in the affinescript repo);
+its *target* is `hyperpolymath/standards`, which is itself MPL-2.0 as a
+sole-owner repo per the estate license classification.

--- a/proposals/toolchain/README.adoc
+++ b/proposals/toolchain/README.adoc
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Proposal: AffineScript compiler/toolchain implications harvested from the idaptik dogfooding run
+:toc: macro
+:source-highlighter: rouge
+
+[IMPORTANT]
+====
+*Status: PROPOSAL, staged for review.* This document lives in the
+affinescript repo (`proposals/toolchain/`) and is the compiler/roadmap
+half of the 2026-06-04 co-development session. Items (1), (2), (3) and
+(6) target *this* repo (`hyperpolymath/affinescript`) directly — they are
+roadmap/issue material. Item (5) is partly estate-facing (install recipe)
+and is mirrored in `proposals/standards/`. Nothing here has been written
+into the compiler, CI, or the roadmap; this is a reviewable artefact so
+the maintainer can accept, defer, or revise before anything lands.
+====
+
+toc::[]
+
+== One-paragraph summary
+
+Dogfooding the idaptik ReScript -> AffineScript -> wasm migration surfaced
+six concrete compiler/toolchain findings, ranked here by leverage. The
+single highest-leverage item is the *variable-string backend gap*: it is
+the reason the estate keeps strings host-side, and closing it unblocks the
+two remaining coprocessor kernels plus all of i18n. The other five are a
+verified-proof-backed *compiler-emitted boundary obligation*, a
+*`--deno-esm` spike to retire ~17.6k LOC of TypeScript parity harnesses*,
+the *stale-harness finding* (those harnesses are doubly stale — wrong
+runtime AND a retired podman container), an *ecosystem-portability recipe*
+for the github-only network, and a *release-cadence coupling* note pinning
+the IO/Quantum kernels to two specific compiler capabilities.
+
+[NOTE]
+====
+All facts below were confirmed in-session by running the tools, not
+inferred. Where a claim depends on a build outcome, the exact command and
+its result are stated. Two compiler facts were re-confirmed against the
+source while drafting this doc:
+
+* `--deno-esm` exists and is issue #122 — `bin/main.ml:1216-1226`,
+  wired in at `bin/main.ml:1576`. It selects the direct AST -> ES-module
+  backend (`Affinescript.Codegen_deno`), lowering `extern fn` to direct
+  host calls (`Deno.*Sync` / `JSON` / `WebAssembly`), `export class` for
+  struct+impl, `export` for public fns/consts. No wasm in that path.
+* The full default `dune build` fails *only* on `js/playground.bc.js`
+  (needs the `js_of_ocaml` *binary*); `dune exec affinescript -- compile
+  FILE -o OUT` builds and emits valid wasm with apt OCaml deps alone.
+====
+
+== Finding 1 — The variable-string backend gap (highest-leverage compiler work)
+
+=== What is true today
+
+AffineScript already supports, and the migrated kernels already use:
+
+* String *literals*;
+* `++` string *concatenation*;
+* String-*typed* parameters.
+
+Verified: `Kernel_Compute.affine` builds wire messages out of exactly
+these three. What is *not* yet supported is **variable-string
+operations** — the value-dependent primitives:
+
+* `String.fromCharCode` (int -> char/string);
+* `String.length`;
+* `String.startsWith` (and prefix/predicate matching generally);
+* string *indexing* / slicing.
+
+=== Why this is the load-bearing blocker
+
+This gap is *the* reason the estate keeps strings host-side. With only
+literals + `++` + string params, a kernel can *assemble* a message but
+cannot *inspect* or *compute over* one. Concretely it blocks or distorts:
+
+[cols="1,3a",options="header"]
+|===
+| Consumer | What the gap costs
+
+| `Kernel_IO`
+| The ASCII path-sandbox check needs `String.length` + indexing +
+  `startsWith` to validate a path purely in-wasm. (See
+  `proposals/idaptik/` — the re-decomposition sidesteps it by comparing
+  Int arrays directly, which *works today* but is a workaround the gap
+  forces.)
+
+| `DeviceType`
+| Stringly-typed device discrimination has to be integerized at the host
+  boundary (the "co-processor integerization" pattern) precisely because
+  the kernel cannot pattern-match the string itself.
+
+| All i18n
+| Any locale/format string handling needs `length` + indexing +
+  `fromCharCode`. With the gap, i18n stays host-side wholesale.
+|===
+
+=== Recommendation
+
+Treat the variable-string backend as the **#1 compiler roadmap item**,
+ahead of the cosmetic/ergonomic backlog. Sequence it as:
+
+. `String.length` + indexing (read-only, needs only the existing String
+  host-boundary ABI — see Finding 5 and Document B);
+. `startsWith` / prefix predicates (built on indexing);
+. `String.fromCharCode` (int -> string, the only one that *constructs*
+  variable string data and therefore exercises `__affine_alloc` on the
+  write path).
+
+The payoff is disproportionate: it is the gate on `Kernel_IO`,
+`DeviceType`, and i18n simultaneously, and it converts the
+integerize-at-boundary workaround from a *necessity* into an *option*.
+File as a tracking epic with the three sub-items above as the slices.
+
+== Finding 2 — Compiler-emitted Echo boundary obligations
+
+=== The link, now machine-checked
+
+The migration slogan *"the integer IS the X"* is an
+encoding-faithfulness theorem, and it is no longer folklore: the staged,
+typechecked Agda module `proposals/echo-types/EchoEncodingFaithfulness.agda`
+(`--safe --without-K`, zero postulates, zero funext; Agda 2.6.3 +
+agda-stdlib v2.3) certifies both halves —
+
+* *lossless* = `enc` injective => each fibre has a unique source
+  (`encoding-lossless`);
+* *controlled loss* = a collision (incl. the canonical
+  clamp-to-sentinel bug) => **no decoder section exists**
+  (`encoding-collision⇒no-section`, `clamp-sentinel-no-section`).
+
+That regularity is the opening for a compiler feature.
+
+=== Sketch: the `@boundary` annotation
+
+A boundary-annotated encoder
+
+[source,affine]
+----
+@boundary enc : X -> i32
+----
+
+would be required to discharge *one of two* obligations, mirroring the
+two proven halves:
+
+[cols="1,3a",options="header"]
+|===
+| Mode | Obligation | Echo shape it maps to
+
+| *Lossless* (default)
+| An **injectivity proof** for `enc` (or, for a finite enumerated `X`, a
+  compiler-discharged exhaustive distinctness check on the code table).
+  Compiler accepts: the integer faithfully names the X.
+| `encoding-lossless` (`injective-fibres-proj-unique`).
+
+| *Acknowledged controlled loss*
+| A **declared clamp-with-sentinel**: the author names the out-of-band
+  -> sentinel collapse explicitly (e.g. `@boundary(clamp = 0) enc : X ->
+  i32`). The compiler accepts the loss *because it was declared*, and can
+  emit the localised-residue note (loss lives at the sentinel code).
+| `clamp-sentinel-no-section` (the checked concrete instance in the
+  module).
+|===
+
+The point is symmetry with the proof: *either* you prove no collision,
+*or* you declare the one you are choosing to accept. A silent clamp (the
+"default a bad input to 0 / `Open`" hazard — which the idaptik
+`SecurityRank` kernel actually does) becomes a *compile error*, not a
+latent bug.
+
+=== Honest boundary (carried over from the proof's `NotProved-*` block)
+
+The proof certifies the encoding is faithful *in principle*; it says
+nothing about whether the deployed wasm *bit-for-bit implements* `enc`.
+That remains the **differential-parity harness's** job (Findings 3-4).
+So the `@boundary` obligation and the parity harness are complementary,
+not redundant — the obligation guards the *model*, the harness guards the
+*lowering*. The compiler feature should explicitly *not* be marketed as
+removing the harness.
+
+=== Recommendation
+
+Open a *design* issue (not an implementation issue) for `@boundary`,
+referencing the staged echo-types module as the soundness artefact. Scope
+the first cut to *finite enumerated* `X` (the idaptik `SecurityRank`
+`Open/Weak/Medium/Strong -> 0/1/2/3` case the module already instantiates
+as `Rank`), where injectivity is a decidable table check the compiler can
+discharge itself — no user-supplied proof term needed for the common case.
+
+== Finding 3 — `--deno-esm` to retire the TypeScript harnesses (spike proposal)
+
+=== The opportunity
+
+`--deno-esm` (issue #122, verified in `bin/main.ml`) already emits a
+standalone Deno/Node ES module directly from the AST. That means the
+differential-parity harnesses — currently TypeScript — *could be authored
+in AffineScript and compiled to Deno-ESM* instead. Doing so lets the
+idaptik migration reach **true TypeScript = 0** rather than declaring
+victory while carrying ~17.6k LOC of TS harness.
+
+=== Proposed spike (bounded, falsifiable)
+
+. Pick *one* already-migrated kernel with a parity harness — *Compute* or
+  *Crypto* (both migrated).
+. Re-author that single harness in AffineScript: run host-side `enc`/kernel
+  and wasm-side `enc`/kernel on the same input vectors, compare.
+. Compile it with `affinescript ... --deno-esm -o harness.js`.
+. Run it under Deno. Success criterion: the AffineScript-authored,
+  Deno-ESM-compiled harness reproduces the TS harness's pass/fail verdict
+  on the same vectors.
+
+=== What the spike tells us
+
+* *If it passes:* the TS harnesses are removable; the migration's TS-0
+  claim becomes real, and Document B's exemption-table unblock condition
+  (the `affinescript-deno-test/**` carve-out) can be tied to it.
+* *If it surfaces gaps* (e.g. the harness needs a string/JSON primitive
+  the `--deno-esm` path doesn't yet lower), those gaps are themselves
+  high-value roadmap signal — they are exactly the primitives a real
+  AffineScript test harness needs, and they likely overlap Finding 1.
+
+Either outcome is a win. Keep it to one kernel; do not convert the corpus
+on spec.
+
+== Finding 4 — The stale-harness finding (TS + retired podman container)
+
+=== What is wrong
+
+The idaptik differential-parity harnesses are *doubly* stale:
+
+. *Wrong runtime.* They are TypeScript (~17.6k LOC across idaptik) —
+  against the post-2026-05-25 policy that AffineScript is the go-forward
+  application language, and against the migration's own TS-0 target.
+. *Wrong toolchain.* They still shell out to a **retired** podman image,
+  `idaptik-affinescript-build:latest` (verified: `vm/tests/affinescript_stralloc_diff.ts`
+  invokes `podman run ... idaptik-affinescript-build:latest compile`). The
+  2026-06-03 idaptik reanchor (authority: Marina) *retired containers* in
+  favour of host-native `affinescript` on PATH (guix/nix dev shell). A
+  harness that invokes the retired container is invoking a toolchain that
+  no longer exists.
+
+=== Recommendation (host-native fix, independent of Finding 3)
+
+Even before the AffineScript-rewrite spike lands, the harnesses should be
+*de-containerised now*:
+
+* Replace every `podman run idaptik-affinescript-build:latest affinescript
+  ...` invocation with a direct host-native `affinescript ...` call,
+  matching the reanchor's `just affinescript-smoke` pattern (sibling
+  `hyperpolymath/affinescript` repo on PATH). This session's harnesses
+  (`proposals/idaptik/`) already do this.
+* This is mechanical and is correct *regardless* of whether the harness
+  body stays TS (interim) or moves to AffineScript (Finding 3 end-state).
+
+Sequence: *de-containerise first* (unblocks the harness today) ->
+*then* re-author in AffineScript via the Finding 3 spike (reaches TS-0).
+The two are separable; do not block the urgent container fix on the
+larger rewrite.
+
+== Finding 5 — Ecosystem portability under the github-only network policy
+
+=== The constraint (verified this session)
+
+The build network is *github-only*. `crates.io`, `deno.land`,
+`opam.ocaml.org`, and launchpad PPAs all return **403**; `github.com` and
+`archive.ubuntu.com` are reachable. Any install path that reaches for a
+package registry will fail.
+
+=== The host-native apt recipe (this is what worked)
+
+The affinescript compiler builds from Ubuntu *universe* OCaml deps with
+**no opam**:
+
+[source,console]
+----
+# Ubuntu universe (archive.ubuntu.com is reachable):
+#   ocaml (4.14), dune (3.14), menhir, ocaml-findlib,
+#   libsedlex-ocaml-dev, libyojson-ocaml-dev, libfmt-ocaml-dev,
+#   libcmdliner-ocaml-dev, libppx-deriving-ocaml-dev,
+#   libppx-sexp-conv-ocaml-dev, libsexplib0-ocaml-dev, libmenhir-ocaml-dev
+$ dune exec affinescript -- compile FILE -o OUT.wasm   # builds, emits valid wasm
+----
+
+=== The `js_of_ocaml` playground caveat (must be documented)
+
+`dune build` *full default* fails on **one** optional target,
+`js/playground.bc.js`, because that target needs the `js_of_ocaml`
+*binary* (not merely the library), which the apt set does not provide. The
+core compiler is unaffected. Guidance:
+
+* For toolchain/CI use, build the compiler target specifically (or `dune
+  exec affinescript -- ...`), *not* the full default, to avoid the
+  playground stop.
+* Document `js/playground.bc.js` as *playground-only, requires
+  `js_of_ocaml` binary, not on the github-only build path*.
+
+=== The "install where the registry can't reach" pattern (generalise it)
+
+State the pattern explicitly for downstream repos: *prefer the OS package
+manager (apt universe) over language registries; vendor or git-submodule
+anything the registry would otherwise serve; never assume registry
+reachability in CI.* This is the affinescript-specific instance of a
+recipe the whole github-only estate needs — see Document B item (3) for
+the estate-CI-guidance form.
+
+== Finding 6 — Release-cadence coupling
+
+=== The pin
+
+The idaptik migration pins **affinescript v0.1.1**. Two of four
+coprocessor kernels are migrated (*Compute*, *Crypto*); the two remaining
+(*IO*, *Quantum*) are *exactly* the ones blocked by compiler capability:
+
+[cols="1,2,2",options="header"]
+|===
+| Kernel | Blocking capability | Maps to
+
+| `Kernel_IO`
+| Variable-string backend (ASCII path-sandbox check needs `length` /
+  indexing / `startsWith`)
+| Finding 1
+
+| `Kernel_Quantum`
+| Effect codegen (module-level mutable state / `Date.now` / `Console.log`
+  cannot yet lower to wasm — `Kernel_Compute.affine` documents the effect
+  codegen "references an unbound binding")
+| The effect-codegen wall
+|===
+
+=== The effect-codegen wall (stated for the record)
+
+`Kernel_Compute.affine` documents that effect codegen cannot lower to
+wasm — it "references an unbound binding". The consequence: any kernel
+needing module-level mutable state, `Date.now`, or `Console.log`
+(`Kernel_Quantum`) cannot be migrated yet; such state must be *threaded as
+explicit parameters* instead. This is a second, independent compiler wall
+sitting beside the string gap.
+
+=== Recommendation
+
+Make the coupling explicit in release planning:
+
+* *Do not* advertise IO/Quantum migration as "scheduled" until *both*
+  gating capabilities land — IO on the variable-string backend (Finding
+  1), Quantum on effect codegen.
+* When cutting the affinescript release that lands either capability, note
+  in the changelog which downstream kernel it unblocks (the migration
+  pins a version, so the changelog is the coordination surface).
+* Until then, the honest status is: *2/4 kernels migrated; the remaining
+  2 are compiler-gated, not effort-gated.*
+
+== Bonus finding — interpreter vs wasm-codegen divergence
+
+While verifying the `Kernel_IO` re-decomposition (`proposals/idaptik/`),
+`affinescript -- eval FILE` (the interpreter) raised `Runtime error: Type
+mismatch: Expected mutable reference` on a `let mut x = ...; x = if c { a }
+else { x }` reassignment, while `affinescript -- compile FILE` (the wasm
+codegen) accepted the same source and produced a wasm whose `main()`
+returned the correct result. This is an *interpreter/codegen divergence*:
+a `let mut` self-referential reassignment that the codegen lowers but the
+interpreter rejects. Worth a focused issue + a regression test feeding the
+shape to `Interp.eval_program` (the same "first user of an existing-but-
+untested shape" class the repo's agent-ops notes flag for `FnExtern`).
+
+== Verification summary (what was actually run)
+
+* *Network:* `crates.io` / `deno.land` / `opam.ocaml.org` / launchpad ->
+  403; `github.com` / `archive.ubuntu.com` -> reachable. Confirmed.
+* *Build:* apt OCaml deps -> `dune exec affinescript -- compile FILE -o
+  OUT` emits valid wasm; full `dune build` stops only on
+  `js/playground.bc.js` (needs `js_of_ocaml` binary). Confirmed.
+* *`--deno-esm`:* present, issue #122, `bin/main.ml:1216-1226` + `:1576`;
+  AST -> ES-module backend, `extern fn` -> direct host calls. Confirmed
+  in source while drafting.
+* *Proof:* `proposals/echo-types/EchoEncodingFaithfulness.agda` typechecks
+  `--safe --without-K`, zero postulates, Agda 2.6.3 + stdlib v2.3.
+* *Migration corpus:* idaptik 107,758 LOC ReScript / 21,540 LOC
+  AffineScript / 17,633 LOC TS; 2/4 kernels migrated; pins affinescript
+  v0.1.1. Stated facts.
+
+== Provenance
+
+Produced in the 2026-06-04 AffineScript co-development session by the
+toolchain-architect analyst, READ-ONLY, from session-verified facts. No
+compiler, CI, roadmap, or issue was modified. License: MPL-2.0 (this doc
+lives in the affinescript repo).

--- a/proposals/toolchain/README.adoc
+++ b/proposals/toolchain/README.adoc
@@ -361,6 +361,28 @@ interpreter rejects. Worth a focused issue + a regression test feeding the
 shape to `Interp.eval_program` (the same "first user of an existing-but-
 untested shape" class the repo's agent-ops notes flag for `FnExtern`).
 
+== Finding 7 — panic-attack has no AffineScript analyzer (the primary language is unanalyzed)
+
+Running `panic-attack assail` (v2.5.5) on the migrated coprocessor cores
+(`idaptik/vm/coprocessor/*.affine`) this session returned `Error: Could
+not detect language` — panic-attack's 49-language analyzer does not yet
+include AffineScript, so the estate's *primary go-forward application
+language* currently has *zero* static-analysis coverage. Two adjacent
+robustness issues surfaced in the same run: on a small `.affine`-only
+directory the tool *backtrace-crashed* (a raw Rust panic + stack trace)
+rather than skipping unknown files gracefully, and it emitted `warning:
+failed to read AI manifest: extra tokens after manifest` on an idaptik
+`.a2ml` manifest.
+
+*Recommendation (targets `hyperpolymath/panic-attack`):* add an
+AffineScript analyzer (a language entry recognising `.affine` with
+weak-point patterns suited to the integerization style — unguarded
+boundary decoders, *silent* clamps, unbounded `nth`/`path_len`-style
+scans), and harden language detection to *skip, not crash* on unknown
+extensions. Until then, AffineScript code is outside the panicbot /
+gitbot-fleet security gate — a notable gap now that AffineScript is the
+estate's primary application language.
+
 == Verification summary (what was actually run)
 
 * *Network:* `crates.io` / `deno.land` / `opam.ocaml.org` / launchpad ->


### PR DESCRIPTION
## What this is

Round 2 of the AffineScript co-development run (round 1 — the verified echo-types soundness proof — merged as #531). This round **practises the idaptik ReScript → AffineScript → wasm migration end-to-end, host-native**, develops the frontier-practices guide, and stages the cross-repo proposals. Writes are affinescript-only; everything targeting another repo is staged under `proposals/` for review.

## Verified this session (every claim was run, not asserted)

| Artifact | Outcome |
|---|---|
| **`Kernel_IO`** — *fresh* re-decomposition | Compiles to wasm (2262B); `main()` logic **6/6 green** through the wasm. The re-decomposition *deletes* the `String.startsWith` step — compares Int arrays directly, so no string crosses the boundary. |
| **`SecurityRank`** — existing port + proof tie-in | Differential parity **78/78 ALL GREEN** vs a JS oracle; its out-of-band clamp is certified as controlled loss by the echo-types `clamp-sentinel-no-section` theorem (demonstrated live: `rank(-5)=rank(0)=0`, `rank(99)=rank(3)=3`). |
| **`Kernel_Quantum`** — honest non-migration | Documented as **compiler-gated** on the effect-codegen wall (module `Dict` state + `Date.now` + `Console.log`), with the re-decomposition path it needs. |

## What's in the diff

- **Guide (first-class, `docs/guides/`)** — the co-processor integerization chapter in `migration-playbook.adoc` (+444), `frontier-guide.adoc` Chapter 9 (+145), and the `AI.a2ml` machine companion (+76). Dual audience: human *and* agent. Six named patterns, each grounded in a verified example.
- **`proposals/idaptik/`** — the two migrations + the non-migration, source embedded (AGPL, since idaptik is AGPL-3.0-or-later; kept out of the MPL tree as standalone files).
- **`proposals/toolchain/`** — six compiler findings: the variable-string-backend gap (#1 leverage), compiler-emitted `@boundary` Echo obligations, `--deno-esm` to retire the TS harnesses, the stale-harness finding (TS + retired podman container), github-only-network portability, release-cadence coupling, plus the interpreter/codegen divergence bonus finding.
- **`proposals/standards/`** — drafted normative text (AS-MIG-1/2, AS-ABI-STR-1, EST-CI-NET-1, the `--deno-esm`/TS-0 exemption amendment, EST-REL-PIN-1).

## Lessons surfaced

Re-decompose-don't-transliterate (sometimes that means *deleting* the String); affine types forbid casual aliasing of owned arrays; the interpreter and wasm codegen **disagree** on a `let mut` self-reassignment (verify through the wasm); host-native compile vs the retired container; and the two compiler walls (string backend, effect codegen) **are** the migration frontier — IO and Quantum are gated on exactly those.

## Toolchain

Built entirely against the **github-only network policy** (crates.io / deno.land / opam.ocaml.org all 403): agda+stdlib, ocaml/dune (apt, no opam), deno (GitHub release), panic-attack — all installed and verified by routing around the block.

Draft for review.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_