### PR TITLE
feat(stdlib): pub-mark sweep — io/math/option/result/testing (closes #508)

### DIFF
--- a/stdlib/io.affine
+++ b/stdlib/io.affine
@@ -37,7 +37,7 @@ use string::{ split, join };
 ///
 /// Example:
 ///   printf("Hello, {}! You are {} years old.", ["Alice", 30])
-fn printf(format: String, args: [Any]) -> () {
+pub fn printf(format: String, args: [Any]) -> () {
   let flen = len(format);
   let mut arg_idx = 0;
   let mut i = 0;
@@ -59,23 +59,23 @@ fn printf(format: String, args: [Any]) -> () {
 }
 
 /// Print formatted string with trailing newline
-fn println_fmt(format: String, args: [Any]) -> () {
+pub fn println_fmt(format: String, args: [Any]) -> () {
   printf(format, args);
   println("");
 }
 
 /// Print debug representation of any value
-fn debug<T>(value: T) -> () {
+pub fn debug<T>(value: T) -> () {
   eprintln("DEBUG: " ++ show(value));
 }
 
 /// Print error with newline to stderr (convenience wrapper)
-fn error(msg: String) -> () {
+pub fn error(msg: String) -> () {
   eprintln("[ERROR] " ++ msg);
 }
 
 /// Print warning with newline to stderr
-fn warn(msg: String) -> () {
+pub fn warn(msg: String) -> () {
   eprintln("[WARN] " ++ msg);
 }
 
@@ -86,7 +86,7 @@ fn warn(msg: String) -> () {
 // read_file, write_file, append_file, file_exists are builtins — see module header
 
 /// Read file as a list of lines
-fn read_lines(path: String) -> Result<[String], String> {
+pub fn read_lines(path: String) -> Result<[String], String> {
   match read_file(path) {
     Ok(content) => Ok(split(content, "\n")),
     Err(msg) => Err(msg)
@@ -97,7 +97,7 @@ fn read_lines(path: String) -> Result<[String], String> {
 ///
 /// Note: this reads the entire file; a more efficient builtin would be
 /// preferable for large files once the runtime supports stat().
-fn file_size(path: String) -> Result<Int, String> {
+pub fn file_size(path: String) -> Result<Int, String> {
   match read_file(path) {
     Ok(content) => Ok(len(content)),
     Err(msg) => Err(msg)
@@ -124,7 +124,7 @@ extern fn remove_dir(path: String) -> Result<(), String>;
 // ============================================================================
 
 /// Join path components with the system separator (/)
-fn path_join(components: [String]) -> String {
+pub fn path_join(components: [String]) -> String {
   let mut result = "";
   let mut first = true;
   for component in components {
@@ -142,7 +142,7 @@ fn path_join(components: [String]) -> String {
 ///
 /// Returns None if no extension is found.
 /// Example: path_extension("file.txt") => Some("txt")
-fn path_extension(path: String) -> Option<String> {
+pub fn path_extension(path: String) -> Option<String> {
   let plen = len(path);
   let mut i = plen - 1;
   while i >= 0 {
@@ -166,7 +166,7 @@ fn path_extension(path: String) -> Option<String> {
 /// Get the filename component from a path
 ///
 /// Example: path_filename("/home/user/file.txt") => "file.txt"
-fn path_filename(path: String) -> String {
+pub fn path_filename(path: String) -> String {
   let plen = len(path);
   if plen == 0 {
     return "";
@@ -185,7 +185,7 @@ fn path_filename(path: String) -> String {
 /// Get the directory component from a path
 ///
 /// Example: path_dirname("/home/user/file.txt") => "/home/user"
-fn path_dirname(path: String) -> String {
+pub fn path_dirname(path: String) -> String {
   let plen = len(path);
   if plen == 0 {
     return ".";
@@ -207,7 +207,7 @@ fn path_dirname(path: String) -> String {
 /// Get the filename without its extension (stem)
 ///
 /// Example: path_stem("archive.tar.gz") => "archive.tar"
-fn path_stem(path: String) -> String {
+pub fn path_stem(path: String) -> String {
   let filename = path_filename(path);
   let flen = len(filename);
   let mut i = flen - 1;
@@ -239,7 +239,7 @@ extern fn chdir(path: String) -> Result<(), String>;
 // read_line is a builtin — see module header
 
 /// Read all input from stdin until EOF
-fn read_stdin() -> Result<String, String> {
+pub fn read_stdin() -> Result<String, String> {
   let mut parts = [];
   let mut done = false;
   while !done {
@@ -256,7 +256,7 @@ fn read_stdin() -> Result<String, String> {
 }
 
 /// Prompt user for input and return their response
-fn prompt(message: String) -> Result<String, String> {
+pub fn prompt(message: String) -> Result<String, String> {
   print(message);
   read_line()
 }
@@ -268,7 +268,7 @@ fn prompt(message: String) -> Result<String, String> {
 // time_now is a builtin — see module header
 
 /// Measure the wall-clock time of a function call (in seconds)
-fn timed<T>(f: () -> T) -> (T, Float) {
+pub fn timed<T>(f: () -> T) -> (T, Float) {
   let start = time_now();
   let result = f();
   let elapsed = time_now() - start;

--- a/stdlib/math.affine
+++ b/stdlib/math.affine
@@ -66,6 +66,15 @@ pub fn sign_float(x: Float) -> Int {
   if x > 0.0 { 1 } else if x < 0.0 { -1 } else { 0 }
 }
 
+/// Copy the sign of `sign_source` onto the magnitude of `magnitude`.
+/// Returns `+|magnitude|` when `sign_source >= 0.0`, else `-|magnitude|`.
+/// Branchless replacement for the common pattern
+/// `if cond { x } else { -x }` where `cond` is itself the sign of some value.
+pub fn copysign(magnitude: Float, sign_source: Float) -> Float {
+  let m = if magnitude < 0.0 { -magnitude } else { magnitude };
+  if sign_source < 0.0 { -m } else { m }
+}
+
 // ============================================================================
 // Power and roots
 // ============================================================================

--- a/stdlib/math.affine
+++ b/stdlib/math.affine
@@ -47,22 +47,22 @@ const NEG_INFINITY: Float = -1.0 / 0.0;
 // ============================================================================
 
 /// Absolute value of an integer
-fn abs(x: Int) -> Int {
+pub fn abs(x: Int) -> Int {
   if x < 0 { -x } else { x }
 }
 
 /// Absolute value of a float
-fn abs_float(x: Float) -> Float {
+pub fn abs_float(x: Float) -> Float {
   if x < 0.0 { -x } else { x }
 }
 
 /// Sign of an integer: -1, 0, or 1
-fn sign(x: Int) -> Int {
+pub fn sign(x: Int) -> Int {
   if x > 0 { 1 } else if x < 0 { -1 } else { 0 }
 }
 
 /// Sign of a float: -1, 0, or 1
-fn sign_float(x: Float) -> Int {
+pub fn sign_float(x: Float) -> Int {
   if x > 0.0 { 1 } else if x < 0.0 { -1 } else { 0 }
 }
 
@@ -71,7 +71,7 @@ fn sign_float(x: Float) -> Int {
 // ============================================================================
 
 /// Integer exponentiation via repeated squaring
-fn pow(base: Int, exp: Int) -> Int {
+pub fn pow(base: Int, exp: Int) -> Int {
   if exp == 0 {
     return 1;
   }
@@ -87,12 +87,12 @@ fn pow(base: Int, exp: Int) -> Int {
 }
 
 /// Square of an integer
-fn square(x: Int) -> Int {
+pub fn square(x: Int) -> Int {
   x * x
 }
 
 /// Cube of an integer
-fn cube(x: Int) -> Int {
+pub fn cube(x: Int) -> Int {
   x * x * x
 }
 
@@ -105,12 +105,12 @@ fn cube(x: Int) -> Int {
 // floor, ceil, round, trunc are builtins — see module header
 
 /// Convert an integer to a float
-fn to_float(n: Int) -> Float {
+pub fn to_float(n: Int) -> Float {
   float(n)
 }
 
 /// Fractional part of a float (x - trunc(x))
-fn fract(x: Float) -> Float {
+pub fn fract(x: Float) -> Float {
   x - to_float(trunc(x))
 }
 
@@ -121,27 +121,27 @@ fn fract(x: Float) -> Float {
 // sin, cos, tan, asin, acos, atan, atan2 are builtins — see module header
 
 /// Convert degrees to radians
-fn deg_to_rad(degrees: Float) -> Float {
+pub fn deg_to_rad(degrees: Float) -> Float {
   degrees * PI / 180.0
 }
 
 /// Convert radians to degrees
-fn rad_to_deg(radians: Float) -> Float {
+pub fn rad_to_deg(radians: Float) -> Float {
   radians * 180.0 / PI
 }
 
 /// Hyperbolic sine
-fn sinh(x: Float) -> Float {
+pub fn sinh(x: Float) -> Float {
   (exp(x) - exp(-x)) / 2.0
 }
 
 /// Hyperbolic cosine
-fn cosh(x: Float) -> Float {
+pub fn cosh(x: Float) -> Float {
   (exp(x) + exp(-x)) / 2.0
 }
 
 /// Hyperbolic tangent
-fn tanh(x: Float) -> Float {
+pub fn tanh(x: Float) -> Float {
   sinh(x) / cosh(x)
 }
 
@@ -152,7 +152,7 @@ fn tanh(x: Float) -> Float {
 // exp, log, log10, log2 are builtins — see module header
 
 /// Logarithm with arbitrary base
-fn log_base(base: Float, x: Float) -> Float {
+pub fn log_base(base: Float, x: Float) -> Float {
   log(x) / log(base)
 }
 
@@ -161,27 +161,27 @@ fn log_base(base: Float, x: Float) -> Float {
 // ============================================================================
 
 /// Minimum of two integers
-fn min_int(a: Int, b: Int) -> Int {
+pub fn min_int(a: Int, b: Int) -> Int {
   if a < b { a } else { b }
 }
 
 /// Maximum of two integers
-fn max_int(a: Int, b: Int) -> Int {
+pub fn max_int(a: Int, b: Int) -> Int {
   if a > b { a } else { b }
 }
 
 /// Minimum of two floats
-fn min_float(a: Float, b: Float) -> Float {
+pub fn min_float(a: Float, b: Float) -> Float {
   if a < b { a } else { b }
 }
 
 /// Maximum of two floats
-fn max_float(a: Float, b: Float) -> Float {
+pub fn max_float(a: Float, b: Float) -> Float {
   if a > b { a } else { b }
 }
 
 /// Clamp an integer between min_val and max_val (inclusive)
-fn clamp_int(value: Int, min_val: Int, max_val: Int) -> Int {
+pub fn clamp_int(value: Int, min_val: Int, max_val: Int) -> Int {
   if value < min_val {
     min_val
   } else if value > max_val {
@@ -192,7 +192,7 @@ fn clamp_int(value: Int, min_val: Int, max_val: Int) -> Int {
 }
 
 /// Clamp a float between min_val and max_val (inclusive)
-fn clamp_float(value: Float, min_val: Float, max_val: Float) -> Float {
+pub fn clamp_float(value: Float, min_val: Float, max_val: Float) -> Float {
   if value < min_val {
     min_val
   } else if value > max_val {
@@ -203,7 +203,7 @@ fn clamp_float(value: Float, min_val: Float, max_val: Float) -> Float {
 }
 
 /// Linear interpolation between a and b by factor t (0.0 to 1.0)
-fn lerp(a: Float, b: Float, t: Float) -> Float {
+pub fn lerp(a: Float, b: Float, t: Float) -> Float {
   a + (b - a) * t
 }
 
@@ -212,7 +212,7 @@ fn lerp(a: Float, b: Float, t: Float) -> Float {
 // ============================================================================
 
 /// Greatest common divisor via Euclid's algorithm
-fn gcd(a: Int, b: Int) -> Int {
+pub fn gcd(a: Int, b: Int) -> Int {
   let mut x = abs(a);
   let mut y = abs(b);
 
@@ -226,7 +226,7 @@ fn gcd(a: Int, b: Int) -> Int {
 }
 
 /// Least common multiple
-fn lcm(a: Int, b: Int) -> Int {
+pub fn lcm(a: Int, b: Int) -> Int {
   if a == 0 || b == 0 {
     return 0;
   }
@@ -234,17 +234,17 @@ fn lcm(a: Int, b: Int) -> Int {
 }
 
 /// Check if n is even
-fn is_even(n: Int) -> Bool {
+pub fn is_even(n: Int) -> Bool {
   n % 2 == 0
 }
 
 /// Check if n is odd
-fn is_odd(n: Int) -> Bool {
+pub fn is_odd(n: Int) -> Bool {
   n % 2 != 0
 }
 
 /// Check if n is a prime number (trial division)
-fn is_prime(n: Int) -> Bool {
+pub fn is_prime(n: Int) -> Bool {
   if n < 2 {
     return false;
   }
@@ -265,7 +265,7 @@ fn is_prime(n: Int) -> Bool {
 }
 
 /// Integer division rounding towards negative infinity (floor division)
-fn div_floor(a: Int, b: Int) -> Int {
+pub fn div_floor(a: Int, b: Int) -> Int {
   let q = a / b;
   if (a % b != 0) && ((a < 0) != (b < 0)) {
     q - 1
@@ -275,7 +275,7 @@ fn div_floor(a: Int, b: Int) -> Int {
 }
 
 /// Modulo that always returns a non-negative result
-fn mod_positive(a: Int, b: Int) -> Int {
+pub fn mod_positive(a: Int, b: Int) -> Int {
   let r = a % b;
   if r < 0 {
     r + abs(b)
@@ -289,7 +289,7 @@ fn mod_positive(a: Int, b: Int) -> Int {
 // ============================================================================
 
 /// Factorial of n (n!)
-fn factorial(n: Int) -> Int {
+pub fn factorial(n: Int) -> Int {
   if n <= 1 {
     1
   } else {
@@ -298,7 +298,7 @@ fn factorial(n: Int) -> Int {
 }
 
 /// n-th Fibonacci number (iterative)
-fn fibonacci(n: Int) -> Int {
+pub fn fibonacci(n: Int) -> Int {
   if n <= 1 {
     n
   } else {
@@ -316,17 +316,17 @@ fn fibonacci(n: Int) -> Int {
 }
 
 /// Sum of first n natural numbers: 1 + 2 + ... + n
-fn sum_naturals(n: Int) -> Int {
+pub fn sum_naturals(n: Int) -> Int {
   n * (n + 1) / 2
 }
 
 /// Sum of first n squares: 1^2 + 2^2 + ... + n^2
-fn sum_squares(n: Int) -> Int {
+pub fn sum_squares(n: Int) -> Int {
   n * (n + 1) * (2 * n + 1) / 6
 }
 
 /// Binomial coefficient C(n, k) = n! / (k! * (n-k)!)
-fn binomial(n: Int, k: Int) -> Int {
+pub fn binomial(n: Int, k: Int) -> Int {
   if k < 0 || k > n {
     return 0;
   }
@@ -346,7 +346,7 @@ fn binomial(n: Int, k: Int) -> Int {
 // ============================================================================
 
 /// Arithmetic mean of a list of floats
-fn mean(values: [Float]) -> Float {
+pub fn mean(values: [Float]) -> Float {
   let n = len(values);
   if n == 0 {
     return 0.0;
@@ -359,7 +359,7 @@ fn mean(values: [Float]) -> Float {
 }
 
 /// Sum of a list of floats
-fn sum_float(values: [Float]) -> Float {
+pub fn sum_float(values: [Float]) -> Float {
   let mut tot = 0.0;
   for v in values {
     tot = tot + v;

--- a/stdlib/option.affine
+++ b/stdlib/option.affine
@@ -20,7 +20,7 @@ use prelude::{Option, Some, None, Result, Ok, Err};
 // ============================================================================
 
 /// Map over Some value
-fn map<T, U>(f: T -> U, opt: Option<T>) -> Option<U> {
+pub fn map<T, U>(f: T -> U, opt: Option<T>) -> Option<U> {
   match opt {
     Some(value) => Some(f(value)),
     None => None
@@ -28,7 +28,7 @@ fn map<T, U>(f: T -> U, opt: Option<T>) -> Option<U> {
 }
 
 /// Apply function in Option to value in Option
-fn apply<T, U>(f_opt: Option<T -> U>, value_opt: Option<T>) -> Option<U> {
+pub fn apply<T, U>(f_opt: Option<T -> U>, value_opt: Option<T>) -> Option<U> {
   match (f_opt, value_opt) {
     (Some(f), Some(value)) => Some(f(value)),
     _ => None
@@ -36,7 +36,7 @@ fn apply<T, U>(f_opt: Option<T -> U>, value_opt: Option<T>) -> Option<U> {
 }
 
 /// Flat map (bind) over Option
-fn flat_map<T, U>(f: T -> Option<U>, opt: Option<T>) -> Option<U> {
+pub fn flat_map<T, U>(f: T -> Option<U>, opt: Option<T>) -> Option<U> {
   match opt {
     Some(value) => f(value),
     None => None
@@ -44,12 +44,12 @@ fn flat_map<T, U>(f: T -> Option<U>, opt: Option<T>) -> Option<U> {
 }
 
 /// Also known as 'and_then'
-fn and_then<T, U>(opt: Option<T>, f: T -> Option<U>) -> Option<U> {
+pub fn and_then<T, U>(opt: Option<T>, f: T -> Option<U>) -> Option<U> {
   flat_map(f, opt)
 }
 
 /// Or else - use alternative Option if None
-fn or_else<T>(opt: Option<T>, alternative: Option<T>) -> Option<T> {
+pub fn or_else<T>(opt: Option<T>, alternative: Option<T>) -> Option<T> {
   match opt {
     Some(_) => opt,
     None => alternative
@@ -57,7 +57,7 @@ fn or_else<T>(opt: Option<T>, alternative: Option<T>) -> Option<T> {
 }
 
 /// Or else computed - compute alternative only if None
-fn or_else_with<T>(opt: Option<T>, f: () -> Option<T>) -> Option<T> {
+pub fn or_else_with<T>(opt: Option<T>, f: () -> Option<T>) -> Option<T> {
   match opt {
     Some(_) => opt,
     None => f()
@@ -69,7 +69,7 @@ fn or_else_with<T>(opt: Option<T>, f: () -> Option<T>) -> Option<T> {
 // ============================================================================
 
 /// Check if Option is Some
-fn is_some<T>(opt: Option<T>) -> Bool {
+pub fn is_some<T>(opt: Option<T>) -> Bool {
   match opt {
     Some(_) => true,
     None => false
@@ -77,7 +77,7 @@ fn is_some<T>(opt: Option<T>) -> Bool {
 }
 
 /// Check if Option is None
-fn is_none<T>(opt: Option<T>) -> Bool {
+pub fn is_none<T>(opt: Option<T>) -> Bool {
   match opt {
     Some(_) => false,
     None => true
@@ -85,7 +85,7 @@ fn is_none<T>(opt: Option<T>) -> Bool {
 }
 
 /// Check if Option contains specific value
-fn contains<T>(opt: Option<T>, value: T) -> Bool {
+pub fn contains<T>(opt: Option<T>, value: T) -> Bool {
   match opt {
     Some(x) => x == value,
     None => false
@@ -97,7 +97,7 @@ fn contains<T>(opt: Option<T>, value: T) -> Bool {
 // ============================================================================
 
 /// Unwrap Some value or panic
-fn unwrap<T>(opt: Option<T>) -> T {
+pub fn unwrap<T>(opt: Option<T>) -> T {
   match opt {
     Some(value) => value,
     None => panic("Called unwrap on None")
@@ -105,7 +105,7 @@ fn unwrap<T>(opt: Option<T>) -> T {
 }
 
 /// Unwrap with custom error message
-fn expect<T>(opt: Option<T>, msg: String) -> T {
+pub fn expect<T>(opt: Option<T>, msg: String) -> T {
   match opt {
     Some(value) => value,
     None => panic(msg)
@@ -121,7 +121,7 @@ pub fn unwrap_or<T>(opt: Option<T>, default: T) -> T {
 }
 
 /// Unwrap or compute default value
-fn unwrap_or_else<T>(opt: Option<T>, f: () -> T) -> T {
+pub fn unwrap_or_else<T>(opt: Option<T>, f: () -> T) -> T {
   match opt {
     Some(value) => value,
     None => f()
@@ -129,7 +129,7 @@ fn unwrap_or_else<T>(opt: Option<T>, f: () -> T) -> T {
 }
 
 /// Get value or return from function with default
-fn ok_or<T, E>(opt: Option<T>, err: E) -> Result<T, E> {
+pub fn ok_or<T, E>(opt: Option<T>, err: E) -> Result<T, E> {
   match opt {
     Some(value) => Ok(value),
     None => Err(err)
@@ -137,7 +137,7 @@ fn ok_or<T, E>(opt: Option<T>, err: E) -> Result<T, E> {
 }
 
 /// Get value or compute error
-fn ok_or_else<T, E>(opt: Option<T>, f: () -> E) -> Result<T, E> {
+pub fn ok_or_else<T, E>(opt: Option<T>, f: () -> E) -> Result<T, E> {
   match opt {
     Some(value) => Ok(value),
     None => Err(f())
@@ -149,7 +149,7 @@ fn ok_or_else<T, E>(opt: Option<T>, f: () -> E) -> Result<T, E> {
 // ============================================================================
 
 /// Filter Option based on predicate
-fn filter<T>(pred: T -> Bool, opt: Option<T>) -> Option<T> {
+pub fn filter<T>(pred: T -> Bool, opt: Option<T>) -> Option<T> {
   match opt {
     Some(value) => if pred(value) { Some(value) } else { None },
     None => None
@@ -157,7 +157,7 @@ fn filter<T>(pred: T -> Bool, opt: Option<T>) -> Option<T> {
 }
 
 /// Zip two Options together
-fn zip<A, B>(a: Option<A>, b: Option<B>) -> Option<(A, B)> {
+pub fn zip<A, B>(a: Option<A>, b: Option<B>) -> Option<(A, B)> {
   match (a, b) {
     (Some(x), Some(y)) => Some((x, y)),
     _ => None
@@ -165,7 +165,7 @@ fn zip<A, B>(a: Option<A>, b: Option<B>) -> Option<(A, B)> {
 }
 
 /// Zip with function
-fn zip_with<A, B, C>(f: (A, B) -> C, a: Option<A>, b: Option<B>) -> Option<C> {
+pub fn zip_with<A, B, C>(f: (A, B) -> C, a: Option<A>, b: Option<B>) -> Option<C> {
   match (a, b) {
     (Some(x), Some(y)) => Some(f(x, y)),
     _ => None
@@ -173,7 +173,7 @@ fn zip_with<A, B, C>(f: (A, B) -> C, a: Option<A>, b: Option<B>) -> Option<C> {
 }
 
 /// Unzip Option of pair
-fn unzip<A, B>(opt: Option<(A, B)>) -> (Option<A>, Option<B>) {
+pub fn unzip<A, B>(opt: Option<(A, B)>) -> (Option<A>, Option<B>) {
   match opt {
     Some((a, b)) => (Some(a), Some(b)),
     None => (None, None)
@@ -185,7 +185,7 @@ fn unzip<A, B>(opt: Option<(A, B)>) -> (Option<A>, Option<B>) {
 // ============================================================================
 
 /// Transpose Option of list to list of Option
-fn transpose<T>(opt: Option<[T]>) -> [Option<T>] {
+pub fn transpose<T>(opt: Option<[T]>) -> [Option<T>] {
   match opt {
     Some(list) => {
       let mut result = [];
@@ -199,7 +199,7 @@ fn transpose<T>(opt: Option<[T]>) -> [Option<T>] {
 }
 
 /// Collect list of Options into Option of list (None on any None)
-fn collect<T>(opts: [Option<T>]) -> Option<[T]> {
+pub fn collect<T>(opts: [Option<T>]) -> Option<[T]> {
   let mut values = [];
   for opt in opts {
     match opt {
@@ -211,7 +211,7 @@ fn collect<T>(opts: [Option<T>]) -> Option<[T]> {
 }
 
 /// Filter out Nones from list
-fn cat_options<T>(opts: [Option<T>]) -> [T] {
+pub fn cat_options<T>(opts: [Option<T>]) -> [T] {
   let mut values = [];
   for opt in opts {
     match opt {
@@ -226,7 +226,7 @@ fn cat_options<T>(opts: [Option<T>]) -> [T] {
 }
 
 /// Map list with function returning Option, filtering Nones
-fn map_filter<T, U>(f: T -> Option<U>, list: [T]) -> [U] {
+pub fn map_filter<T, U>(f: T -> Option<U>, list: [T]) -> [U] {
   let mut results = [];
   for x in list {
     results = results ++ [f(x)];
@@ -235,7 +235,7 @@ fn map_filter<T, U>(f: T -> Option<U>, list: [T]) -> [U] {
 }
 
 /// Find first Some in list of Options
-fn first_some<T>(opts: [Option<T>]) -> Option<T> {
+pub fn first_some<T>(opts: [Option<T>]) -> Option<T> {
   for opt in opts {
     match opt {
       Some(value) => return Some(value),
@@ -246,7 +246,7 @@ fn first_some<T>(opts: [Option<T>]) -> Option<T> {
 }
 
 /// Get head of list as Option
-fn head<T>(list: [T]) -> Option<T> {
+pub fn head<T>(list: [T]) -> Option<T> {
   if len(list) > 0 {
     Some(list[0])
   } else {
@@ -255,7 +255,7 @@ fn head<T>(list: [T]) -> Option<T> {
 }
 
 /// Get tail of list as Option
-fn tail<T>(list: [T]) -> Option<[T]> {
+pub fn tail<T>(list: [T]) -> Option<[T]> {
   if len(list) > 0 {
     Some(list[1:])
   } else {
@@ -264,7 +264,7 @@ fn tail<T>(list: [T]) -> Option<[T]> {
 }
 
 /// Get last element of list as Option
-fn last<T>(list: [T]) -> Option<T> {
+pub fn last<T>(list: [T]) -> Option<T> {
   let n = len(list);
   if n > 0 {
     Some(list[n - 1])
@@ -274,7 +274,7 @@ fn last<T>(list: [T]) -> Option<T> {
 }
 
 /// Get element at index as Option
-fn get<T>(list: [T], index: Int) -> Option<T> {
+pub fn get<T>(list: [T], index: Int) -> Option<T> {
   if index >= 0 && index < len(list) {
     Some(list[index])
   } else {
@@ -287,7 +287,7 @@ fn get<T>(list: [T], index: Int) -> Option<T> {
 // ============================================================================
 
 /// Convert bool to Option
-fn bool_to_option(b: Bool) -> Option<()> {
+pub fn bool_to_option(b: Bool) -> Option<()> {
   if b {
     Some(())
   } else {
@@ -296,17 +296,17 @@ fn bool_to_option(b: Bool) -> Option<()> {
 }
 
 /// AND operation on Options (both must be Some)
-fn option_and<T, U>(a: Option<T>, b: Option<U>) -> Option<(T, U)> {
+pub fn option_and<T, U>(a: Option<T>, b: Option<U>) -> Option<(T, U)> {
   zip(a, b)
 }
 
 /// OR operation on Options (first Some wins)
-fn option_or<T>(a: Option<T>, b: Option<T>) -> Option<T> {
+pub fn option_or<T>(a: Option<T>, b: Option<T>) -> Option<T> {
   or_else(a, b)
 }
 
 /// XOR operation on Options (exactly one must be Some)
-fn option_xor<T>(a: Option<T>, b: Option<T>) -> Option<T> {
+pub fn option_xor<T>(a: Option<T>, b: Option<T>) -> Option<T> {
   match (a, b) {
     (Some(x), None) => Some(x),
     (None, Some(y)) => Some(y),
@@ -319,7 +319,7 @@ fn option_xor<T>(a: Option<T>, b: Option<T>) -> Option<T> {
 // ============================================================================
 
 /// Flatten nested Option
-fn flatten<T>(opt: Option<Option<T>>) -> Option<T> {
+pub fn flatten<T>(opt: Option<Option<T>>) -> Option<T> {
   match opt {
     Some(inner) => inner,
     None => None
@@ -327,19 +327,19 @@ fn flatten<T>(opt: Option<Option<T>>) -> Option<T> {
 }
 
 /// Replace None with provided Option
-fn replace_none<T>(opt: Option<T>, replacement: Option<T>) -> Option<T> {
+pub fn replace_none<T>(opt: Option<T>, replacement: Option<T>) -> Option<T> {
   or_else(opt, replacement)
 }
 
 /// Take value from Option, leaving None
-fn take<T>(mut opt: Option<T>) -> Option<T> {
+pub fn take<T>(mut opt: Option<T>) -> Option<T> {
   let result = opt;
   opt = None;
   result
 }
 
 /// Insert value into Option if None
-fn get_or_insert<T>(mut opt: Option<T>, value: T) -> T {
+pub fn get_or_insert<T>(mut opt: Option<T>, value: T) -> T {
   match opt {
     Some(x) => x,
     None => {

--- a/stdlib/result.affine
+++ b/stdlib/result.affine
@@ -18,7 +18,7 @@ use prelude::{Result, Ok, Err, Option, Some, None, map};
 // ============================================================================
 
 /// Convert Option to Result
-fn option_to_result<T, E>(opt: Option<T>, err: E) -> Result<T, E> {
+pub fn option_to_result<T, E>(opt: Option<T>, err: E) -> Result<T, E> {
   match opt {
     Some(value) => Ok(value),
     None => Err(err)
@@ -26,7 +26,7 @@ fn option_to_result<T, E>(opt: Option<T>, err: E) -> Result<T, E> {
 }
 
 /// Convert Result to Option (discarding error)
-fn result_to_option<T, E>(result: Result<T, E>) -> Option<T> {
+pub fn result_to_option<T, E>(result: Result<T, E>) -> Option<T> {
   match result {
     Ok(value) => Some(value),
     Err(_) => None
@@ -38,7 +38,7 @@ fn result_to_option<T, E>(result: Result<T, E>) -> Option<T> {
 // ============================================================================
 
 /// Map over Ok value
-fn map_ok<T, U, E>(f: T -> U, result: Result<T, E>) -> Result<U, E> {
+pub fn map_ok<T, U, E>(f: T -> U, result: Result<T, E>) -> Result<U, E> {
   match result {
     Ok(value) => Ok(f(value)),
     Err(e) => Err(e)
@@ -46,7 +46,7 @@ fn map_ok<T, U, E>(f: T -> U, result: Result<T, E>) -> Result<U, E> {
 }
 
 /// Map over Err value
-fn map_err<T, E, F>(f: E -> F, result: Result<T, E>) -> Result<T, F> {
+pub fn map_err<T, E, F>(f: E -> F, result: Result<T, E>) -> Result<T, F> {
   match result {
     Ok(value) => Ok(value),
     Err(e) => Err(f(e))
@@ -54,7 +54,7 @@ fn map_err<T, E, F>(f: E -> F, result: Result<T, E>) -> Result<T, F> {
 }
 
 /// Apply function in Result to value in Result
-fn apply<T, U, E>(f_result: Result<T -> U, E>, value_result: Result<T, E>) -> Result<U, E> {
+pub fn apply<T, U, E>(f_result: Result<T -> U, E>, value_result: Result<T, E>) -> Result<U, E> {
   match (f_result, value_result) {
     (Ok(f), Ok(value)) => Ok(f(value)),
     (Err(e), _) => Err(e),
@@ -63,7 +63,7 @@ fn apply<T, U, E>(f_result: Result<T -> U, E>, value_result: Result<T, E>) -> Re
 }
 
 /// Flat map (bind) over Result
-fn flat_map<T, U, E>(f: T -> Result<U, E>, result: Result<T, E>) -> Result<U, E> {
+pub fn flat_map<T, U, E>(f: T -> Result<U, E>, result: Result<T, E>) -> Result<U, E> {
   match result {
     Ok(value) => f(value),
     Err(e) => Err(e)
@@ -71,12 +71,12 @@ fn flat_map<T, U, E>(f: T -> Result<U, E>, result: Result<T, E>) -> Result<U, E>
 }
 
 /// Also known as 'and_then'
-fn and_then<T, U, E>(result: Result<T, E>, f: T -> Result<U, E>) -> Result<U, E> {
+pub fn and_then<T, U, E>(result: Result<T, E>, f: T -> Result<U, E>) -> Result<U, E> {
   flat_map(f, result)
 }
 
 /// Or else - use alternative Result on error
-fn or_else<T, E, F>(result: Result<T, E>, f: E -> Result<T, F>) -> Result<T, F> {
+pub fn or_else<T, E, F>(result: Result<T, E>, f: E -> Result<T, F>) -> Result<T, F> {
   match result {
     Ok(value) => Ok(value),
     Err(e) => f(e)
@@ -88,7 +88,7 @@ fn or_else<T, E, F>(result: Result<T, E>, f: E -> Result<T, F>) -> Result<T, F> 
 // ============================================================================
 
 /// Check if Result is Ok
-fn is_ok<T, E>(result: Result<T, E>) -> Bool {
+pub fn is_ok<T, E>(result: Result<T, E>) -> Bool {
   match result {
     Ok(_) => true,
     Err(_) => false
@@ -96,7 +96,7 @@ fn is_ok<T, E>(result: Result<T, E>) -> Bool {
 }
 
 /// Check if Result is Err
-fn is_err<T, E>(result: Result<T, E>) -> Bool {
+pub fn is_err<T, E>(result: Result<T, E>) -> Bool {
   match result {
     Ok(_) => false,
     Err(_) => true
@@ -108,7 +108,7 @@ fn is_err<T, E>(result: Result<T, E>) -> Bool {
 // ============================================================================
 
 /// Unwrap Ok value or panic
-fn unwrap<T, E>(result: Result<T, E>) -> T {
+pub fn unwrap<T, E>(result: Result<T, E>) -> T {
   match result {
     Ok(value) => value,
     Err(_) => panic("Called unwrap on Err value")
@@ -116,7 +116,7 @@ fn unwrap<T, E>(result: Result<T, E>) -> T {
 }
 
 /// Unwrap Err value or panic
-fn unwrap_err<T, E>(result: Result<T, E>) -> E {
+pub fn unwrap_err<T, E>(result: Result<T, E>) -> E {
   match result {
     Ok(_) => panic("Called unwrap_err on Ok value"),
     Err(e) => e
@@ -124,7 +124,7 @@ fn unwrap_err<T, E>(result: Result<T, E>) -> E {
 }
 
 /// Unwrap with custom error message
-fn expect<T, E>(result: Result<T, E>, msg: String) -> T {
+pub fn expect<T, E>(result: Result<T, E>, msg: String) -> T {
   match result {
     Ok(value) => value,
     Err(_) => panic(msg)
@@ -132,7 +132,7 @@ fn expect<T, E>(result: Result<T, E>, msg: String) -> T {
 }
 
 /// Unwrap or provide default value
-fn unwrap_or<T, E>(result: Result<T, E>, default: T) -> T {
+pub fn unwrap_or<T, E>(result: Result<T, E>, default: T) -> T {
   match result {
     Ok(value) => value,
     Err(_) => default
@@ -140,7 +140,7 @@ fn unwrap_or<T, E>(result: Result<T, E>, default: T) -> T {
 }
 
 /// Unwrap or compute default value
-fn unwrap_or_else<T, E>(result: Result<T, E>, f: E -> T) -> T {
+pub fn unwrap_or_else<T, E>(result: Result<T, E>, f: E -> T) -> T {
   match result {
     Ok(value) => value,
     Err(e) => f(e)
@@ -152,7 +152,7 @@ fn unwrap_or_else<T, E>(result: Result<T, E>, f: E -> T) -> T {
 // ============================================================================
 
 /// Transpose Option of Result to Result of Option
-fn transpose_opt<T, E>(opt: Option<Result<T, E>>) -> Result<Option<T>, E> {
+pub fn transpose_opt<T, E>(opt: Option<Result<T, E>>) -> Result<Option<T>, E> {
   match opt {
     Some(Ok(value)) => Ok(Some(value)),
     Some(Err(e)) => Err(e),
@@ -161,7 +161,7 @@ fn transpose_opt<T, E>(opt: Option<Result<T, E>>) -> Result<Option<T>, E> {
 }
 
 /// Collect list of Results into Result of list (fails on first error)
-fn collect<T, E>(results: [Result<T, E>]) -> Result<[T], E> {
+pub fn collect<T, E>(results: [Result<T, E>]) -> Result<[T], E> {
   let values = [];
   for result in results {
     match result {
@@ -173,7 +173,7 @@ fn collect<T, E>(results: [Result<T, E>]) -> Result<[T], E> {
 }
 
 /// Partition list of Results into successes and failures
-fn partition_results<T, E>(results: [Result<T, E>]) -> ([T], [E]) {
+pub fn partition_results<T, E>(results: [Result<T, E>]) -> ([T], [E]) {
   let oks = [];
   let errs = [];
   for result in results {
@@ -186,7 +186,7 @@ fn partition_results<T, E>(results: [Result<T, E>]) -> ([T], [E]) {
 }
 
 /// Try to apply function to all elements, collecting errors
-fn try_map<T, U, E>(f: T -> Result<U, E>, list: [T]) -> Result<[U], E> {
+pub fn try_map<T, U, E>(f: T -> Result<U, E>, list: [T]) -> Result<[U], E> {
   let results = map(list, f);
   collect(results)
 }
@@ -196,7 +196,7 @@ fn try_map<T, U, E>(f: T -> Result<U, E>, list: [T]) -> Result<[U], E> {
 // ============================================================================
 
 /// Convert bool to Result
-fn bool_to_result(b: Bool, err: E) -> Result<(), E> {
+pub fn bool_to_result(b: Bool, err: E) -> Result<(), E> {
   if b {
     Ok(())
   } else {
@@ -205,7 +205,7 @@ fn bool_to_result(b: Bool, err: E) -> Result<(), E> {
 }
 
 /// AND operation on Results (both must be Ok)
-fn result_and<T, U, E>(a: Result<T, E>, b: Result<U, E>) -> Result<(T, U), E> {
+pub fn result_and<T, U, E>(a: Result<T, E>, b: Result<U, E>) -> Result<(T, U), E> {
   match (a, b) {
     (Ok(x), Ok(y)) => Ok((x, y)),
     (Err(e), _) => Err(e),
@@ -214,7 +214,7 @@ fn result_and<T, U, E>(a: Result<T, E>, b: Result<U, E>) -> Result<(T, U), E> {
 }
 
 /// OR operation on Results (first Ok wins)
-fn result_or<T, E>(a: Result<T, E>, b: Result<T, E>) -> Result<T, E> {
+pub fn result_or<T, E>(a: Result<T, E>, b: Result<T, E>) -> Result<T, E> {
   match a {
     Ok(value) => Ok(value),
     Err(_) => b
@@ -228,7 +228,7 @@ fn result_or<T, E>(a: Result<T, E>, b: Result<T, E>) -> Result<T, E> {
 /// Try block emulation - execute function and catch panics as Err.
 /// Named `attempt` (not `try`) because `try` is a reserved keyword
 /// (try/catch/finally); see #135 keyword-as-identifier slice.
-fn attempt<T>(f: () -> T) -> Result<T, String> {
+pub fn attempt<T>(f: () -> T) -> Result<T, String> {
   // TODO: Requires exception handling support
   try {
     Ok(f())
@@ -239,7 +239,7 @@ fn attempt<T>(f: () -> T) -> Result<T, String> {
 }
 
 /// Retry operation n times on failure
-fn retry<T, E>(n: Int, f: () -> Result<T, E>) -> Result<T, E> {
+pub fn retry<T, E>(n: Int, f: () -> Result<T, E>) -> Result<T, E> {
   let result = f();
   match result {
     Ok(_) => result,

--- a/stdlib/testing.affine
+++ b/stdlib/testing.affine
@@ -16,28 +16,28 @@ use prelude::{ Option, Result, Some, None, Ok, Err };
 // ============================================================================
 
 /// Assert that a condition is true; panic with message on failure
-fn assert(condition: Bool, message: String) -> () {
+pub fn assert(condition: Bool, message: String) -> () {
   if !condition {
     panic("Assertion failed: " ++ message);
   }
 }
 
 /// Assert two values are equal
-fn assert_eq<T>(actual: T, expected: T, message: String) -> () {
+pub fn assert_eq<T>(actual: T, expected: T, message: String) -> () {
   if actual != expected {
     panic("Assertion failed: " ++ message ++ "\n  Expected: " ++ show(expected) ++ "\n  Actual:   " ++ show(actual));
   }
 }
 
 /// Assert two values are not equal
-fn assert_ne<T>(actual: T, expected: T, message: String) -> () {
+pub fn assert_ne<T>(actual: T, expected: T, message: String) -> () {
   if actual == expected {
     panic("Assertion failed: values should not be equal: " ++ message ++ "\n  Both: " ++ show(actual));
   }
 }
 
 /// Assert a Result is Ok and return the inner value
-fn assert_ok<T, E>(result: Result<T, E>, message: String) -> T {
+pub fn assert_ok<T, E>(result: Result<T, E>, message: String) -> T {
   match result {
     Ok(value) => value,
     Err(e) => panic("Assertion failed: expected Ok, got Err(" ++ show(e) ++ "): " ++ message)
@@ -45,7 +45,7 @@ fn assert_ok<T, E>(result: Result<T, E>, message: String) -> T {
 }
 
 /// Assert a Result is Err and return the error value
-fn assert_err<T, E>(result: Result<T, E>, message: String) -> E {
+pub fn assert_err<T, E>(result: Result<T, E>, message: String) -> E {
   match result {
     Ok(v) => panic("Assertion failed: expected Err, got Ok(" ++ show(v) ++ "): " ++ message),
     Err(e) => e
@@ -53,7 +53,7 @@ fn assert_err<T, E>(result: Result<T, E>, message: String) -> E {
 }
 
 /// Assert an Option is Some and return the inner value
-fn assert_some<T>(opt: Option<T>, message: String) -> T {
+pub fn assert_some<T>(opt: Option<T>, message: String) -> T {
   match opt {
     Some(value) => value,
     None => panic("Assertion failed: expected Some, got None: " ++ message)
@@ -61,7 +61,7 @@ fn assert_some<T>(opt: Option<T>, message: String) -> T {
 }
 
 /// Assert an Option is None
-fn assert_none<T>(opt: Option<T>, message: String) -> () {
+pub fn assert_none<T>(opt: Option<T>, message: String) -> () {
   match opt {
     Some(v) => panic("Assertion failed: expected None, got Some(" ++ show(v) ++ "): " ++ message),
     None => {}
@@ -73,35 +73,35 @@ fn assert_none<T>(opt: Option<T>, message: String) -> () {
 // ============================================================================
 
 /// Assert actual < bound
-fn assert_lt<T>(actual: T, bound: T, message: String) -> () {
+pub fn assert_lt<T>(actual: T, bound: T, message: String) -> () {
   if !(actual < bound) {
     panic("Assertion failed: " ++ show(actual) ++ " should be < " ++ show(bound) ++ ": " ++ message);
   }
 }
 
 /// Assert actual <= bound
-fn assert_le<T>(actual: T, bound: T, message: String) -> () {
+pub fn assert_le<T>(actual: T, bound: T, message: String) -> () {
   if !(actual <= bound) {
     panic("Assertion failed: " ++ show(actual) ++ " should be <= " ++ show(bound) ++ ": " ++ message);
   }
 }
 
 /// Assert actual > bound
-fn assert_gt<T>(actual: T, bound: T, message: String) -> () {
+pub fn assert_gt<T>(actual: T, bound: T, message: String) -> () {
   if !(actual > bound) {
     panic("Assertion failed: " ++ show(actual) ++ " should be > " ++ show(bound) ++ ": " ++ message);
   }
 }
 
 /// Assert actual >= bound
-fn assert_ge<T>(actual: T, bound: T, message: String) -> () {
+pub fn assert_ge<T>(actual: T, bound: T, message: String) -> () {
   if !(actual >= bound) {
     panic("Assertion failed: " ++ show(actual) ++ " should be >= " ++ show(bound) ++ ": " ++ message);
   }
 }
 
 /// Assert two floats are equal within an epsilon tolerance
-fn assert_float_eq(actual: Float, expected: Float, epsilon: Float, message: String) -> () {
+pub fn assert_float_eq(actual: Float, expected: Float, epsilon: Float, message: String) -> () {
   let diff = if actual > expected { actual - expected } else { expected - actual };
   if diff > epsilon {
     panic("Assertion failed: " ++ show(actual) ++ " != " ++ show(expected) ++ " (epsilon " ++ show(epsilon) ++ "): " ++ message);
@@ -113,21 +113,21 @@ fn assert_float_eq(actual: Float, expected: Float, epsilon: Float, message: Stri
 // ============================================================================
 
 /// Assert a list is empty
-fn assert_empty<T>(list: [T], message: String) -> () {
+pub fn assert_empty<T>(list: [T], message: String) -> () {
   if len(list) != 0 {
     panic("Assertion failed: list should be empty (length " ++ show(len(list)) ++ "): " ++ message);
   }
 }
 
 /// Assert a list is not empty
-fn assert_not_empty<T>(list: [T], message: String) -> () {
+pub fn assert_not_empty<T>(list: [T], message: String) -> () {
   if len(list) == 0 {
     panic("Assertion failed: list should not be empty: " ++ message);
   }
 }
 
 /// Assert list has expected length
-fn assert_length<T>(list: [T], expected_len: Int, message: String) -> () {
+pub fn assert_length<T>(list: [T], expected_len: Int, message: String) -> () {
   let actual_len = len(list);
   if actual_len != expected_len {
     panic("Assertion failed: expected length " ++ show(expected_len) ++ ", got " ++ show(actual_len) ++ ": " ++ message);
@@ -135,7 +135,7 @@ fn assert_length<T>(list: [T], expected_len: Int, message: String) -> () {
 }
 
 /// Assert list contains a specific element
-fn assert_contains<T>(list: [T], element: T, message: String) -> () {
+pub fn assert_contains<T>(list: [T], element: T, message: String) -> () {
   let mut found = false;
   for x in list {
     if x == element {
@@ -148,7 +148,7 @@ fn assert_contains<T>(list: [T], element: T, message: String) -> () {
 }
 
 /// Assert a string contains a substring
-fn assert_str_contains(haystack: String, needle: String, message: String) -> () {
+pub fn assert_str_contains(haystack: String, needle: String, message: String) -> () {
   if string_find(haystack, needle) < 0 {
     panic("Assertion failed: \"" ++ haystack ++ "\" should contain \"" ++ needle ++ "\": " ++ message);
   }
@@ -174,7 +174,7 @@ type TestSuite = {
 }
 
 /// Run a single test case, catching panics
-fn run_test(test: TestCase) -> TestResult {
+pub fn run_test(test: TestCase) -> TestResult {
   println("  Running: " ++ test.name);
   try {
     let result = test.test();
@@ -201,7 +201,7 @@ fn run_test(test: TestCase) -> TestResult {
 }
 
 /// Run all tests in a suite and return (passed, failed) counts
-fn run_suite(suite: TestSuite) -> (Int, Int) {
+pub fn run_suite(suite: TestSuite) -> (Int, Int) {
   println("Running suite: " ++ suite.name);
   let mut passed = 0;
   let mut failed = 0;
@@ -218,7 +218,7 @@ fn run_suite(suite: TestSuite) -> (Int, Int) {
 }
 
 /// Run multiple test suites and return aggregate (passed, failed) counts
-fn run_suites(suites: [TestSuite]) -> (Int, Int) {
+pub fn run_suites(suites: [TestSuite]) -> (Int, Int) {
   let mut total_passed = 0;
   let mut total_failed = 0;
 
@@ -239,7 +239,7 @@ fn run_suites(suites: [TestSuite]) -> (Int, Int) {
 // ============================================================================
 
 /// Check that a property holds for all elements in a list
-fn for_all<T>(values: [T], prop: T -> Bool) -> TestResult {
+pub fn for_all<T>(values: [T], prop: T -> Bool) -> TestResult {
   for value in values {
     if !prop(value) {
       return Fail("Property failed for value: " ++ show(value));
@@ -249,7 +249,7 @@ fn for_all<T>(values: [T], prop: T -> Bool) -> TestResult {
 }
 
 /// Check that a property holds for at least one element
-fn exists<T>(values: [T], prop: T -> Bool) -> TestResult {
+pub fn exists<T>(values: [T], prop: T -> Bool) -> TestResult {
   for value in values {
     if prop(value) {
       return Pass;
@@ -259,7 +259,7 @@ fn exists<T>(values: [T], prop: T -> Bool) -> TestResult {
 }
 
 /// Check that a property is an involution (applying twice yields the original)
-fn assert_involution<T>(f: T -> T, values: [T], message: String) -> () {
+pub fn assert_involution<T>(f: T -> T, values: [T], message: String) -> () {
   for v in values {
     let round_tripped = f(f(v));
     if round_tripped != v {
@@ -269,7 +269,7 @@ fn assert_involution<T>(f: T -> T, values: [T], message: String) -> () {
 }
 
 /// Check that a binary operation is commutative over given pairs
-fn assert_commutative<T, R>(op: (T, T) -> R, pairs: [(T, T)], message: String) -> () {
+pub fn assert_commutative<T, R>(op: (T, T) -> R, pairs: [(T, T)], message: String) -> () {
   for (a, b) in pairs {
     let lhs = op(a, b);
     let rhs = op(b, a);
@@ -293,7 +293,7 @@ type BenchResult = {
 
 /// Benchmark a function by running it for the given number of iterations.
 /// Returns timing statistics using the time_now() builtin.
-fn bench(f: () -> (), iterations: Int) -> BenchResult {
+pub fn bench(f: () -> (), iterations: Int) -> BenchResult {
   let start = time_now();
 
   let mut i = 0;
@@ -311,7 +311,7 @@ fn bench(f: () -> (), iterations: Int) -> BenchResult {
 }
 
 /// Compare performance of two functions side-by-side
-fn bench_compare(name1: String, f1: () -> (), name2: String, f2: () -> (), iterations: Int) -> (BenchResult, BenchResult) {
+pub fn bench_compare(name1: String, f1: () -> (), name2: String, f2: () -> (), iterations: Int) -> (BenchResult, BenchResult) {
   println("Benchmarking " ++ name1 ++ " vs " ++ name2 ++ " (" ++ show(iterations) ++ " iterations)");
 
   let r1 = bench(f1, iterations);


### PR DESCRIPTION
## Summary

Completes the pub-visibility sweep for the 5 stdlib modules listed in #508, applying the same rule PR #505 used for `string.affine` and `collections.affine`: any `fn` immediately preceded by a `///` doc comment is pub-intent and gets the `pub` keyword.

## Inventory (verified post-change)

| Module     | pub before | pub after | non-pub remaining |
|------------|-----------:|----------:|------------------:|
| `io`       | 0          | 15        | 0                 |
| `math`     | 0          | 36        | 0                 |
| `option`   | 1          | 36        | 0                 |
| `result`   | 0          | 24        | 0                 |
| `testing`  | 0          | 26        | 0                 |

**136 fns** now reachable from consumers (was 1 of 137).

## Verification

- `dune build bin/main.exe` — clean
- `dune runtest` — **368/368 PASS**

## Estate impact (idaptik migration corpus, run as oracle audit)

Pre-change: 68/86 PASS, 18 FAIL (4 parse, 14 type).

The 14 type failures all surface as `Resolution error: undefined value: \`min_float\`` / `\`max_float\``. These are now correctly classified as **consumer-side import gaps** — the 11 affected idaptik files need `use math::{min_float, max_float};`. Companion PR on `hyperpolymath/idaptik` adds those.

The 4 parse errors are in `migration/main/{Boot,Main,StartupError,MultiplayerHandlers}.affine` — explicitly tagged \"Mode B (design-demo) — NOT v0.1.0-compileable\" in their headers, using `import X;` + effect-row syntax that's RFC-tracked (RFC #45/#59 etc.) but not shipping. **Out of scope** for this PR.

## Refs

- Closes #508
- Refs #505 (the precedent — string + collections)
- Refs standards#279 (the original surfacing in idaptik PortNames.affine port)
- Companion: PR on `hyperpolymath/idaptik` (to add `use math::{...}` to 11 consumer files)