### PR TITLE
docs(examples): wasm-exports-demo.affine + smoke harness (closes #500)

### DIFF
--- a/docs/bindings-roadmap.adoc
+++ b/docs/bindings-roadmap.adoc
@@ -75,7 +75,7 @@ no further significant ReScript → AffineScript work is tractable.
 |*WASM-exports calling pattern* — invoke individual `exports.fn_name(args)` from a `WasmExports` value
 |`●` usable (Option A landed)
 |`stdlib/Deno.affine`
-|`wasmCall(exports: WasmExports, name: String, args: [Float]) -> Float` lowers to `Number(exports[name](...args))` on `--deno-esm`. AS-side surface + docstring example landed in `stdlib/Deno.affine`; round-trip exercised by `tests/codegen-deno/wasm_call.{affine,harness.mjs}` against a hand-built 41-byte wasm module exporting `add(i32, i32) -> i32`. *Option A (generic) — typed per-Zig-fn shims can layer on top per-consumer if needed.* Closes #414 via host-side #422 + AS-side this PR.
+|`wasmCall(exports: WasmExports, name: String, args: [Float]) -> Float` lowers to `Number(exports[name](...args))` on `--deno-esm`. AS-side surface + docstring example landed in `stdlib/Deno.affine`; round-trip exercised by `tests/codegen-deno/wasm_call.{affine,harness.mjs}` against a hand-built 41-byte wasm module exporting `add(i32, i32) -> i32`. *Option A (generic) — typed per-Zig-fn shims can layer on top per-consumer if needed.* Closes #414 via host-side #422 + AS-side this PR. *Generic export-call shipped #455* (`wasm_export_call(exports, name, args: [WasmValue]) -> WasmValue` + `WasmValue` opaque + `wv_i32`/`wv_i64`/`wv_f32`/`wv_f64` + `wv_as_int`/`wv_as_float`/`wv_kind`); end-to-end demo at `examples/wasm-exports-demo.affine` (#500) with smoke-test `tests/codegen-deno/wasm_exports_demo.{affine,harness.mjs}` exercising all four scalar kinds.
 
 |6
 |*Phoenix Channels / WebSocket* (Socket connect/disconnect, Channel join/leave/push, presence)

--- a/examples/wasm-exports-demo.affine
+++ b/examples/wasm-exports-demo.affine
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// wasm-exports-demo — end-to-end usage example for the generic
+// `wasm_export_call` binding (#455 — Tier 1 #5, closes #500).
+//
+// What this demonstrates
+// ----------------------
+//
+// `stdlib/Deno.affine` exposes a single calling primitive for wasm
+// exports:
+//
+//     wasm_export_call(exports, name, args: [WasmValue]) -> WasmValue
+//
+// Values cross the AS↔JS boundary as `WasmValue` — an opaque host
+// handle wrapping `{ kind: "i32"|"i64"|"f32"|"f64", v: <number> }`.
+// The four `wv_*` constructors marshal a typed AS value into a
+// `WasmValue`; the `wv_as_*` accessors read it back out.
+//
+// This file ships one driver per wasm scalar kind. A loaded host module
+// is expected to export four functions:
+//
+//     add_i32 :: (i32, i32) -> i32
+//     add_i64 :: (i64, i64) -> i64
+//     mul_f32 :: (f32, f32) -> f32
+//     mul_f64 :: (f64, f64) -> f64
+//
+// The harness `tests/codegen-deno/wasm_exports_demo.{affine,harness.mjs}`
+// instantiates a hand-built wasm module with exactly that shape and
+// asserts every driver round-trips.
+//
+// Why one driver per kind
+// -----------------------
+//
+// `wasm_export_call`'s return value is always a `WasmValue`. AS code
+// has to know the expected kind statically to pick `wv_as_int`
+// (i32/i64 → Int) or `wv_as_float` (f32/f64 → Float). The drivers
+// below pin that knowledge at the AS-side call site — exactly the
+// pattern downstream consumers should copy. A `wv_kind`-driven dynamic
+// dispatch is also possible (see `dispatch_unknown` at the bottom)
+// for the rare case where the kind is not statically known.
+//
+// Usage in your own AS code
+// -------------------------
+//
+//     use Deno::{
+//       Bytes, WasmExports, wasmInstance, wasm_export_call,
+//       wv_i32, wv_as_int,
+//     };
+//
+//     pub fn add_via_wasm(bytes: Bytes, a: Int, b: Int) -> Int {
+//       let exports = wasmInstance(bytes);
+//       let result = wasm_export_call(
+//         exports, "add", [wv_i32(a), wv_i32(b)]);
+//       wv_as_int(result)
+//     }
+
+use Deno::{ WasmExports, wasm_export_call, wv_i32, wv_i64, wv_f32, wv_f64, wv_as_int, wv_as_float, wv_kind };
+
+// ── Drivers — one per wasm scalar kind ───────────────────────────
+
+/// Call a wasm export of shape `add_i32(i32, i32) -> i32` and read
+/// the result as an AS `Int`.
+///
+/// The four-step pattern (marshal → call → marshal-back → cast) is
+/// the canonical use of `wasm_export_call`; every other driver below
+/// follows the same shape.
+pub fn add_i32_via_wasm(exports: WasmExports, a: Int, b: Int) -> Int {
+  let result = wasm_export_call(
+    exports, "add_i32", [wv_i32(a), wv_i32(b)]);
+  wv_as_int(result)
+}
+
+/// `add_i64(i64, i64) -> i64`. Values cross the boundary as `BigInt`
+/// host-side, so values beyond ±2^53 preserve exact precision until
+/// they round-trip back through `wv_as_int` (which clamps to the
+/// JS safe-integer range).
+pub fn add_i64_via_wasm(exports: WasmExports, a: Int, b: Int) -> Int {
+  let result = wasm_export_call(
+    exports, "add_i64", [wv_i64(a), wv_i64(b)]);
+  wv_as_int(result)
+}
+
+/// `mul_f32(f32, f32) -> f32`. Inputs are rounded to f32 precision
+/// via `Math.fround` at the host boundary; outputs come back as JS
+/// numbers (f64), and `wv_as_float` returns the AS `Float`.
+pub fn mul_f32_via_wasm(exports: WasmExports, a: Float, b: Float) -> Float {
+  let result = wasm_export_call(
+    exports, "mul_f32", [wv_f32(a), wv_f32(b)]);
+  wv_as_float(result)
+}
+
+/// `mul_f64(f64, f64) -> f64`. Full f64 precision preserved in both
+/// directions.
+pub fn mul_f64_via_wasm(exports: WasmExports, a: Float, b: Float) -> Float {
+  let result = wasm_export_call(
+    exports, "mul_f64", [wv_f64(a), wv_f64(b)]);
+  wv_as_float(result)
+}
+
+// ── Dynamic dispatch (the rare case) ─────────────────────────────
+
+/// When the kind of an export's return is not statically known —
+/// e.g. when wrapping an unknown wasm module — read the result kind
+/// at runtime via `wv_kind` and map to a tagged AS value.
+///
+/// Returns a one-character kind code as a `String` so the caller can
+/// decide what to do (we keep this binding small; a richer sum-type
+/// dispatch can layer on top once tagged-variant codegen for the
+/// Deno-ESM backend ships).
+pub fn dispatch_unknown(exports: WasmExports, name: String, args: [WasmValue]) -> String {
+  let result = wasm_export_call(exports, name, args);
+  wv_kind(result)
+}

--- a/tests/codegen-deno/wasm_exports_demo.affine
+++ b/tests/codegen-deno/wasm_exports_demo.affine
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MPL-2.0
+// #500 — smoke test for examples/wasm-exports-demo.affine drivers.
+//
+// Test surface mirrors the example: one wrapper per wasm scalar kind.
+// The harness instantiates a hand-built wasm module with four
+// exports (add_i32 / add_i64 / mul_f32 / mul_f64) and asserts each
+// driver round-trips at the boundary.
+
+use Deno::{ WasmExports, wasm_export_call, wv_i32, wv_i64, wv_f32, wv_f64, wv_as_int, wv_as_float };
+
+pub fn add_i32_via_wasm(exports: WasmExports, a: Int, b: Int) -> Int {
+  let result = wasm_export_call(
+    exports, "add_i32", [wv_i32(a), wv_i32(b)]);
+  wv_as_int(result)
+}
+
+pub fn add_i64_via_wasm(exports: WasmExports, a: Int, b: Int) -> Int {
+  let result = wasm_export_call(
+    exports, "add_i64", [wv_i64(a), wv_i64(b)]);
+  wv_as_int(result)
+}
+
+pub fn mul_f32_via_wasm(exports: WasmExports, a: Float, b: Float) -> Float {
+  let result = wasm_export_call(
+    exports, "mul_f32", [wv_f32(a), wv_f32(b)]);
+  wv_as_float(result)
+}
+
+pub fn mul_f64_via_wasm(exports: WasmExports, a: Float, b: Float) -> Float {
+  let result = wasm_export_call(
+    exports, "mul_f64", [wv_f64(a), wv_f64(b)]);
+  wv_as_float(result)
+}

--- a/tests/codegen-deno/wasm_exports_demo.harness.mjs
+++ b/tests/codegen-deno/wasm_exports_demo.harness.mjs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MPL-2.0
+// #500 — Node-ESM harness for examples/wasm-exports-demo.affine.
+//
+// Instantiates a hand-built 120-byte wasm module exporting four
+// scalar-typed functions (one per WasmValue kind), then verifies each
+// AS-side driver round-trips through the `wasm_export_call` boundary.
+
+import assert from "node:assert/strict";
+import {
+  add_i32_via_wasm,
+  add_i64_via_wasm,
+  mul_f32_via_wasm,
+  mul_f64_via_wasm,
+} from "./wasm_exports_demo.deno.js";
+
+// Hand-built minimal wasm module:
+//   (module
+//     (func (export "add_i32") (param i32 i32) (result i32)
+//       local.get 0  local.get 1  i32.add)
+//     (func (export "add_i64") (param i64 i64) (result i64)
+//       local.get 0  local.get 1  i64.add)
+//     (func (export "mul_f32") (param f32 f32) (result f32)
+//       local.get 0  local.get 1  f32.mul)
+//     (func (export "mul_f64") (param f64 f64) (result f64)
+//       local.get 0  local.get 1  f64.mul))
+//
+// Layout (each section is `id` `size` `count` `entries…`):
+//   - magic + version: 8 bytes
+//   - type    section (0x01): 4 func-types        — (TT)->T for T∈{i32,i64,f32,f64}
+//   - func    section (0x03): 4 funcs idx -> type — 0->0, 1->1, 2->2, 3->3
+//   - export  section (0x07): 4 exports           — "add_i32"/"add_i64"/"mul_f32"/"mul_f64"
+//   - code    section (0x0a): 4 bodies            — local.get 0, local.get 1, <op>, end
+const wasmBytes = new Uint8Array([
+  // Magic + version
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+
+  // Type section (0x01), size 25, count 4
+  0x01, 0x19, 0x04,
+  // (i32,i32)->i32
+  0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f,
+  // (i64,i64)->i64
+  0x60, 0x02, 0x7e, 0x7e, 0x01, 0x7e,
+  // (f32,f32)->f32
+  0x60, 0x02, 0x7d, 0x7d, 0x01, 0x7d,
+  // (f64,f64)->f64
+  0x60, 0x02, 0x7c, 0x7c, 0x01, 0x7c,
+
+  // Function section (0x03), size 5, count 4
+  0x03, 0x05, 0x04, 0x00, 0x01, 0x02, 0x03,
+
+  // Export section (0x07), size 41, count 4
+  0x07, 0x29, 0x04,
+  // "add_i32" -> func 0
+  0x07, 0x61, 0x64, 0x64, 0x5f, 0x69, 0x33, 0x32, 0x00, 0x00,
+  // "add_i64" -> func 1
+  0x07, 0x61, 0x64, 0x64, 0x5f, 0x69, 0x36, 0x34, 0x00, 0x01,
+  // "mul_f32" -> func 2
+  0x07, 0x6d, 0x75, 0x6c, 0x5f, 0x66, 0x33, 0x32, 0x00, 0x02,
+  // "mul_f64" -> func 3
+  0x07, 0x6d, 0x75, 0x6c, 0x5f, 0x66, 0x36, 0x34, 0x00, 0x03,
+
+  // Code section (0x0a), size 33, count 4
+  0x0a, 0x21, 0x04,
+  // add_i32 body: local.get 0  local.get 1  i32.add  end
+  0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b,
+  // add_i64 body: local.get 0  local.get 1  i64.add  end
+  0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x7c, 0x0b,
+  // mul_f32 body: local.get 0  local.get 1  f32.mul  end
+  0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x94, 0x0b,
+  // mul_f64 body: local.get 0  local.get 1  f64.mul  end
+  0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0xa2, 0x0b,
+]);
+
+const instance = new WebAssembly.Instance(new WebAssembly.Module(wasmBytes));
+const exports = instance.exports;
+
+// Sanity-check the hand-built module before we trust the AS path.
+assert.equal(exports.add_i32(2, 3), 5, "module add_i32(2,3) == 5");
+assert.equal(exports.add_i64(2n, 3n), 5n, "module add_i64(2,3) == 5n");
+assert.ok(Math.abs(exports.mul_f32(2.5, 4.0) - 10) < 1e-5, "module mul_f32(2.5,4) ~= 10");
+assert.ok(Math.abs(exports.mul_f64(2.5, 4.0) - 10) < 1e-12, "module mul_f64(2.5,4) ~= 10");
+
+// ── i32 round-trip ──────────────────────────────────────────────
+assert.equal(add_i32_via_wasm(exports, 2, 3),       5,   "add_i32(2,3) == 5");
+assert.equal(add_i32_via_wasm(exports, -1, 1),      0,   "add_i32(-1,1) == 0");
+assert.equal(add_i32_via_wasm(exports, 100, 200),   300, "add_i32(100,200) == 300");
+
+// ── i64 round-trip — large values past i32 range ────────────────
+assert.equal(add_i64_via_wasm(exports, 4000000000, 1000000000),
+             5000000000, "add_i64 sums values beyond i32 range");
+
+// ── f32 round-trip — assert at f32 precision (~1e-6) ────────────
+{
+  const got = mul_f32_via_wasm(exports, 2.5, 4.0);
+  assert.ok(Math.abs(got - 10.0) < 1e-5, `mul_f32(2.5, 4) ~= 10 (got ${got})`);
+}
+{
+  const got = mul_f32_via_wasm(exports, 0.1, 0.2);
+  assert.ok(Math.abs(got - 0.02) < 1e-5, `mul_f32(0.1, 0.2) ~= 0.02 (got ${got})`);
+}
+
+// ── f64 round-trip ──────────────────────────────────────────────
+{
+  const got = mul_f64_via_wasm(exports, 2.5, 4.0);
+  assert.ok(Math.abs(got - 10.0) < 1e-12, `mul_f64(2.5, 4) ~= 10 (got ${got})`);
+}
+{
+  const got = mul_f64_via_wasm(exports, Math.PI, Math.E);
+  assert.ok(Math.abs(got - Math.PI * Math.E) < 1e-12, "mul_f64 π × e at f64 precision");
+}
+
+console.log("wasm_exports_demo.harness.mjs OK");


### PR DESCRIPTION
## Summary

Lands the deferred end-to-end demo for the generic `wasm_export_call` binding (Tier 1 #5, #455). `examples/wasm-exports-demo.affine` ships one driver per `WasmValue` scalar kind (`add_i32` / `add_i64` / `mul_f32` / `mul_f64` + a `dispatch_unknown` for the runtime-dispatch case), and a smoke fixture at `tests/codegen-deno/wasm_exports_demo.{affine,harness.mjs}` round-trips each through a hand-built 120-byte wasm module exporting all four shapes.

The harness asserts both the raw module exports and the AS-side wrappers at appropriate precision: exact for i32/i64 (including values past i32 range, exercising the i64 BigInt boundary), 1e-5 for f32, 1e-12 for f64.

`docs/bindings-roadmap.adoc` Tier-1 row 5 grows a pointer to the new example so future readers find the canonical end-to-end demo.

## Test plan

- [x] `dune build` clean
- [x] `dune test` — 375/375 (was 374; +1 from examples/ auto-discovery picking up the new file)
- [x] `bash tools/run_codegen_deno_tests.sh` — all codegen-deno harnesses green, including new `wasm_exports_demo.harness.mjs`
- [x] AS frontend accepts `examples/wasm-exports-demo.affine` (`affinescript check`)

## Closes

- #500 — examples/wasm-exports-demo.affine end-to-end usage demo

## Refs

- #455 (closed kickoff; landed via PR #467) — shipped surface
- #446 / #450 — Tier 1 umbrella + sub-issue list
- `docs/bindings-roadmap.adoc` Tier 1 row 5 — updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)