### PR TITLE
security: standardize secret scanning on TruffleHog (+ ADR-023 draft stub, zig wasm_export_call types)

### DIFF
--- a/.github/workflows/affine-vscode-publish.yml
+++ b/.github/workflows/affine-vscode-publish.yml
@@ -17,26 +17,21 @@
 # publish rights to the @hyperpolymath scope).
 
 name: Publish affine-vscode
-
 on:
   push:
     tags:
       - 'affine-vscode-v*'
-
 permissions:
   contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Verify tag matches package version
         working-directory: packages/affine-vscode
         run: |
@@ -47,7 +42,6 @@ jobs:
             exit 1
           fi
           echo "✅ Publishing @hyperpolymath/affine-vscode@$pkg"
-
       - name: Configure npm auth
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -57,11 +51,9 @@ jobs:
             exit 1
           fi
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${HOME}/.npmrc"
-
       - name: Publish to npm
         working-directory: packages/affine-vscode
         run: npm publish --access public
-
       - name: Clean up npm auth
         if: always()
         run: rm -f "${HOME}/.npmrc"

--- a/.github/workflows/casket-pages.yml
+++ b/.github/workflows/casket-pages.yml
@@ -1,20 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0
 name: GitHub Pages
-
 on:
   push:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   contents: read
   pages: write
   id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
 jobs:
   # Pages is a repo-level admin feature; a workflow's `GITHUB_TOKEN`
   # cannot enable it from CI, regardless of `pages: write` at workflow
@@ -45,7 +41,6 @@ jobs:
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Pages not enabled on ${GITHUB_REPOSITORY} — skipping build/deploy. Enable via repo Settings → Pages to unblock."
           fi
-
   build:
     needs: precheck
     if: needs.precheck.outputs.enabled == 'true'
@@ -53,19 +48,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-
       - name: Checkout casket-ssg
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           repository: hyperpolymath/casket-ssg
           path: .casket-ssg
-
       - name: Setup GHCup
         uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553 # v2
         with:
           ghc-version: '9.8.2'
           cabal-version: '3.10'
-
       - name: Cache Cabal
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4
         with:
@@ -74,11 +66,9 @@ jobs:
             ~/.cabal/store
             .casket-ssg/dist-newstyle
           key: ${{ runner.os }}-casket-${{ hashFiles('.casket-ssg/casket-ssg.cabal') }}
-
       - name: Build casket-ssg
         working-directory: .casket-ssg
         run: cabal build
-
       - name: Build site
         run: |
           mkdir -p site _site
@@ -109,7 +99,6 @@ jobs:
             fi
           fi
           cd .casket-ssg && cabal run casket-ssg -- build ../site ../_site
-
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         with:
@@ -121,12 +110,10 @@ jobs:
           # own permissions (pages: write, id-token: write) authorise
           # this.
           enablement: true
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: '_site'
-
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,42 +1,33 @@
 # SPDX-License-Identifier: MPL-2.0
 name: CI
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
 permissions:
   contents: read
-
 # Actions concurrency pool. Applied only to read-only check workflows
 # (no publish/mutation), so cancelling a superseded run is always safe.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Set up OCaml
         uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3
         with:
           ocaml-compiler: "5.1"
-
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
           node-version: "20"
-
       - name: Install dependencies
         run: opam install . --deps-only --with-test --with-doc
-
       - name: Install tree-sitter CLI (for res-to-affine walker tests)
         # Same rationale as the migration-assistant job (see below):
         # npm distribution is the fast CI install (~5 s). The walker
@@ -45,28 +36,21 @@ jobs:
         # this step is only required to *exercise* the walker — the
         # build itself does not depend on it.
         run: npm install -g tree-sitter-cli@^0.25.0
-
       - name: Build pinned tree-sitter-rescript grammar
         run: ./editors/tree-sitter-rescript/scripts/install.sh
-
       - name: Build
         run: opam exec -- dune build
-
       - name: Run tests
         run: opam exec -- dune runtest
-
       - name: Run codegen WASM tests
         run: opam exec -- ./tools/run_codegen_wasm_tests.sh
-
       - name: Run codegen Deno-ESM tests (issue #122)
         # Compiles tests/codegen-deno/*.affine with the --deno-esm backend
         # and runs the *.harness.mjs under Node (CI has Node 20, not Deno;
         # the Phase 1 fixtures are pure logic so Node ESM exercises them).
         run: opam exec -- ./tools/run_codegen_deno_tests.sh
-
       - name: Run face-transformer regression tests
         run: opam exec -- ./tools/run_face_transformer_tests.sh
-
       - name: Issue #35 Phase 3 — block extension.ts regression
         # The vscode extension is now authored in extension.affine and
         # compiled to extension.cjs. Re-introducing extension.ts would
@@ -74,7 +58,6 @@ jobs:
         # the policy forbids. See tools/check-no-extension-ts.sh for
         # rationale + recovery instructions.
         run: ./tools/check-no-extension-ts.sh
-
       - name: Issue #176 — doc-truthing re-drift guard (DOC-01..09)
         # Single toolchain-free gate enforcing both halves of the doc-truthing
         # MONITOR: the presence invariants (DOC-04/05 — banner pointers, matrix
@@ -83,65 +66,51 @@ jobs:
         # "production-ready" / stdlib-% phrase beyond tools/doc-overclaims.allow).
         # See tools/check-doc-truthing.sh.
         run: ./tools/check-doc-truthing.sh
-
       - name: Check formatting
         run: opam exec -- dune build @fmt
-
   lint:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Set up OCaml
         uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3
         with:
           ocaml-compiler: "5.1"
-
       - name: Install dependencies
         # Match the build job: `dune build` compiles everything including
         # test/ (which depends on alcotest, with-test) and the @doc target
         # below (which depends on odoc, with-doc). Without these flags, lint
         # fails on missing alcotest before it ever reaches the doc step.
         run: opam install . --deps-only --with-test --with-doc
-
       - name: Build
         run: opam exec -- dune build
-
       - name: Lint with odoc
         run: opam exec -- dune build @doc
         continue-on-error: true
-
   bench-visibility:
     # Visibility-only microbenchmarks per docs/standards/TESTING.adoc
     # §"Bench standards". Does NOT block merge. Promotion to a
     # ratcheted gate requires a calibrated baseline first.
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Set up OCaml
         uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3
         with:
           ocaml-compiler: "5.1"
-
       - name: Install dependencies
         run: opam install . --deps-only --with-test --with-doc
-
       - name: Build bench targets
         run: opam exec -- dune build @bench --force
         continue-on-error: true
-
       - name: Run benches
         id: bench
         continue-on-error: true
         run: |
           set -o pipefail
           opam exec -- dune runtest @bench --force 2>&1 | tee bench-output.log
-
       - name: Render bench summary
         if: always()
         run: |
@@ -156,7 +125,6 @@ jobs:
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload bench log
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -164,35 +132,28 @@ jobs:
           name: bench-output
           path: bench-output.log
           retention-days: 30
-
   coverage-visibility:
     # Visibility-only coverage report per
     # docs/standards/TESTING.adoc §"Coverage (visibility-only)".
     # No merge-blocking floor today.
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Set up OCaml
         uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3
         with:
           ocaml-compiler: "5.1"
-
       - name: Install dependencies
         run: opam install . --deps-only --with-test --with-doc
-
       - name: Run tests with bisect_ppx instrumentation
         run: |
           opam exec -- dune runtest --force --instrument-with bisect_ppx
-
       - name: Generate HTML coverage report
         continue-on-error: true
         run: |
           opam exec -- bisect-ppx-report html -o _coverage --title="AffineScript coverage"
           opam exec -- bisect-ppx-report summary | tee coverage-summary.txt
-
       - name: Render coverage summary
         if: always()
         run: |
@@ -207,7 +168,6 @@ jobs:
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload coverage HTML
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -215,7 +175,6 @@ jobs:
           name: coverage-html
           path: _coverage
           retention-days: 30
-
   vscode-smoke:
     # In-editor end-to-end smoke test for the .affine VS Code extension
     # (issue #139). Loads the compiled out/extension.cjs in a real VS Code
@@ -232,16 +191,13 @@ jobs:
     # (previously gated on #104's npm publish). A real regression should
     # turn this job red and gate, so no `continue-on-error`.
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
           node-version: "20"
-
       - name: Install test runner dependencies
         working-directory: editors/vscode
         # The compiled out/extension.cjs is checked in (see #35 Phase 3)
@@ -251,7 +207,6 @@ jobs:
         # The #381 SKIP-when-missing guard remains downstream as a safety
         # net but is now expected to find the adapter present.
         run: npm install --no-audit --no-fund
-
       - name: Report adapter availability
         working-directory: editors/vscode
         # Surface the @hyperpolymath/affine-vscode publish state in the
@@ -264,7 +219,6 @@ jobs:
           else
             echo "::notice title=adapter::@hyperpolymath/affine-vscode NOT installed (optional, awaits #104 npm publish) — smoke will skip"
           fi
-
       - name: Run in-editor smoke (xvfb)
         working-directory: editors/vscode
         # Headless display required because @vscode/test-electron launches
@@ -272,7 +226,6 @@ jobs:
         # available the suite calls `this.skip()` in suiteSetup and exits
         # 0 with all tests marked skipped (mocha's expected behaviour).
         run: xvfb-run -a npm test
-
   migration-assistant:
     # Build pinned tree-sitter-rescript grammar consumed by the
     # `.res → .affine` migration assistant (#57 Phase 2). The grammar
@@ -281,16 +234,13 @@ jobs:
     # commit still build cleanly and (b) gate `tools/res-to-affine/`
     # walker work that depends on the generated parser.
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
           node-version: "20"
-
       - name: Install tree-sitter CLI
         # npm install of tree-sitter-cli is the fast CI path (~5 s vs.
         # ~5 min for `cargo install tree-sitter-cli`). The repo's
@@ -300,7 +250,6 @@ jobs:
         # tracks `tree-sitter-rescript`'s package.json devDependency
         # range.
         run: npm install -g tree-sitter-cli@^0.25.0
-
       - name: Build pinned tree-sitter-rescript grammar
         # Direct script invocation rather than `just install-grammar` —
         # GitHub Actions runners do not ship `just` preinstalled, and
@@ -308,7 +257,6 @@ jobs:
         # adding a setup step for it. The justfile recipe still exists
         # for local developer ergonomics; both call the same script.
         run: ./editors/tree-sitter-rescript/scripts/install.sh
-
       - name: Verify generated parser
         # `tree-sitter generate` is supposed to drop src/parser.c into
         # the cloned grammar. If it didn't, the install path is broken
@@ -318,7 +266,6 @@ jobs:
           test -f tools/vendor/tree-sitter-rescript/src/parser.c \
             || { echo "error: parser.c not produced by tree-sitter generate" >&2; exit 1; }
           echo "parser.c size: $(wc -c < tools/vendor/tree-sitter-rescript/src/parser.c) bytes"
-
       - name: Smoke-parse a sample .res file
         # Sanity-check that the grammar actually parses a non-trivial
         # ReScript source. Picks the existing res-to-affine test fixture

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 name: CodeQL Security Analysis
-
 on:
   push:
     branches: [main, master]
@@ -8,7 +7,6 @@ on:
     branches: [main, master]
   schedule:
     - cron: '0 6 1 * *'
-
 # Estate guardrail: cancel superseded runs so re-pushes / rebased PR
 # updates do not pile up queued runs against the shared account-wide
 # Actions concurrency pool. Applied only to read-only check workflows
@@ -16,9 +14,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 permissions: read-all
-
 jobs:
   analyze:
     runs-on: ubuntu-latest
@@ -33,17 +29,14 @@ jobs:
           # Using 'actions' to scan GitHub Actions workflow files
           - language: actions
             build-mode: none
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.1
         with:

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -5,13 +5,11 @@
 # workflows (rust-ci, codeql, dependabot, release, secret-scanner, scorecard)
 # stay standalone in this repo.
 name: Governance
-
 on:
   push:
     branches: [main, master]
   pull_request:
   workflow_dispatch:
-
 # Estate guardrail: cancel superseded runs so re-pushes / rebased PR
 # updates do not pile up queued runs against the shared account-wide
 # Actions concurrency pool. Applied only to read-only check workflows
@@ -19,10 +17,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
-
 jobs:
   governance:
     uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@main

--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -3,7 +3,6 @@
 # See standards#191 for the reusable's purpose and design.
 
 name: Hypatia Security Scan
-
 on:
   push:
     branches: [main, master, develop]
@@ -12,17 +11,14 @@ on:
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:
-
 # Estate guardrail: cancel superseded runs so re-pushes don't pile up.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
   security-events: write
   pull-requests: write
-
 jobs:
   hypatia:
     uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@5eb28d7d8790d5389b7b6a5233fe6265a775e3d0

--- a/.github/workflows/instant-sync.yml
+++ b/.github/workflows/instant-sync.yml
@@ -1,20 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0
 # Instant Forge Sync - Triggers propagation to all forges on push/release
 name: Instant Sync
-
 on:
   push:
     branches: [main, master]
   release:
     types: [published]
-
 permissions:
   contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   dispatch:
     runs-on: ubuntu-latest
@@ -37,6 +33,5 @@ jobs:
               "sha": "${{ github.sha }}",
               "forges": ""
             }
-
       - name: Confirm
         run: echo "::notice::Propagation triggered for ${{ github.event.repository.name }}"

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,14 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
 name: Mirror to Git Forges
-
 on:
   push:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   mirror:
     uses: hyperpolymath/standards/.github/workflows/mirror-reusable.yml@e6b2884722350515934d443daf23442f2195796f

--- a/.github/workflows/panic-attack.yml
+++ b/.github/workflows/panic-attack.yml
@@ -13,22 +13,18 @@
 #       Installed from crates.io.
 
 name: Panic-Attack (compliance scan)
-
 on:
   schedule:
     # Sundays 03:00 UTC — quiet window for the estate's CI fleet.
     - cron: '0 3 * * 0'
   workflow_dispatch:
-
 # Read-only audit workflow — safe to cancel superseded runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
-  issues: write  # opens a tracking issue on unresolved critical/high
-
+  issues: write # opens a tracking issue on unresolved critical/high
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -37,12 +33,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Install Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
-
       - name: Install panic-attacker
         # Installed from crates.io (the estate crate is published at
         # `hyperpolymath/panic-attack`). The previous `road-skate/features/
@@ -55,14 +49,12 @@ jobs:
             echo "::error::panic-attacker unavailable from crates.io"
             exit 1
           }
-
       - name: Run panic-attack
         id: scan
         continue-on-error: true
         run: |
           set -o pipefail
           panic-attack assail 2>&1 | tee panic-attack.log
-
       - name: Render summary
         if: always()
         run: |
@@ -83,7 +75,6 @@ jobs:
             echo ""
             echo "Policy: see [docs/standards/PANIC-ATTACK.adoc](docs/standards/PANIC-ATTACK.adoc)."
           } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload log artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -12,7 +12,6 @@
 # on the former via an import map).
 
 name: Publish to JSR (manual)
-
 on:
   workflow_dispatch:
     inputs:
@@ -29,15 +28,12 @@ on:
         required: true
         type: boolean
         default: true
-
 permissions:
   contents: read
   id-token: write # JSR OIDC; no token secret needed
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,19 +18,15 @@
 # third-party action needs SHA-pinning beyond checkout + setup-ocaml.
 
 name: Release
-
 on:
   push:
     tags:
       - 'v*'
-
 permissions:
   contents: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -47,7 +43,6 @@ jobs:
           else
             gh release create "$tag" --generate-notes --verify-tag --title "$tag"
           fi
-
   build:
     needs: prepare
     strategy:
@@ -64,15 +59,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Set up OCaml
         uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3
         with:
           ocaml-compiler: "5.1"
-
       - name: Install dependencies
         run: opam install . --deps-only --yes
-
       - name: Bake release version into source (#297)
         # Single source of truth for the compiler version string lives
         # in `lib/version.ml`; `dune-project` mirrors it for opam.  The
@@ -86,22 +78,18 @@ jobs:
           echo "Baked version: $v"
           grep '^let value' lib/version.ml
           grep '^(version' .build/dune-project
-
       - name: Build release
         run: opam exec -- dune build --release
-
       - name: Stage the binary
         run: |
           install -m 0755 _build/default/bin/main.exe \
             "affinescript-${{ matrix.target }}"
-
       - name: Upload the binary to the release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${GITHUB_REF_NAME}" \
             "affinescript-${{ matrix.target }}" --clobber
-
   checksums:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard-enforcer.yml
+++ b/.github/workflows/scorecard-enforcer.yml
@@ -1,14 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 # Prevention workflow - runs OpenSSF Scorecard and fails on low scores
 name: OpenSSF Scorecard Enforcer
-
 on:
   push:
     branches: [main]
   schedule:
-    - cron: '0 6 * * 1'  # Weekly on Monday
+    - cron: '0 6 * * 1' # Weekly on Monday
   workflow_dispatch:
-
 # Estate guardrail: cancel superseded runs so re-pushes / rebased PR
 # updates do not pile up queued runs against the shared account-wide
 # Actions concurrency pool. Applied only to read-only check workflows
@@ -16,45 +14,38 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 permissions: read-all
-
 jobs:
   scorecard:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      id-token: write  # For OIDC
+      id-token: write # For OIDC
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           persist-credentials: false
-
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
         with:
           sarif_file: results.sarif
-
   # Check specific high-priority items
   check-critical:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-
       - name: Check SECURITY.md exists
         run: |
           if [ ! -f "SECURITY.md" ]; then
             echo "::error::SECURITY.md is required"
             exit 1
           fi
-
       - name: Check for pinned dependencies
         run: |
           # Check workflows for unpinned actions

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
 name: Scorecards supply-chain security
-
 on:
   branch_protection_rule:
   schedule:
     - cron: '23 4 * * 1'
   push:
     branches: [main]
-
 # Workflow-level permissions are read-only. The job that calls the
 # reusable upgrades to the writes required by `ossf/scorecard-action`.
 # Job-level permissions REPLACE workflow-level for the job, so a bare
@@ -21,7 +19,6 @@ on:
 # adoption — see PR #457's test-plan delta).
 permissions:
   contents: read
-
 jobs:
   analysis:
     permissions:

--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -1,19 +1,25 @@
 # SPDX-License-Identifier: MPL-2.0
 name: Secret Scanner
-
 on:
   pull_request:
   push:
     branches: [main]
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
-
 jobs:
   scan:
     uses: hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@3e4bd4c93911750727e2e4c66dff859e00079da0
     secrets: inherit
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: TruffleHog Secret Scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified --fail

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 name: Semgrep SAST
-
 on:
   push:
     branches: [main]
@@ -9,15 +8,12 @@ on:
   schedule:
     - cron: '0 5 * * 1'
   workflow_dispatch:
-
 permissions: read-all
-
 # Actions concurrency pool. Applied only to read-only check workflows
 # (no publish/mutation), so cancelling a superseded run is always safe.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   semgrep:
     runs-on: ubuntu-latest
@@ -28,12 +24,10 @@ jobs:
       image: semgrep/semgrep
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Run Semgrep
         run: semgrep scan --sarif --output=semgrep.sarif --config=auto .
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:

--- a/.github/workflows/spark-theatre-gate.yml
+++ b/.github/workflows/spark-theatre-gate.yml
@@ -4,15 +4,12 @@
 # estate action-pinning policy. Regenerate the pin only when the reusable
 # workflow is intentionally bumped.
 name: SPARK Theatre Gate
-
 on:
   pull_request:
   push:
     branches: [main]
-
 permissions:
   contents: read
-
 # Note: NO workflow-level `concurrency:` block here. The reusable
 # workflow in standards already declares concurrency on the same key
 # (`${{ github.workflow }}-${{ github.ref }}` — which resolves to the
@@ -24,7 +21,6 @@ permissions:
 # 410+ runs since have been `startup_failure`, blocking auto-merge
 # across the repo and forcing a 14-PR admin-merge sweep on
 # 2026-05-28. See hypatia#376 BP008 for the class-level detector.
-
 jobs:
   spark-theatre-gate:
     uses: hyperpolymath/standards/.github/workflows/spark-theatre-gate.yml@462003782f3ebb93ea763e81d0d199ce13ef7d73

--- a/.github/workflows/stdlib-naming.yml
+++ b/.github/workflows/stdlib-naming.yml
@@ -10,28 +10,23 @@
 # at lowercase prevents the duplicate-file regression.
 
 name: Stdlib Naming Convention
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
 permissions:
   contents: read
-
 # Actions concurrency pool. Applied only to read-only check workflows
 # (no publish/mutation), so cancelling a superseded run is always safe.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   enforce-lowercase-stdlib:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Enforce lowercase .affine filenames in stdlib/
         run: |
           BAD=$(find stdlib -maxdepth 1 -type f -name '*.affine' | grep -E '/stdlib/[A-Z]' || true)

--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Prevention workflow - validates all workflows have proper security config
 name: Workflow Security Linter
-
 on:
   pull_request:
     paths:
@@ -9,21 +8,17 @@ on:
   push:
     paths:
       - '.github/workflows/**'
-
 permissions: read-all
-
 # Actions concurrency pool. Applied only to read-only check workflows
 # (no publish/mutation), so cancelling a superseded run is always safe.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   lint-workflows:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-
       - name: Check SPDX headers
         run: |
           errors=0
@@ -35,7 +30,6 @@ jobs:
             fi
           done
           exit $errors
-
       - name: Check permissions declaration
         run: |
           errors=0
@@ -47,7 +41,6 @@ jobs:
             fi
           done
           exit $errors
-
       - name: Check pinned actions
         run: |
           errors=0

--- a/affinescript-vite/.github/workflows/boj-build.yml
+++ b/affinescript-vite/.github/workflows/boj-build.yml
@@ -6,15 +6,12 @@
 # To enable: set BOJ_SERVER_URL as a repository secret or variable.
 # To disable: delete this file or leave BOJ_SERVER_URL unset.
 name: BoJ Server Build Trigger
-
 on:
   push:
     branches: [main, master]
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   trigger-boj:
     runs-on: ubuntu-latest
@@ -22,7 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Trigger BoJ Server (Casket/ssg-mcp)
         env:
           BOJ_URL: ${{ secrets.BOJ_SERVER_URL || vars.BOJ_SERVER_URL }}

--- a/affinescript-vite/.github/workflows/codeql.yml
+++ b/affinescript-vite/.github/workflows/codeql.yml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 name: CodeQL Security Analysis
-
 on:
   push:
     branches: [main, master]
@@ -8,10 +7,8 @@ on:
     branches: [main, master]
   schedule:
     - cron: '0 6 1 * *'
-
 permissions:
   contents: read
-
 jobs:
   analyze:
     runs-on: ubuntu-latest
@@ -24,17 +21,14 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.28.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.28.1
         with:

--- a/affinescript-vite/.github/workflows/e2e.yml
+++ b/affinescript-vite/.github/workflows/e2e.yml
@@ -13,7 +13,6 @@
 # Delete sections that don't apply. See examples in each job.
 
 name: E2E + Aspect + Bench
-
 on:
   push:
     branches: [main, master, develop]
@@ -29,162 +28,159 @@ on:
       - 'ffi/**'
       - 'tests/**'
   workflow_dispatch:
-
 permissions: read-all
-
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
-  # ─── End-to-End Tests ──────────────────────────────────────────────
-  # Uncomment ONE of the following e2e job blocks matching your stack.
+# ─── End-to-End Tests ──────────────────────────────────────────────
+# Uncomment ONE of the following e2e job blocks matching your stack.
 
-  ## === RUST E2E ===
-  # e2e:
-  #   name: E2E — Full Pipeline
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7  # stable
-  #     - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2
-  #     - run: cargo build --release
-  #     - run: bash tests/e2e.sh
-  #       # OR: cargo test --test end_to_end -- --nocapture
+## === RUST E2E ===
+# e2e:
+#   name: E2E — Full Pipeline
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 15
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7  # stable
+#     - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2
+#     - run: cargo build --release
+#     - run: bash tests/e2e.sh
+#       # OR: cargo test --test end_to_end -- --nocapture
 
-  ## === ZIG FFI E2E ===
-  # e2e:
-  #   name: E2E — FFI Pipeline
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d7b4f723a50dea1f3608  # v2
-  #       with:
-  #         version: 0.15.0
-  #     - run: cd ffi/zig && zig build test
-  #     - run: bash tests/e2e.sh
+## === ZIG FFI E2E ===
+# e2e:
+#   name: E2E — FFI Pipeline
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 15
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d7b4f723a50dea1f3608  # v2
+#       with:
+#         version: 0.15.0
+#     - run: cd ffi/zig && zig build test
+#     - run: bash tests/e2e.sh
 
-  ## === ELIXIR E2E ===
-  # e2e:
-  #   name: E2E — Full Pipeline
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: erlef/setup-beam@5a67e1a1dd86cae5e5bef84e2da5060406a66c07  # v1
-  #       with:
-  #         otp-version: '27.0'
-  #         elixir-version: '1.17'
-  #     - run: mix deps.get && mix compile --warnings-as-errors
-  #     - run: mix test test/integration/e2e_test.exs --trace
+## === ELIXIR E2E ===
+# e2e:
+#   name: E2E — Full Pipeline
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 15
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: erlef/setup-beam@5a67e1a1dd86cae5e5bef84e2da5060406a66c07  # v1
+#       with:
+#         otp-version: '27.0'
+#         elixir-version: '1.17'
+#     - run: mix deps.get && mix compile --warnings-as-errors
+#     - run: mix test test/integration/e2e_test.exs --trace
 
-  ## === DENO/RESCRIPT E2E ===
-  # e2e:
-  #   name: E2E — Full Pipeline
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: denoland/setup-deno@5fae568d37c3b73e0e4ca63d4e2c4e324a2b3497  # v2
-  #       with:
-  #         deno-version: v2.x
-  #     - run: deno install --node-modules-dir=auto
-  #     - run: deno task res:build  # ReScript compile
-  #     - run: deno test tests/e2e/
+## === DENO/RESCRIPT E2E ===
+# e2e:
+#   name: E2E — Full Pipeline
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 15
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: denoland/setup-deno@5fae568d37c3b73e0e4ca63d4e2c4e324a2b3497  # v2
+#       with:
+#         deno-version: v2.x
+#     - run: deno install --node-modules-dir=auto
+#     - run: deno task res:build  # ReScript compile
+#     - run: deno test tests/e2e/
 
-  ## === PLAYWRIGHT (Browser E2E) ===
-  # e2e-playwright:
-  #   name: Playwright — ${{ matrix.project }}
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 20
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       project: [chromium-1080p, firefox-1080p, webkit-1080p]
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: denoland/setup-deno@5fae568d37c3b73e0e4ca63d4e2c4e324a2b3497  # v2
-  #       with:
-  #         deno-version: v2.x
-  #     - run: deno install --node-modules-dir=auto
-  #     - run: npx playwright install --with-deps
-  #     - run: npx playwright test --project=${{ matrix.project }}
-  #     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-  #       if: failure()
-  #       with:
-  #         name: playwright-traces-${{ matrix.project }}
-  #         path: test-results/**/trace.zip
-  #         retention-days: 7
+## === PLAYWRIGHT (Browser E2E) ===
+# e2e-playwright:
+#   name: Playwright — ${{ matrix.project }}
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 20
+#   strategy:
+#     fail-fast: false
+#     matrix:
+#       project: [chromium-1080p, firefox-1080p, webkit-1080p]
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: denoland/setup-deno@5fae568d37c3b73e0e4ca63d4e2c4e324a2b3497  # v2
+#       with:
+#         deno-version: v2.x
+#     - run: deno install --node-modules-dir=auto
+#     - run: npx playwright install --with-deps
+#     - run: npx playwright test --project=${{ matrix.project }}
+#     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+#       if: failure()
+#       with:
+#         name: playwright-traces-${{ matrix.project }}
+#         path: test-results/**/trace.zip
+#         retention-days: 7
 
-  ## === HASKELL E2E ===
-  # e2e:
-  #   name: E2E — Full Pipeline
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: haskell-actions/setup@dd344bc1cec854a9b55c2b857c28b688010e4fce  # v2
-  #       with:
-  #         ghc-version: '9.6'
-  #         cabal-version: '3.10'
-  #     - run: cabal build all
-  #     - run: bash tests/integration-test.sh
+## === HASKELL E2E ===
+# e2e:
+#   name: E2E — Full Pipeline
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 15
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: haskell-actions/setup@dd344bc1cec854a9b55c2b857c28b688010e4fce  # v2
+#       with:
+#         ghc-version: '9.6'
+#         cabal-version: '3.10'
+#     - run: cabal build all
+#     - run: bash tests/integration-test.sh
 
-  # ─── Aspect Tests ──────────────────────────────────────────────────
-  # Cross-cutting concerns: thread safety, ABI contracts, SPDX, dangerous patterns
-  # Uncomment and customise:
+# ─── Aspect Tests ──────────────────────────────────────────────────
+# Cross-cutting concerns: thread safety, ABI contracts, SPDX, dangerous patterns
+# Uncomment and customise:
 
-  # aspect-tests:
-  #   name: Aspect — Architectural Invariants
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - run: bash tests/aspect_tests.sh
+# aspect-tests:
+#   name: Aspect — Architectural Invariants
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 10
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - run: bash tests/aspect_tests.sh
 
-  # ─── Benchmarks ────────────────────────────────────────────────────
-  # Performance regression detection. Uncomment matching stack:
+# ─── Benchmarks ────────────────────────────────────────────────────
+# Performance regression detection. Uncomment matching stack:
 
-  ## === RUST BENCH ===
-  # benchmarks:
-  #   name: Bench — Performance Regression
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7  # stable
-  #     - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2
-  #     - run: cargo bench 2>&1 | tee /tmp/bench-results.txt
-  #     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-  #       if: always()
-  #       with:
-  #         name: benchmark-results
-  #         path: /tmp/bench-results.txt
-  #         retention-days: 30
+## === RUST BENCH ===
+# benchmarks:
+#   name: Bench — Performance Regression
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 15
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7  # stable
+#     - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2
+#     - run: cargo bench 2>&1 | tee /tmp/bench-results.txt
+#     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+#       if: always()
+#       with:
+#         name: benchmark-results
+#         path: /tmp/bench-results.txt
+#         retention-days: 30
 
-  ## === ZIG BENCH ===
-  # benchmarks:
-  #   name: Bench — Performance Regression
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d7b4f723a50dea1f3608  # v2
-  #       with:
-  #         version: 0.15.0
-  #     - run: cd ffi/zig && zig build bench
+## === ZIG BENCH ===
+# benchmarks:
+#   name: Bench — Performance Regression
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 15
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d7b4f723a50dea1f3608  # v2
+#       with:
+#         version: 0.15.0
+#     - run: cd ffi/zig && zig build bench
 
-  # ─── Readiness (CRG) ──────────────────────────────────────────────
-  # Component Readiness Grade: D (runs) → C (correct) → B (edge cases)
+# ─── Readiness (CRG) ──────────────────────────────────────────────
+# Component Readiness Grade: D (runs) → C (correct) → B (edge cases)
 
-  # readiness:
-  #   name: Readiness — Grade D/C/B
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   steps:
-  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-  #     - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7  # stable
-  #     - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2
-  #     - run: cargo test --test readiness -- --nocapture
+# readiness:
+#   name: Readiness — Grade D/C/B
+#   runs-on: ubuntu-latest
+#   timeout-minutes: 10
+#   steps:
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+#     - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7  # stable
+#     - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2
+#     - run: cargo test --test readiness -- --nocapture

--- a/affinescript-vite/.github/workflows/governance.yml
+++ b/affinescript-vite/.github/workflows/governance.yml
@@ -11,16 +11,13 @@
 # (rust-ci, codeql, dependabot, release, scan/mirror/pages plumbing).
 
 name: Governance
-
 on:
   push:
     branches: [main, master]
   pull_request:
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   governance:
     uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@main

--- a/affinescript-vite/.github/workflows/hypatia-scan.yml
+++ b/affinescript-vite/.github/workflows/hypatia-scan.yml
@@ -1,42 +1,35 @@
 # SPDX-License-Identifier: MPL-2.0
 # Hypatia Neurosymbolic CI/CD Security Scan
 name: Hypatia Security Scan
-
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [main, master, develop]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
   schedule:
-    - cron: '0 0 * * 0'  # Weekly on Sunday
+    - cron: '0 0 * * 0' # Weekly on Sunday
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   scan:
     name: Hypatia Neurosymbolic Analysis
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0  # Full history for better pattern analysis
-
+          fetch-depth: 0 # Full history for better pattern analysis
       - name: Setup Elixir for Hypatia scanner
         uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.18.2
         with:
           elixir-version: '1.19.4'
           otp-version: '28.3'
-
       - name: Clone Hypatia
         run: |
           if [ ! -d "$HOME/hypatia" ]; then
             git clone https://github.com/hyperpolymath/hypatia.git "$HOME/hypatia"
           fi
-
       - name: Build Hypatia scanner (if needed)
         working-directory: ${{ env.HOME }}/hypatia
         run: |
@@ -45,7 +38,6 @@ jobs:
             mix deps.get
             mix escript.build
           fi
-
       - name: Run Hypatia scan
         id: scan
         run: |
@@ -72,35 +64,19 @@ jobs:
           echo "- Critical: $CRITICAL" >> $GITHUB_STEP_SUMMARY
           echo "- High: $HIGH" >> $GITHUB_STEP_SUMMARY
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
-
       - name: Upload findings artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json
           retention-days: 90
-
       - name: Submit findings to gitbot-fleet (Phase 2)
         if: steps.scan.outputs.findings_count > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SHA: ${{ github.sha }}
-        run: |
-          echo "📤 Submitting ${{ steps.scan.outputs.findings_count }} findings to gitbot-fleet..."
-
-          # Clone gitbot-fleet to temp directory
-          FLEET_DIR="/tmp/gitbot-fleet-$$"
-          git clone https://github.com/hyperpolymath/gitbot-fleet.git "$FLEET_DIR"
-
-          # Run submission script
-          bash "$FLEET_DIR/scripts/submit-finding.sh" hypatia-findings.json
-
-          # Cleanup
-          rm -rf "$FLEET_DIR"
-
-          echo "✅ Finding submission complete"
-
+        run: "echo \"\U0001F4E4 Submitting ${{ steps.scan.outputs.findings_count }} findings to gitbot-fleet...\"\n\n# Clone gitbot-fleet to temp directory\nFLEET_DIR=\"/tmp/gitbot-fleet-$$\"\ngit clone https://github.com/hyperpolymath/gitbot-fleet.git \"$FLEET_DIR\"\n\n# Run submission script\nbash \"$FLEET_DIR/scripts/submit-finding.sh\" hypatia-findings.json\n\n# Cleanup\nrm -rf \"$FLEET_DIR\"\n\necho \"✅ Finding submission complete\"\n"
       - name: Check for critical issues
         if: steps.scan.outputs.critical > 0
         run: |
@@ -108,7 +84,6 @@ jobs:
           echo "Review hypatia-findings.json for details"
           # Don't fail the build yet - just warn
           # exit 1
-
       - name: Generate scan report
         run: |
           cat << EOF > hypatia-report.md
@@ -142,37 +117,8 @@ jobs:
           EOF
 
           cat hypatia-report.md >> $GITHUB_STEP_SUMMARY
-
       - name: Comment on PR with findings
         if: github.event_name == 'pull_request' && steps.scan.outputs.findings_count > 0
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
         with:
-          script: |
-            const fs = require('fs');
-            const findings = JSON.parse(fs.readFileSync('hypatia-findings.json', 'utf8'));
-
-            const critical = findings.filter(f => f.severity === 'critical').length;
-            const high = findings.filter(f => f.severity === 'high').length;
-
-            let comment = `## 🔍 Hypatia Security Scan\n\n`;
-            comment += `**Findings:** ${findings.length} issues detected\n\n`;
-            comment += `| Severity | Count |\n|----------|-------|\n`;
-            comment += `| 🔴 Critical | ${critical} |\n`;
-            comment += `| 🟠 High | ${high} |\n`;
-            comment += `| 🟡 Medium | ${findings.length - critical - high} |\n\n`;
-
-            if (critical > 0) {
-              comment += `⚠️ **Action Required:** Critical security issues found!\n\n`;
-            }
-
-            comment += `<details><summary>View findings</summary>\n\n`;
-            comment += `\`\`\`json\n${JSON.stringify(findings.slice(0, 10), null, 2)}\n\`\`\`\n`;
-            comment += `</details>\n\n`;
-            comment += `*Powered by Hypatia Neurosymbolic CI/CD Intelligence*`;
-
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: comment
-            });
+          script: "const fs = require('fs');\nconst findings = JSON.parse(fs.readFileSync('hypatia-findings.json', 'utf8'));\n\nconst critical = findings.filter(f => f.severity === 'critical').length;\nconst high = findings.filter(f => f.severity === 'high').length;\n\nlet comment = `## \U0001F50D Hypatia Security Scan\\n\\n`;\ncomment += `**Findings:** ${findings.length} issues detected\\n\\n`;\ncomment += `| Severity | Count |\\n|----------|-------|\\n`;\ncomment += `| \U0001F534 Critical | ${critical} |\\n`;\ncomment += `| \U0001F7E0 High | ${high} |\\n`;\ncomment += `| \U0001F7E1 Medium | ${findings.length - critical - high} |\\n\\n`;\n\nif (critical > 0) {\n  comment += `⚠️ **Action Required:** Critical security issues found!\\n\\n`;\n}\n\ncomment += `<details><summary>View findings</summary>\\n\\n`;\ncomment += `\\`\\`\\`json\\n${JSON.stringify(findings.slice(0, 10), null, 2)}\\n\\`\\`\\`\\n`;\ncomment += `</details>\\n\\n`;\ncomment += `*Powered by Hypatia Neurosymbolic CI/CD Intelligence*`;\n\ngithub.rest.issues.createComment({\n  owner: context.repo.owner,\n  repo: context.repo.repo,\n  issue_number: context.issue.number,\n  body: comment\n});\n"

--- a/affinescript-vite/.github/workflows/instant-sync.yml
+++ b/affinescript-vite/.github/workflows/instant-sync.yml
@@ -1,16 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
 # Instant Forge Sync - Triggers propagation to all forges on push/release
 name: Instant Sync
-
 on:
   push:
     branches: [main, master]
   release:
     types: [published]
-
 permissions:
   contents: read
-
 jobs:
   dispatch:
     runs-on: ubuntu-latest
@@ -28,7 +25,6 @@ jobs:
               "sha": "${{ github.sha }}",
               "forges": ""
             }
-
       - name: Confirm
         env:
           REPO_NAME: ${{ github.event.repository.name }}

--- a/affinescript-vite/.github/workflows/mirror.yml
+++ b/affinescript-vite/.github/workflows/mirror.yml
@@ -1,15 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 # SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell
 name: Mirror to Git Forges
-
 on:
   push:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   mirror-gitlab:
     runs-on: ubuntu-latest
@@ -18,17 +15,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
-
       - name: Mirror to GitLab
         run: |
           ssh-keyscan -t ed25519 gitlab.com >> ~/.ssh/known_hosts
           git remote add gitlab git@gitlab.com:${{ vars.GITLAB_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force gitlab main
-
   mirror-bitbucket:
     runs-on: ubuntu-latest
     if: vars.BITBUCKET_MIRROR_ENABLED == 'true'
@@ -36,17 +30,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.BITBUCKET_SSH_KEY }}
-
       - name: Mirror to Bitbucket
         run: |
           ssh-keyscan -t ed25519 bitbucket.org >> ~/.ssh/known_hosts
           git remote add bitbucket git@bitbucket.org:${{ vars.BITBUCKET_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force bitbucket main
-
   mirror-codeberg:
     runs-on: ubuntu-latest
     if: vars.CODEBERG_MIRROR_ENABLED == 'true'
@@ -54,17 +45,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.CODEBERG_SSH_KEY }}
-
       - name: Mirror to Codeberg
         run: |
           ssh-keyscan -t ed25519 codeberg.org >> ~/.ssh/known_hosts
           git remote add codeberg git@codeberg.org:${{ vars.CODEBERG_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force codeberg main
-
   mirror-sourcehut:
     runs-on: ubuntu-latest
     if: vars.SOURCEHUT_MIRROR_ENABLED == 'true'
@@ -72,17 +60,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.SOURCEHUT_SSH_KEY }}
-
       - name: Mirror to SourceHut
         run: |
           ssh-keyscan -t ed25519 git.sr.ht >> ~/.ssh/known_hosts
           git remote add sourcehut git@git.sr.ht:~${{ vars.SOURCEHUT_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }} || true
           git push --force sourcehut main
-
   mirror-disroot:
     runs-on: ubuntu-latest
     if: vars.DISROOT_MIRROR_ENABLED == 'true'
@@ -90,17 +75,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.DISROOT_SSH_KEY }}
-
       - name: Mirror to Disroot
         run: |
           ssh-keyscan -t ed25519 git.disroot.org >> ~/.ssh/known_hosts
           git remote add disroot git@git.disroot.org:${{ vars.DISROOT_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force disroot main
-
   mirror-gitea:
     runs-on: ubuntu-latest
     if: vars.GITEA_MIRROR_ENABLED == 'true'
@@ -108,17 +90,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.GITEA_SSH_KEY }}
-
       - name: Mirror to Gitea
         run: |
           ssh-keyscan -t ed25519 ${{ vars.GITEA_HOST }} >> ~/.ssh/known_hosts
           git remote add gitea git@${{ vars.GITEA_HOST }}:${{ vars.GITEA_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force gitea main
-
   mirror-radicle:
     runs-on: ubuntu-latest
     if: vars.RADICLE_MIRROR_ENABLED == 'true'
@@ -126,18 +105,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
           toolchain: stable
-
       - name: Install Radicle
         run: |
           # Install via cargo (safer than curl|sh)
           cargo install radicle-cli --locked
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
       - name: Mirror to Radicle
         run: |
           echo "${{ secrets.RADICLE_KEY }}" > ~/.radicle/keys/radicle

--- a/affinescript-vite/.github/workflows/openssf-compliance.yml
+++ b/affinescript-vite/.github/workflows/openssf-compliance.yml
@@ -2,17 +2,14 @@
 # OpenSSF Best Practices compliance gate — blocks PRs and pushes that lack
 # required files or still contain unfilled placeholder tokens.
 name: OpenSSF Compliance
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   openssf-compliance:
     runs-on: ubuntu-latest
@@ -22,7 +19,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-
       - name: Check SECURITY.md exists and has substance
         run: |
           SECFILE=""
@@ -41,7 +37,6 @@ jobs:
             exit 1
           fi
           echo "SECURITY file: OK ($SECFILE, $LINES lines)"
-
       - name: Check LICENSE exists
         run: |
           if [ ! -f "LICENSE" ] && [ ! -f "LICENSE.txt" ] && [ ! -f "LICENSE.md" ]; then
@@ -49,7 +44,6 @@ jobs:
             exit 1
           fi
           echo "LICENSE: OK"
-
       - name: Check CONTRIBUTING exists
         run: |
           if [ ! -f "CONTRIBUTING.md" ] && [ ! -f "CONTRIBUTING.adoc" ]; then
@@ -57,7 +51,6 @@ jobs:
             exit 1
           fi
           echo "CONTRIBUTING: OK"
-
       - name: Check README exists
         run: |
           if [ ! -f "README.md" ] && [ ! -f "README.adoc" ] && [ ! -f "README.rst" ] && [ ! -f "README.txt" ] && [ ! -f "README" ]; then
@@ -65,7 +58,6 @@ jobs:
             exit 1
           fi
           echo "README: OK"
-
       - name: Check .machine_readable directory and STATE.a2ml
         run: |
           if [ ! -d ".machine_readable" ]; then
@@ -78,7 +70,6 @@ jobs:
             exit 1
           fi
           echo ".machine_readable/STATE.a2ml: OK"
-
       - name: Check CHANGELOG exists
         run: |
           if [ ! -f "CHANGELOG.md" ] && [ ! -f "CHANGELOG.adoc" ] && [ ! -f "CHANGES.md" ]; then
@@ -86,7 +77,6 @@ jobs:
             exit 1
           fi
           echo "CHANGELOG: OK"
-
       - name: Check no unfilled placeholder tokens in required files
         run: |
           ERRORS=0
@@ -116,7 +106,6 @@ jobs:
             exit 1
           fi
           echo "Placeholder check: OK (no unfilled tokens in required files)"
-
       - name: Summary
         run: |
           echo "=== OpenSSF Best Practices Compliance: PASS ==="

--- a/affinescript-vite/.github/workflows/release.yml
+++ b/affinescript-vite/.github/workflows/release.yml
@@ -5,15 +5,12 @@
 # Builds artifacts, generates changelog via git-cliff, creates a GitHub Release,
 # and produces SLSA provenance attestations.
 name: Release
-
 on:
   push:
     tags:
       - 'v*'
-
 permissions:
   contents: read
-
 jobs:
   build:
     name: Build Artifacts
@@ -22,7 +19,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Detect project type and build
         id: build
         run: |
@@ -68,13 +64,11 @@ jobs:
             echo "Expected one of: mix.exs, Cargo.toml, build.zig, deno.json, gossamer.conf.json, gleam.toml, rebar.config, Justfile"
             exit 1
           fi
-
-      # TODO: Upload build artifacts if needed
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #     name: release-artifacts
-      #     path: target/release/
-
+        # TODO: Upload build artifacts if needed
+        # - uses: actions/upload-artifact@v4
+        #   with:
+        #     name: release-artifacts
+        #     path: target/release/
   changelog:
     name: Generate Changelog
     runs-on: ubuntu-latest
@@ -87,16 +81,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
       - name: Install git-cliff
         run: |
           curl -sSfL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-$(uname -m)-unknown-linux-gnu.tar.gz \
             | tar -xz --strip-components=1 -C /usr/local/bin/ git-cliff-*/git-cliff
-
       - name: Generate changelog for this release
         id: cliff
         run: |
@@ -108,18 +99,15 @@ jobs:
             echo "$CHANGELOG"
             echo "CLIFF_EOF"
           } >> "$GITHUB_OUTPUT"
-
       - name: Update full CHANGELOG.md
         run: |
           git cliff --output CHANGELOG.md
-
       - name: Upload updated CHANGELOG.md
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: changelog
           path: CHANGELOG.md
           retention-days: 5
-
   release:
     name: Create GitHub Release
     needs: [build, changelog]
@@ -128,13 +116,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       # TODO: Download build artifacts if uploading to the release
       # - uses: actions/download-artifact@v4
       #   with:
       #     name: release-artifacts
       #     path: artifacts/
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
@@ -147,7 +133,6 @@ jobs:
           #   artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   provenance:
     name: SLSA Provenance
     needs: [build]

--- a/affinescript-vite/.github/workflows/rhodibot.yml
+++ b/affinescript-vite/.github/workflows/rhodibot.yml
@@ -10,20 +10,17 @@
 #
 # Runs weekly and on Hypatia scan completion.
 
-name: "🤖 Rhodibot — RSR Auto-Fix"
-
+name: "\U0001F916 Rhodibot — RSR Auto-Fix"
 on:
   schedule:
-    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
-  workflow_dispatch:       # Manual trigger
+    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
+  workflow_dispatch: # Manual trigger
   workflow_run:
     workflows: ["Hypatia Neurosymbolic Analysis"]
     types: [completed]
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   rhodibot:
     runs-on: ubuntu-latest
@@ -32,7 +29,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
-
       - name: Rhodibot — Scan and Fix
         id: fix
         run: |
@@ -173,53 +169,11 @@ jobs:
             echo -e "$DANGEROUS"
             echo "EOF"
           } >> $GITHUB_OUTPUT
-
       - name: Create PR with fixes
         if: steps.fix.outputs.CHANGED == 'true'
-        run: |
-          git config user.name "rhodibot"
-          git config user.email "rhodibot@hyperpolymath.dev"
-          BRANCH="rhodibot/rsr-compliance-$(date +%Y%m%d)"
-          git checkout -b "$BRANCH"
-          git add -A
-          git commit -m "fix(rhodibot): automated RSR compliance fixes
-
-          ${{ steps.fix.outputs.FIXES }}
-
-          Co-Authored-By: rhodibot <rhodibot@hyperpolymath.dev>"
-
-          git push origin "$BRANCH"
-
-          BODY="## 🤖 Rhodibot — RSR Compliance Fixes
-
-          ### Changes Made
-          ${{ steps.fix.outputs.FIXES }}
-          "
-
-          if [ -n "${{ steps.fix.outputs.ISSUES }}" ]; then
-            BODY="$BODY
-          ### Issues Found (manual fix needed)
-          ${{ steps.fix.outputs.ISSUES }}
-          "
-          fi
-
-          if [ -n "${{ steps.fix.outputs.DANGEROUS }}" ]; then
-            BODY="$BODY
-          ### ⚠️ Dangerous Patterns Detected
-          ${{ steps.fix.outputs.DANGEROUS }}
-
-          _These bypass formal verification. See \`proven\` repo for alternatives._
-          "
-          fi
-
-          gh pr create \
-            --title "🤖 Rhodibot: RSR compliance fixes" \
-            --body "$BODY" \
-            --base main \
-            --head "$BRANCH"
+        run: "git config user.name \"rhodibot\"\ngit config user.email \"rhodibot@hyperpolymath.dev\"\nBRANCH=\"rhodibot/rsr-compliance-$(date +%Y%m%d)\"\ngit checkout -b \"$BRANCH\"\ngit add -A\ngit commit -m \"fix(rhodibot): automated RSR compliance fixes\n\n${{ steps.fix.outputs.FIXES }}\n\nCo-Authored-By: rhodibot <rhodibot@hyperpolymath.dev>\"\n\ngit push origin \"$BRANCH\"\n\nBODY=\"## \U0001F916 Rhodibot — RSR Compliance Fixes\n\n### Changes Made\n${{ steps.fix.outputs.FIXES }}\n\"\n\nif [ -n \"${{ steps.fix.outputs.ISSUES }}\" ]; then\n  BODY=\"$BODY\n### Issues Found (manual fix needed)\n${{ steps.fix.outputs.ISSUES }}\n\"\nfi\n\nif [ -n \"${{ steps.fix.outputs.DANGEROUS }}\" ]; then\n  BODY=\"$BODY\n### ⚠️ Dangerous Patterns Detected\n${{ steps.fix.outputs.DANGEROUS }}\n\n_These bypass formal verification. See \\`proven\\` repo for alternatives._\n\"\nfi\n\ngh pr create \\\n  --title \"\U0001F916 Rhodibot: RSR compliance fixes\" \\\n  --body \"$BODY\" \\\n  --base main \\\n  --head \"$BRANCH\"\n"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Report (no changes needed)
         if: steps.fix.outputs.CHANGED != 'true'
         run: |

--- a/affinescript-vite/.github/workflows/rust-ci.yml
+++ b/affinescript-vite/.github/workflows/rust-ci.yml
@@ -4,62 +4,47 @@
 # rust-ci.yml — Cargo build, test, clippy, and fmt for Rust projects.
 # Only runs if Cargo.toml exists in the repo root.
 name: Rust CI
-
 on:
   pull_request:
     branches: ['**']
   push:
     branches: [main, master]
-
 permissions:
   contents: read
-
 jobs:
   check:
     name: Cargo check + clippy + fmt
     runs-on: ubuntu-latest
     if: hashFiles('Cargo.toml') != ''
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
           components: clippy, rustfmt
-
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-
       - name: Cargo check
         run: cargo check --all-targets 2>&1
-
       - name: Cargo fmt
         run: cargo fmt --all -- --check
-
       - name: Cargo clippy
         run: cargo clippy --all-targets -- -D warnings
-
   test:
     name: Cargo test
     runs-on: ubuntu-latest
     needs: check
     if: hashFiles('Cargo.toml') != ''
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
-
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-
       - name: Run tests
         run: cargo test --all-targets
-
       - name: Write summary
         if: always()
         run: |

--- a/affinescript-vite/.github/workflows/scorecard-enforcer.yml
+++ b/affinescript-vite/.github/workflows/scorecard-enforcer.yml
@@ -1,40 +1,34 @@
 # SPDX-License-Identifier: MPL-2.0
 # Prevention workflow - runs OpenSSF Scorecard and fails on low scores
 name: OpenSSF Scorecard Enforcer
-
 on:
   push:
     branches: [main]
   schedule:
-    - cron: '0 6 * * 1'  # Weekly on Monday
+    - cron: '0 6 * * 1' # Weekly on Monday
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   scorecard:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      id-token: write  # For OIDC
+      id-token: write # For OIDC
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: false
-
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
         with:
           sarif_file: results.sarif
-
       - name: Check minimum score
         run: |
           # Parse score from results
@@ -49,34 +43,29 @@ jobs:
             echo "::error::Scorecard score $SCORE is below minimum $MIN_SCORE"
             exit 1
           fi
-
   # Check specific high-priority items
   check-critical:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Check SECURITY.md exists
         run: |
           if [ ! -f "SECURITY.md" ]; then
             echo "::error::SECURITY.md is required"
             exit 1
           fi
-
       - name: Check LICENSE exists
         run: |
           if [ ! -f "LICENSE" ] && [ ! -f "LICENSE.txt" ] && [ ! -f "LICENSE.md" ]; then
             echo "::error::LICENSE file is required for OpenSSF Best Practices"
             exit 1
           fi
-
       - name: Check CONTRIBUTING exists
         run: |
           if [ ! -f "CONTRIBUTING.md" ] && [ ! -f "CONTRIBUTING.adoc" ]; then
             echo "::error::CONTRIBUTING file is required for OpenSSF Best Practices"
             exit 1
           fi
-
       - name: Check for pinned dependencies
         run: |
           # Check workflows for unpinned actions

--- a/affinescript-vite/.github/workflows/scorecard.yml
+++ b/affinescript-vite/.github/workflows/scorecard.yml
@@ -6,10 +6,8 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   analysis:
     runs-on: ubuntu-latest
@@ -20,13 +18,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
-
       - name: Upload results
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.31.8
         with:

--- a/affinescript-vite/.github/workflows/secret-scanner.yml
+++ b/affinescript-vite/.github/workflows/secret-scanner.yml
@@ -1,47 +1,29 @@
 # SPDX-License-Identifier: MPL-2.0
 # Prevention workflow - scans for hardcoded secrets before they reach main
 name: Secret Scanner
-
 on:
   pull_request:
   push:
     branches: [main]
-
 permissions:
   contents: read
-
 jobs:
   trufflehog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0  # Full history for scanning
-
+          fetch-depth: 0 # Full history for scanning
       - name: TruffleHog Secret Scan
         uses: trufflesecurity/trufflehog@6c05c4a00b91aa542267d8e32a8254774799d68d # v3
         with:
           extra_args: --only-verified --fail
-
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Gitleaks Secret Scan
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # Rust-specific: Check for hardcoded crypto values
   rust-secrets:
     runs-on: ubuntu-latest
     if: hashFiles('**/Cargo.toml') != ''
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Check for hardcoded secrets in Rust
         run: |
           # Patterns that suggest hardcoded secrets

--- a/affinescript-vite/.github/workflows/static-analysis-gate.yml
+++ b/affinescript-vite/.github/workflows/static-analysis-gate.yml
@@ -2,16 +2,13 @@
 # Static Analysis Gate — Required by branch protection rules.
 # Runs panic-attack and hypatia, deposits findings for gitbot-fleet learning.
 name: Static Analysis Gate
-
 on:
   pull_request:
     branches: ['**']
   push:
     branches: [main, master]
-
 permissions:
   contents: read
-
 jobs:
   # ---------------------------------------------------------------------------
   # Job 1: panic-attack assail
@@ -19,13 +16,11 @@ jobs:
   panic-attack-assail:
     name: panic-attack assail
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Install panic-attack (if available)
         id: install
         run: |
@@ -39,7 +34,6 @@ jobs:
             echo "::notice::panic-attack binary not available — skipping assail"
             echo "installed=false" >> "$GITHUB_OUTPUT"
           fi
-
       - name: Run panic-attack assail
         id: assail
         if: steps.install.outputs.installed == 'true'
@@ -66,7 +60,6 @@ jobs:
           echo "medium=$MEDIUM" >> "$GITHUB_OUTPUT"
           echo "low=$LOW" >> "$GITHUB_OUTPUT"
           echo "exit_code=$PA_EXIT" >> "$GITHUB_OUTPUT"
-
       - name: Emit check annotations
         if: steps.install.outputs.installed == 'true'
         run: |
@@ -80,7 +73,6 @@ jobs:
               "::warning file=\(.file),line=\(.line // 1)::[panic-attack] \(.message)"
             end
           ' panic-attack-findings.json || true
-
       - name: Write step summary
         if: steps.install.outputs.installed == 'true'
         run: |
@@ -95,7 +87,6 @@ jobs:
           | Low      | ${{ steps.assail.outputs.low }} |
           | **Total**| ${{ steps.assail.outputs.total }} |
           EOF
-
       - name: Create stub findings (when panic-attack unavailable)
         if: steps.install.outputs.installed != 'true'
         run: |
@@ -103,33 +94,28 @@ jobs:
           echo "## panic-attack assail" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Skipped: panic-attack not available in this environment." >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload panic-attack findings
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: panic-attack-findings
           path: panic-attack-findings.json
           retention-days: 90
-
       - name: Fail on critical findings
         if: steps.install.outputs.installed == 'true' && steps.assail.outputs.critical > 0
         run: |
           echo "::error::panic-attack found ${{ steps.assail.outputs.critical }} critical issue(s) — blocking merge"
           exit 1
-
   # ---------------------------------------------------------------------------
   # Job 2: hypatia-scan
   # ---------------------------------------------------------------------------
   hypatia-scan:
     name: Hypatia neurosymbolic scan
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Setup Elixir for Hypatia scanner
         id: beam
         continue-on-error: true
@@ -137,7 +123,6 @@ jobs:
         with:
           elixir-version: '1.19.4'
           otp-version: '28.3'
-
       - name: Clone and build Hypatia
         id: build
         continue-on-error: true
@@ -155,7 +140,6 @@ jobs:
             echo "::notice::Hypatia scanner not available — skipping scan"
             echo "ready=false" >> "$GITHUB_OUTPUT"
           fi
-
       - name: Run Hypatia scan
         id: scan
         if: steps.build.outputs.ready == 'true'
@@ -180,7 +164,6 @@ jobs:
           echo "high=$HIGH" >> "$GITHUB_OUTPUT"
           echo "medium=$MEDIUM" >> "$GITHUB_OUTPUT"
           echo "low=$LOW" >> "$GITHUB_OUTPUT"
-
       - name: Emit check annotations
         if: steps.build.outputs.ready == 'true'
         run: |
@@ -193,7 +176,6 @@ jobs:
               "::warning file=\(.file),line=\(.line // 1)::[hypatia] \(.message)"
             end
           ' hypatia-findings.json || true
-
       - name: Write step summary
         if: steps.build.outputs.ready == 'true'
         run: |
@@ -208,7 +190,6 @@ jobs:
           | Low      | ${{ steps.scan.outputs.low }} |
           | **Total**| ${{ steps.scan.outputs.total }} |
           EOF
-
       - name: Create stub findings (when Hypatia unavailable)
         if: steps.build.outputs.ready != 'true'
         run: |
@@ -216,33 +197,28 @@ jobs:
           echo "## Hypatia Scan" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Skipped: Hypatia scanner not available in this environment." >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload hypatia findings
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json
           retention-days: 90
-
       - name: Fail on critical security findings
         if: steps.build.outputs.ready == 'true' && steps.scan.outputs.critical > 0
         run: |
           echo "::error::Hypatia found ${{ steps.scan.outputs.critical }} critical security issue(s) — blocking merge"
           exit 1
-
   # ---------------------------------------------------------------------------
   # Job 3: patch-bridge triage (CVE contextual assessment)
   # ---------------------------------------------------------------------------
   patch-bridge-triage:
     name: Patch Bridge CVE triage
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Install panic-attack (if available)
         id: install
         run: |
@@ -255,7 +231,6 @@ jobs:
             echo "::notice::panic-attack binary not available — skipping Patch Bridge"
             echo "installed=false" >> "$GITHUB_OUTPUT"
           fi
-
       - name: Run Patch Bridge triage
         id: triage
         if: steps.install.outputs.installed == 'true'
@@ -278,7 +253,6 @@ jobs:
           echo "mitigated=$MITIGATED" >> "$GITHUB_OUTPUT"
           echo "concatenative=$CONCATENATIVE" >> "$GITHUB_OUTPUT"
           echo "informational=$INFORMATIONAL" >> "$GITHUB_OUTPUT"
-
       - name: Write step summary
         if: steps.install.outputs.installed == 'true'
         run: |
@@ -296,7 +270,6 @@ jobs:
           Mitigated CVEs have active controls with soundness proofs.
           Concatenative risks are CVE combinations that multiply severity.
           EOF
-
       - name: Create stub report (when unavailable)
         if: steps.install.outputs.installed != 'true'
         run: |
@@ -304,21 +277,18 @@ jobs:
           echo "## Patch Bridge CVE Triage" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Skipped: panic-attack not available in this environment." >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload bridge report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bridge-report
           path: bridge-report.json
           retention-days: 90
-
       - name: Fail on unmitigable CVEs in critical paths
         if: steps.install.outputs.installed == 'true' && steps.triage.outputs.unmitigable > 0
         run: |
           echo "::warning::Patch Bridge found ${{ steps.triage.outputs.unmitigable }} unmitigable CVE(s) — review required"
           # Warning only, not blocking. Unmitigable means the developer needs
           # to make an architectural decision, not that the PR is wrong.
-
   # ---------------------------------------------------------------------------
   # Job 4: deposit-findings (combines + archives for gitbot-fleet)
   # ---------------------------------------------------------------------------
@@ -327,26 +297,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [panic-attack-assail, hypatia-scan, patch-bridge-triage]
     if: always()
-
     steps:
       - name: Download panic-attack findings
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: panic-attack-findings
           path: findings/
-
       - name: Download hypatia findings
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: hypatia-findings
           path: findings/
-
       - name: Download bridge report
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: bridge-report
           path: findings/
-
       - name: Combine findings into unified report
         id: combine
         run: |
@@ -402,14 +368,12 @@ jobs:
           echo "high=$HIGH"         >> "$GITHUB_OUTPUT"
           echo "medium=$MEDIUM"     >> "$GITHUB_OUTPUT"
           echo "low=$LOW"           >> "$GITHUB_OUTPUT"
-
       - name: Upload unified findings (fleet scanner picks these up)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unified-findings
           path: findings/unified-findings.json
           retention-days: 90
-
       - name: Write deposit summary
         run: |
           cat <<EOF >> "$GITHUB_STEP_SUMMARY"

--- a/affinescript-vite/.gitlab-ci.yml
+++ b/affinescript-vite/.gitlab-ci.yml
@@ -6,20 +6,16 @@ stages:
   - lint
   - test
   - build
-
 variables:
   CARGO_HOME: ${CI_PROJECT_DIR}/.cargo
-
 cache:
   key: ${CI_COMMIT_REF_SLUG}
   paths:
     - .cargo/
     - target/
-
 # ==================
 # Security Scanning
 # ==================
-
 trivy:
   stage: security
   image: aquasec/trivy:latest
@@ -27,21 +23,12 @@ trivy:
     - trivy fs --exit-code 0 --severity HIGH,CRITICAL --format table .
     - trivy fs --exit-code 1 --severity CRITICAL .
   allow_failure: false
-
-gitleaks:
-  stage: security
-  image: zricethezav/gitleaks:latest
-  script:
-    - gitleaks detect --source . --verbose --redact
-  allow_failure: false
-
 semgrep:
   stage: security
   image: returntocorp/semgrep
   script:
     - semgrep --config auto --error .
   allow_failure: true
-
 cargo-audit:
   stage: security
   image: rust:latest
@@ -51,7 +38,6 @@ cargo-audit:
   rules:
     - exists:
         - Cargo.toml
-
 cargo-deny:
   stage: security
   image: rust:latest
@@ -62,7 +48,6 @@ cargo-deny:
     - exists:
         - Cargo.toml
   allow_failure: true
-
 mix-audit:
   stage: security
   image: elixir:latest
@@ -75,11 +60,9 @@ mix-audit:
     - exists:
         - mix.exs
   allow_failure: true
-
 # ==================
 # Linting
 # ==================
-
 rustfmt:
   stage: lint
   image: rust:latest
@@ -89,7 +72,6 @@ rustfmt:
   rules:
     - exists:
         - Cargo.toml
-
 clippy:
   stage: lint
   image: rust:latest
@@ -100,7 +82,6 @@ clippy:
     - exists:
         - Cargo.toml
   allow_failure: true
-
 mix-format:
   stage: lint
   image: elixir:latest
@@ -109,7 +90,6 @@ mix-format:
   rules:
     - exists:
         - mix.exs
-
 credo:
   stage: lint
   image: elixir:latest
@@ -121,11 +101,9 @@ credo:
     - exists:
         - mix.exs
   allow_failure: true
-
 # ==================
 # Testing
 # ==================
-
 cargo-test:
   stage: test
   image: rust:latest
@@ -134,7 +112,6 @@ cargo-test:
   rules:
     - exists:
         - Cargo.toml
-
 mix-test:
   stage: test
   image: elixir:latest
@@ -145,11 +122,9 @@ mix-test:
   rules:
     - exists:
         - mix.exs
-
 # ==================
 # Build
 # ==================
-
 cargo-build:
   stage: build
   image: rust:latest
@@ -162,7 +137,6 @@ cargo-build:
   rules:
     - exists:
         - Cargo.toml
-
 mix-build:
   stage: build
   image: elixir:latest
@@ -173,3 +147,8 @@ mix-build:
   rules:
     - exists:
         - mix.exs
+trufflehog:
+  stage: security
+  image: trufflesecurity/trufflehog:latest
+  script:
+    - trufflehog git file://. --only-verified --fail

--- a/affinescript-vite/.pre-commit-config.yaml
+++ b/affinescript-vite/.pre-commit-config.yaml
@@ -46,7 +46,5 @@ repos:
         exclude: '(\.git|node_modules|target|_build|deps|\.deno|external_corpora|\.lake)/'
 
   # --- Secret detection ---
-  - repo: https://github.com/gitleaks/gitleaks
     rev: v8.24.3
     hooks:
-      - id: gitleaks

--- a/affinescript-vite/Justfile
+++ b/affinescript-vite/Justfile
@@ -797,7 +797,6 @@ deps-audit:
     #   cargo audit
     #   mix audit
     @command -v trivy >/dev/null && trivy fs --severity HIGH,CRITICAL --quiet . || true
-    @command -v gitleaks >/dev/null && gitleaks detect --source . --no-git --quiet || true
     @echo "Audit complete"
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1032,7 +1031,6 @@ install-hooks:
 # Run security audit
 security: deps-audit
     @echo "=== Security Audit ==="
-    @command -v gitleaks >/dev/null && gitleaks detect --source . --verbose || true
     @command -v trivy >/dev/null && trivy fs --severity HIGH,CRITICAL . || true
     @echo "Security audit complete"
 
@@ -1480,3 +1478,6 @@ proof-status:
     else
         echo "(No PROOF-STATUS.md found)"
     fi
+
+secret-scan-trufflehog:
+    @command -v trufflehog >/dev/null && trufflehog filesystem . --only-verified || true

--- a/affinescript.opam
+++ b/affinescript.opam
@@ -23,7 +23,7 @@ doc: "https://github.com/hyperpolymath/affinescript"
 bug-reports: "https://github.com/hyperpolymath/affinescript/issues"
 depends: [
   "ocaml" {>= "4.14"}
-  "dune" {>= "3.14"}
+  "dune" {>= "3.14" & >= "3.14"}
   "menhir" {>= "20231231"}
   "sedlex" {>= "3.2"}
   "ppx_deriving" {>= "5.2"}

--- a/affinescriptiser/.github/workflows/casket-pages.yml
+++ b/affinescriptiser/.github/workflows/casket-pages.yml
@@ -1,39 +1,32 @@
 # SPDX-License-Identifier: MPL-2.0
 name: GitHub Pages
-
 on:
   push:
     branches: [main, master]
   workflow_dispatch:
-
 permissions:
   contents: read
   pages: write
   id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
       - name: Checkout casket-ssg
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           repository: hyperpolymath/casket-ssg
           path: .casket-ssg
-
       - name: Setup GHCup
         uses: haskell-actions/setup@ec49483bfc012387b227434aba94f59a6ecd0900 # v2
         with:
           ghc-version: '9.8.2'
           cabal-version: '3.10'
-
       - name: Cache Cabal
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -42,11 +35,9 @@ jobs:
             ~/.cabal/store
             .casket-ssg/dist-newstyle
           key: ${{ runner.os }}-casket-${{ hashFiles('.casket-ssg/casket-ssg.cabal') }}
-
       - name: Build casket-ssg
         working-directory: .casket-ssg
         run: cabal build
-
       - name: Prepare site source
         shell: bash
         run: |
@@ -89,21 +80,17 @@ jobs:
               echo "Project-specific site content can be added later under site/."
             } > .site-src/index.md
           fi
-
       - name: Build site
         run: |
           mkdir -p _site
           cd .casket-ssg && cabal run casket-ssg -- build ../.site-src ../_site
           touch ../_site/.nojekyll
-
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: '_site'
-
   deploy:
     environment:
       name: github-pages

--- a/affinescriptiser/.github/workflows/codeql.yml
+++ b/affinescriptiser/.github/workflows/codeql.yml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 name: CodeQL Security Analysis
-
 on:
   push:
     branches: [main, master]
@@ -8,10 +7,8 @@ on:
     branches: [main, master]
   schedule:
     - cron: '0 6 1 * *'
-
 permissions:
   contents: read
-
 jobs:
   analyze:
     runs-on: ubuntu-latest
@@ -24,17 +21,14 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.28.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.28.1
         with:

--- a/affinescriptiser/.github/workflows/governance.yml
+++ b/affinescriptiser/.github/workflows/governance.yml
@@ -11,16 +11,13 @@
 # (rust-ci, codeql, dependabot, release, scan/mirror/pages plumbing).
 
 name: Governance
-
 on:
   push:
     branches: [main, master]
   pull_request:
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   governance:
     uses: hyperpolymath/standards/.github/workflows/governance-reusable.yml@main

--- a/affinescriptiser/.github/workflows/hypatia-scan.yml
+++ b/affinescriptiser/.github/workflows/hypatia-scan.yml
@@ -1,42 +1,35 @@
 # SPDX-License-Identifier: MPL-2.0
 # Hypatia Neurosymbolic CI/CD Security Scan
 name: Hypatia Security Scan
-
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [main, master, develop]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
   schedule:
-    - cron: '0 0 * * 0'  # Weekly on Sunday
+    - cron: '0 0 * * 0' # Weekly on Sunday
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   scan:
     name: Hypatia Neurosymbolic Analysis
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0  # Full history for better pattern analysis
-
+          fetch-depth: 0 # Full history for better pattern analysis
       - name: Setup Elixir for Hypatia scanner
         uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.18.2
         with:
           elixir-version: '1.19.4'
           otp-version: '28.3'
-
       - name: Clone Hypatia
         run: |
           if [ ! -d "$HOME/hypatia" ]; then
             git clone https://github.com/hyperpolymath/hypatia.git "$HOME/hypatia"
           fi
-
       - name: Build Hypatia scanner (if needed)
         working-directory: ${{ env.HOME }}/hypatia
         run: |
@@ -46,7 +39,6 @@ jobs:
             mix escript.build
             mv hypatia ../hypatia-v2
           fi
-
       - name: Run Hypatia scan
         id: scan
         run: |
@@ -73,35 +65,19 @@ jobs:
           echo "- Critical: $CRITICAL" >> $GITHUB_STEP_SUMMARY
           echo "- High: $HIGH" >> $GITHUB_STEP_SUMMARY
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
-
       - name: Upload findings artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json
           retention-days: 90
-
       - name: Submit findings to gitbot-fleet (Phase 2)
         if: steps.scan.outputs.findings_count > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SHA: ${{ github.sha }}
-        run: |
-          echo "📤 Submitting ${{ steps.scan.outputs.findings_count }} findings to gitbot-fleet..."
-
-          # Clone gitbot-fleet to temp directory
-          FLEET_DIR="/tmp/gitbot-fleet-$$"
-          git clone https://github.com/hyperpolymath/gitbot-fleet.git "$FLEET_DIR"
-
-          # Run submission script
-          bash "$FLEET_DIR/scripts/submit-finding.sh" hypatia-findings.json
-
-          # Cleanup
-          rm -rf "$FLEET_DIR"
-
-          echo "✅ Finding submission complete"
-
+        run: "echo \"\U0001F4E4 Submitting ${{ steps.scan.outputs.findings_count }} findings to gitbot-fleet...\"\n\n# Clone gitbot-fleet to temp directory\nFLEET_DIR=\"/tmp/gitbot-fleet-$$\"\ngit clone https://github.com/hyperpolymath/gitbot-fleet.git \"$FLEET_DIR\"\n\n# Run submission script\nbash \"$FLEET_DIR/scripts/submit-finding.sh\" hypatia-findings.json\n\n# Cleanup\nrm -rf \"$FLEET_DIR\"\n\necho \"✅ Finding submission complete\"\n"
       - name: Check for critical issues
         if: steps.scan.outputs.critical > 0
         run: |
@@ -109,7 +85,6 @@ jobs:
           echo "Review hypatia-findings.json for details"
           # Don't fail the build yet - just warn
           # exit 1
-
       - name: Generate scan report
         run: |
           cat << EOF > hypatia-report.md
@@ -143,37 +118,8 @@ jobs:
           EOF
 
           cat hypatia-report.md >> $GITHUB_STEP_SUMMARY
-
       - name: Comment on PR with findings
         if: github.event_name == 'pull_request' && steps.scan.outputs.findings_count > 0
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
         with:
-          script: |
-            const fs = require('fs');
-            const findings = JSON.parse(fs.readFileSync('hypatia-findings.json', 'utf8'));
-
-            const critical = findings.filter(f => f.severity === 'critical').length;
-            const high = findings.filter(f => f.severity === 'high').length;
-
-            let comment = `## 🔍 Hypatia Security Scan\n\n`;
-            comment += `**Findings:** ${findings.length} issues detected\n\n`;
-            comment += `| Severity | Count |\n|----------|-------|\n`;
-            comment += `| 🔴 Critical | ${critical} |\n`;
-            comment += `| 🟠 High | ${high} |\n`;
-            comment += `| 🟡 Medium | ${findings.length - critical - high} |\n\n`;
-
-            if (critical > 0) {
-              comment += `⚠️ **Action Required:** Critical security issues found!\n\n`;
-            }
-
-            comment += `<details><summary>View findings</summary>\n\n`;
-            comment += `\`\`\`json\n${JSON.stringify(findings.slice(0, 10), null, 2)}\n\`\`\`\n`;
-            comment += `</details>\n\n`;
-            comment += `*Powered by Hypatia Neurosymbolic CI/CD Intelligence*`;
-
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: comment
-            });
+          script: "const fs = require('fs');\nconst findings = JSON.parse(fs.readFileSync('hypatia-findings.json', 'utf8'));\n\nconst critical = findings.filter(f => f.severity === 'critical').length;\nconst high = findings.filter(f => f.severity === 'high').length;\n\nlet comment = `## \U0001F50D Hypatia Security Scan\\n\\n`;\ncomment += `**Findings:** ${findings.length} issues detected\\n\\n`;\ncomment += `| Severity | Count |\\n|----------|-------|\\n`;\ncomment += `| \U0001F534 Critical | ${critical} |\\n`;\ncomment += `| \U0001F7E0 High | ${high} |\\n`;\ncomment += `| \U0001F7E1 Medium | ${findings.length - critical - high} |\\n\\n`;\n\nif (critical > 0) {\n  comment += `⚠️ **Action Required:** Critical security issues found!\\n\\n`;\n}\n\ncomment += `<details><summary>View findings</summary>\\n\\n`;\ncomment += `\\`\\`\\`json\\n${JSON.stringify(findings.slice(0, 10), null, 2)}\\n\\`\\`\\`\\n`;\ncomment += `</details>\\n\\n`;\ncomment += `*Powered by Hypatia Neurosymbolic CI/CD Intelligence*`;\n\ngithub.rest.issues.createComment({\n  owner: context.repo.owner,\n  repo: context.repo.repo,\n  issue_number: context.issue.number,\n  body: comment\n});"

--- a/affinescriptiser/.github/workflows/instant-sync.yml
+++ b/affinescriptiser/.github/workflows/instant-sync.yml
@@ -1,16 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
 # Instant Forge Sync - Triggers propagation to all forges on push/release
 name: Instant Sync
-
 on:
   push:
     branches: [main, master]
   release:
     types: [published]
-
 permissions:
   contents: read
-
 jobs:
   dispatch:
     runs-on: ubuntu-latest
@@ -28,6 +25,5 @@ jobs:
               "sha": "${{ github.sha }}",
               "forges": ""
             }
-
       - name: Confirm
         run: echo "::notice::Propagation triggered for ${{ github.event.repository.name }}"

--- a/affinescriptiser/.github/workflows/mirror.yml
+++ b/affinescriptiser/.github/workflows/mirror.yml
@@ -1,15 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 # SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell
 name: Mirror to Git Forges
-
 on:
   push:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   mirror-gitlab:
     runs-on: ubuntu-latest
@@ -18,17 +15,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
-
       - name: Mirror to GitLab
         run: |
           ssh-keyscan -t ed25519 gitlab.com >> ~/.ssh/known_hosts
           git remote add gitlab git@gitlab.com:${{ vars.GITLAB_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force gitlab main
-
   mirror-bitbucket:
     runs-on: ubuntu-latest
     if: vars.BITBUCKET_MIRROR_ENABLED == 'true'
@@ -36,17 +30,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.BITBUCKET_SSH_KEY }}
-
       - name: Mirror to Bitbucket
         run: |
           ssh-keyscan -t ed25519 bitbucket.org >> ~/.ssh/known_hosts
           git remote add bitbucket git@bitbucket.org:${{ vars.BITBUCKET_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force bitbucket main
-
   mirror-codeberg:
     runs-on: ubuntu-latest
     if: vars.CODEBERG_MIRROR_ENABLED == 'true'
@@ -54,17 +45,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.CODEBERG_SSH_KEY }}
-
       - name: Mirror to Codeberg
         run: |
           ssh-keyscan -t ed25519 codeberg.org >> ~/.ssh/known_hosts
           git remote add codeberg git@codeberg.org:${{ vars.CODEBERG_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force codeberg main
-
   mirror-sourcehut:
     runs-on: ubuntu-latest
     if: vars.SOURCEHUT_MIRROR_ENABLED == 'true'
@@ -72,17 +60,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.SOURCEHUT_SSH_KEY }}
-
       - name: Mirror to SourceHut
         run: |
           ssh-keyscan -t ed25519 git.sr.ht >> ~/.ssh/known_hosts
           git remote add sourcehut git@git.sr.ht:~${{ vars.SOURCEHUT_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }} || true
           git push --force sourcehut main
-
   mirror-disroot:
     runs-on: ubuntu-latest
     if: vars.DISROOT_MIRROR_ENABLED == 'true'
@@ -90,17 +75,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.DISROOT_SSH_KEY }}
-
       - name: Mirror to Disroot
         run: |
           ssh-keyscan -t ed25519 git.disroot.org >> ~/.ssh/known_hosts
           git remote add disroot git@git.disroot.org:${{ vars.DISROOT_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force disroot main
-
   mirror-gitea:
     runs-on: ubuntu-latest
     if: vars.GITEA_MIRROR_ENABLED == 'true'
@@ -108,17 +90,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.GITEA_SSH_KEY }}
-
       - name: Mirror to Gitea
         run: |
           ssh-keyscan -t ed25519 ${{ vars.GITEA_HOST }} >> ~/.ssh/known_hosts
           git remote add gitea git@${{ vars.GITEA_HOST }}:${{ vars.GITEA_ORG || vars.MIRROR_ORG || github.repository_owner }}/${{ github.event.repository.name }}.git || true
           git push --force gitea main
-
   mirror-radicle:
     runs-on: ubuntu-latest
     if: vars.RADICLE_MIRROR_ENABLED == 'true'
@@ -126,18 +105,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
           toolchain: stable
-
       - name: Install Radicle
         run: |
           # Install via cargo (safer than curl|sh)
           cargo install radicle-cli --locked
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
       - name: Mirror to Radicle
         run: |
           echo "${{ secrets.RADICLE_KEY }}" > ~/.radicle/keys/radicle

--- a/affinescriptiser/.github/workflows/release.yml
+++ b/affinescriptiser/.github/workflows/release.yml
@@ -5,15 +5,12 @@
 # Builds artifacts, generates changelog via git-cliff, creates a GitHub Release,
 # and produces SLSA provenance attestations.
 name: Release
-
 on:
   push:
     tags:
       - 'v*'
-
 permissions:
   contents: read
-
 jobs:
   build:
     name: Build Artifacts
@@ -22,7 +19,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Build
         run: |
           echo "Build your artifacts here"
@@ -32,13 +28,11 @@ jobs:
           #   zig build -Doptimize=ReleaseFast
           #   gleam build
           #   mix release
-
-      # TODO: Upload build artifacts if needed
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #     name: release-artifacts
-      #     path: target/release/
-
+        # TODO: Upload build artifacts if needed
+        # - uses: actions/upload-artifact@v4
+        #   with:
+        #     name: release-artifacts
+        #     path: target/release/
   changelog:
     name: Generate Changelog
     runs-on: ubuntu-latest
@@ -51,16 +45,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
       - name: Install git-cliff
         run: |
           curl -sSfL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-$(uname -m)-unknown-linux-gnu.tar.gz \
             | tar -xz --strip-components=1 -C /usr/local/bin/ git-cliff-*/git-cliff
-
       - name: Generate changelog for this release
         id: cliff
         run: |
@@ -72,18 +63,15 @@ jobs:
             echo "$CHANGELOG"
             echo "CLIFF_EOF"
           } >> "$GITHUB_OUTPUT"
-
       - name: Update full CHANGELOG.md
         run: |
           git cliff --output CHANGELOG.md
-
       - name: Upload updated CHANGELOG.md
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: changelog
           path: CHANGELOG.md
           retention-days: 5
-
   release:
     name: Create GitHub Release
     needs: [build, changelog]
@@ -92,13 +80,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       # TODO: Download build artifacts if uploading to the release
       # - uses: actions/download-artifact@v4
       #   with:
       #     name: release-artifacts
       #     path: artifacts/
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
@@ -111,7 +97,6 @@ jobs:
           #   artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   provenance:
     name: SLSA Provenance
     needs: [build]

--- a/affinescriptiser/.github/workflows/rhodibot.yml
+++ b/affinescriptiser/.github/workflows/rhodibot.yml
@@ -10,20 +10,17 @@
 #
 # Runs weekly and on Hypatia scan completion.
 
-name: "🤖 Rhodibot — RSR Auto-Fix"
-
+name: "\U0001F916 Rhodibot — RSR Auto-Fix"
 on:
   schedule:
-    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
-  workflow_dispatch:       # Manual trigger
+    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
+  workflow_dispatch: # Manual trigger
   workflow_run:
     workflows: ["Hypatia Neurosymbolic Analysis"]
     types: [completed]
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   rhodibot:
     runs-on: ubuntu-latest
@@ -32,7 +29,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
-
       - name: Rhodibot — Scan and Fix
         id: fix
         run: |
@@ -173,53 +169,11 @@ jobs:
             echo -e "$DANGEROUS"
             echo "EOF"
           } >> $GITHUB_OUTPUT
-
       - name: Create PR with fixes
         if: steps.fix.outputs.CHANGED == 'true'
-        run: |
-          git config user.name "rhodibot"
-          git config user.email "rhodibot@hyperpolymath.dev"
-          BRANCH="rhodibot/rsr-compliance-$(date +%Y%m%d)"
-          git checkout -b "$BRANCH"
-          git add -A
-          git commit -m "fix(rhodibot): automated RSR compliance fixes
-
-          ${{ steps.fix.outputs.FIXES }}
-
-          Co-Authored-By: rhodibot <rhodibot@hyperpolymath.dev>"
-
-          git push origin "$BRANCH"
-
-          BODY="## 🤖 Rhodibot — RSR Compliance Fixes
-
-          ### Changes Made
-          ${{ steps.fix.outputs.FIXES }}
-          "
-
-          if [ -n "${{ steps.fix.outputs.ISSUES }}" ]; then
-            BODY="$BODY
-          ### Issues Found (manual fix needed)
-          ${{ steps.fix.outputs.ISSUES }}
-          "
-          fi
-
-          if [ -n "${{ steps.fix.outputs.DANGEROUS }}" ]; then
-            BODY="$BODY
-          ### ⚠️ Dangerous Patterns Detected
-          ${{ steps.fix.outputs.DANGEROUS }}
-
-          _These bypass formal verification. See \`proven\` repo for alternatives._
-          "
-          fi
-
-          gh pr create \
-            --title "🤖 Rhodibot: RSR compliance fixes" \
-            --body "$BODY" \
-            --base main \
-            --head "$BRANCH"
+        run: "git config user.name \"rhodibot\"\ngit config user.email \"rhodibot@hyperpolymath.dev\"\nBRANCH=\"rhodibot/rsr-compliance-$(date +%Y%m%d)\"\ngit checkout -b \"$BRANCH\"\ngit add -A\ngit commit -m \"fix(rhodibot): automated RSR compliance fixes\n\n${{ steps.fix.outputs.FIXES }}\n\nCo-Authored-By: rhodibot <rhodibot@hyperpolymath.dev>\"\n\ngit push origin \"$BRANCH\"\n\nBODY=\"## \U0001F916 Rhodibot — RSR Compliance Fixes\n\n### Changes Made\n${{ steps.fix.outputs.FIXES }}\n\"\n\nif [ -n \"${{ steps.fix.outputs.ISSUES }}\" ]; then\n  BODY=\"$BODY\n### Issues Found (manual fix needed)\n${{ steps.fix.outputs.ISSUES }}\n\"\nfi\n\nif [ -n \"${{ steps.fix.outputs.DANGEROUS }}\" ]; then\n  BODY=\"$BODY\n### ⚠️ Dangerous Patterns Detected\n${{ steps.fix.outputs.DANGEROUS }}\n\n_These bypass formal verification. See \\`proven\\` repo for alternatives._\n\"\nfi\n\ngh pr create \\\n  --title \"\U0001F916 Rhodibot: RSR compliance fixes\" \\\n  --body \"$BODY\" \\\n  --base main \\\n  --head \"$BRANCH\"\n"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Report (no changes needed)
         if: steps.fix.outputs.CHANGED != 'true'
         run: |

--- a/affinescriptiser/.github/workflows/rust-ci.yml
+++ b/affinescriptiser/.github/workflows/rust-ci.yml
@@ -4,62 +4,47 @@
 # rust-ci.yml — Cargo build, test, clippy, and fmt for Rust projects.
 # Only runs if Cargo.toml exists in the repo root.
 name: Rust CI
-
 on:
   pull_request:
     branches: ['**']
   push:
     branches: [main, master]
-
 permissions:
   contents: read
-
 jobs:
   check:
     name: Cargo check + clippy + fmt
     runs-on: ubuntu-latest
     if: hashFiles('Cargo.toml') != ''
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
           components: clippy, rustfmt
-
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-
       - name: Cargo check
         run: cargo check --all-targets 2>&1
-
       - name: Cargo fmt
         run: cargo fmt --all -- --check
-
       - name: Cargo clippy
         run: cargo clippy --all-targets -- -D warnings
-
   test:
     name: Cargo test
     runs-on: ubuntu-latest
     needs: check
     if: hashFiles('Cargo.toml') != ''
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
-
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-
       - name: Run tests
         run: cargo test --all-targets
-
       - name: Write summary
         if: always()
         run: |

--- a/affinescriptiser/.github/workflows/scorecard-enforcer.yml
+++ b/affinescriptiser/.github/workflows/scorecard-enforcer.yml
@@ -1,40 +1,34 @@
 # SPDX-License-Identifier: MPL-2.0
 # Prevention workflow - runs OpenSSF Scorecard and fails on low scores
 name: OpenSSF Scorecard Enforcer
-
 on:
   push:
     branches: [main]
   schedule:
-    - cron: '0 6 * * 1'  # Weekly on Monday
+    - cron: '0 6 * * 1' # Weekly on Monday
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   scorecard:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      id-token: write  # For OIDC
+      id-token: write # For OIDC
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
         with:
           sarif_file: results.sarif
-
       - name: Check minimum score
         run: |
           # Parse score from results
@@ -49,20 +43,17 @@ jobs:
             echo "::error::Scorecard score $SCORE is below minimum $MIN_SCORE"
             exit 1
           fi
-
   # Check specific high-priority items
   check-critical:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Check SECURITY.md exists
         run: |
           if [ ! -f "SECURITY.md" ]; then
             echo "::error::SECURITY.md is required"
             exit 1
           fi
-
       - name: Check for pinned dependencies
         run: |
           # Check workflows for unpinned actions

--- a/affinescriptiser/.github/workflows/scorecard.yml
+++ b/affinescriptiser/.github/workflows/scorecard.yml
@@ -6,10 +6,8 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
   analysis:
     runs-on: ubuntu-latest
@@ -20,13 +18,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
-
       - name: Upload results
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.31.8
         with:

--- a/affinescriptiser/.github/workflows/secret-scanner.yml
+++ b/affinescriptiser/.github/workflows/secret-scanner.yml
@@ -1,47 +1,29 @@
 # SPDX-License-Identifier: MPL-2.0
 # Prevention workflow - scans for hardcoded secrets before they reach main
 name: Secret Scanner
-
 on:
   pull_request:
   push:
     branches: [main]
-
 permissions:
   contents: read
-
 jobs:
   trufflehog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0  # Full history for scanning
-
+          fetch-depth: 0 # Full history for scanning
       - name: TruffleHog Secret Scan
         uses: trufflesecurity/trufflehog@6c05c4a00b91aa542267d8e32a8254774799d68d # v3
         with:
           extra_args: --only-verified --fail
-
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Gitleaks Secret Scan
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # Rust-specific: Check for hardcoded crypto values
   rust-secrets:
     runs-on: ubuntu-latest
     if: hashFiles('**/Cargo.toml') != ''
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Check for hardcoded secrets in Rust
         run: |
           # Patterns that suggest hardcoded secrets

--- a/affinescriptiser/.github/workflows/static-analysis-gate.yml
+++ b/affinescriptiser/.github/workflows/static-analysis-gate.yml
@@ -2,16 +2,13 @@
 # Static Analysis Gate — Required by branch protection rules.
 # Runs panic-attack and hypatia, deposits findings for gitbot-fleet learning.
 name: Static Analysis Gate
-
 on:
   pull_request:
     branches: ['**']
   push:
     branches: [main, master]
-
 permissions:
   contents: read
-
 jobs:
   # ---------------------------------------------------------------------------
   # Job 1: panic-attack assail
@@ -19,13 +16,11 @@ jobs:
   panic-attack-assail:
     name: panic-attack assail
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Install panic-attack (if available)
         id: install
         run: |
@@ -39,7 +34,6 @@ jobs:
             echo "::notice::panic-attack binary not available — skipping assail"
             echo "installed=false" >> "$GITHUB_OUTPUT"
           fi
-
       - name: Run panic-attack assail
         id: assail
         if: steps.install.outputs.installed == 'true'
@@ -66,7 +60,6 @@ jobs:
           echo "medium=$MEDIUM" >> "$GITHUB_OUTPUT"
           echo "low=$LOW" >> "$GITHUB_OUTPUT"
           echo "exit_code=$PA_EXIT" >> "$GITHUB_OUTPUT"
-
       - name: Emit check annotations
         if: steps.install.outputs.installed == 'true'
         run: |
@@ -80,7 +73,6 @@ jobs:
               "::warning file=\(.file),line=\(.line // 1)::[panic-attack] \(.message)"
             end
           ' panic-attack-findings.json || true
-
       - name: Write step summary
         if: steps.install.outputs.installed == 'true'
         run: |
@@ -95,7 +87,6 @@ jobs:
           | Low      | ${{ steps.assail.outputs.low }} |
           | **Total**| ${{ steps.assail.outputs.total }} |
           EOF
-
       - name: Create stub findings (when panic-attack unavailable)
         if: steps.install.outputs.installed != 'true'
         run: |
@@ -103,33 +94,28 @@ jobs:
           echo "## panic-attack assail" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Skipped: panic-attack not available in this environment." >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload panic-attack findings
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: panic-attack-findings
           path: panic-attack-findings.json
           retention-days: 90
-
       - name: Fail on critical findings
         if: steps.install.outputs.installed == 'true' && steps.assail.outputs.critical > 0
         run: |
           echo "::error::panic-attack found ${{ steps.assail.outputs.critical }} critical issue(s) — blocking merge"
           exit 1
-
   # ---------------------------------------------------------------------------
   # Job 2: hypatia-scan
   # ---------------------------------------------------------------------------
   hypatia-scan:
     name: Hypatia neurosymbolic scan
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Setup Elixir for Hypatia scanner
         id: beam
         continue-on-error: true
@@ -137,7 +123,6 @@ jobs:
         with:
           elixir-version: '1.19.4'
           otp-version: '28.3'
-
       - name: Clone and build Hypatia
         id: build
         continue-on-error: true
@@ -154,7 +139,6 @@ jobs:
             echo "::notice::Hypatia scanner not available — skipping scan"
             echo "ready=false" >> "$GITHUB_OUTPUT"
           fi
-
       - name: Run Hypatia scan
         id: scan
         if: steps.build.outputs.ready == 'true'
@@ -179,7 +163,6 @@ jobs:
           echo "high=$HIGH" >> "$GITHUB_OUTPUT"
           echo "medium=$MEDIUM" >> "$GITHUB_OUTPUT"
           echo "low=$LOW" >> "$GITHUB_OUTPUT"
-
       - name: Emit check annotations
         if: steps.build.outputs.ready == 'true'
         run: |
@@ -192,7 +175,6 @@ jobs:
               "::warning file=\(.file),line=\(.line // 1)::[hypatia] \(.message)"
             end
           ' hypatia-findings.json || true
-
       - name: Write step summary
         if: steps.build.outputs.ready == 'true'
         run: |
@@ -207,7 +189,6 @@ jobs:
           | Low      | ${{ steps.scan.outputs.low }} |
           | **Total**| ${{ steps.scan.outputs.total }} |
           EOF
-
       - name: Create stub findings (when Hypatia unavailable)
         if: steps.build.outputs.ready != 'true'
         run: |
@@ -215,20 +196,17 @@ jobs:
           echo "## Hypatia Scan" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Skipped: Hypatia scanner not available in this environment." >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload hypatia findings
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json
           retention-days: 90
-
       - name: Fail on critical security findings
         if: steps.build.outputs.ready == 'true' && steps.scan.outputs.critical > 0
         run: |
           echo "::error::Hypatia found ${{ steps.scan.outputs.critical }} critical security issue(s) — blocking merge"
           exit 1
-
   # ---------------------------------------------------------------------------
   # Job 3: deposit-findings (combines + archives for gitbot-fleet)
   # ---------------------------------------------------------------------------
@@ -237,20 +215,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [panic-attack-assail, hypatia-scan]
     if: always()
-
     steps:
       - name: Download panic-attack findings
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: panic-attack-findings
           path: findings/
-
       - name: Download hypatia findings
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: hypatia-findings
           path: findings/
-
       - name: Combine findings into unified report
         id: combine
         run: |
@@ -298,14 +273,12 @@ jobs:
           echo "high=$HIGH"         >> "$GITHUB_OUTPUT"
           echo "medium=$MEDIUM"     >> "$GITHUB_OUTPUT"
           echo "low=$LOW"           >> "$GITHUB_OUTPUT"
-
       - name: Upload unified findings (fleet scanner picks these up)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unified-findings
           path: findings/unified-findings.json
           retention-days: 90
-
       - name: Write deposit summary
         run: |
           cat <<EOF >> "$GITHUB_STEP_SUMMARY"

--- a/affinescriptiser/.gitlab-ci.yml
+++ b/affinescriptiser/.gitlab-ci.yml
@@ -6,20 +6,16 @@ stages:
   - lint
   - test
   - build
-
 variables:
   CARGO_HOME: ${CI_PROJECT_DIR}/.cargo
-
 cache:
   key: ${CI_COMMIT_REF_SLUG}
   paths:
     - .cargo/
     - target/
-
 # ==================
 # Security Scanning
 # ==================
-
 trivy:
   stage: security
   image: aquasec/trivy:latest
@@ -27,21 +23,12 @@ trivy:
     - trivy fs --exit-code 0 --severity HIGH,CRITICAL --format table .
     - trivy fs --exit-code 1 --severity CRITICAL .
   allow_failure: false
-
-gitleaks:
-  stage: security
-  image: zricethezav/gitleaks:latest
-  script:
-    - gitleaks detect --source . --verbose --redact
-  allow_failure: false
-
 semgrep:
   stage: security
   image: returntocorp/semgrep
   script:
     - semgrep --config auto --error .
   allow_failure: true
-
 cargo-audit:
   stage: security
   image: rust:latest
@@ -51,7 +38,6 @@ cargo-audit:
   rules:
     - exists:
         - Cargo.toml
-
 cargo-deny:
   stage: security
   image: rust:latest
@@ -62,7 +48,6 @@ cargo-deny:
     - exists:
         - Cargo.toml
   allow_failure: true
-
 mix-audit:
   stage: security
   image: elixir:latest
@@ -75,11 +60,9 @@ mix-audit:
     - exists:
         - mix.exs
   allow_failure: true
-
 # ==================
 # Linting
 # ==================
-
 rustfmt:
   stage: lint
   image: rust:latest
@@ -89,7 +72,6 @@ rustfmt:
   rules:
     - exists:
         - Cargo.toml
-
 clippy:
   stage: lint
   image: rust:latest
@@ -100,7 +82,6 @@ clippy:
     - exists:
         - Cargo.toml
   allow_failure: true
-
 mix-format:
   stage: lint
   image: elixir:latest
@@ -109,7 +90,6 @@ mix-format:
   rules:
     - exists:
         - mix.exs
-
 credo:
   stage: lint
   image: elixir:latest
@@ -121,11 +101,9 @@ credo:
     - exists:
         - mix.exs
   allow_failure: true
-
 # ==================
 # Testing
 # ==================
-
 cargo-test:
   stage: test
   image: rust:latest
@@ -134,7 +112,6 @@ cargo-test:
   rules:
     - exists:
         - Cargo.toml
-
 mix-test:
   stage: test
   image: elixir:latest
@@ -145,11 +122,9 @@ mix-test:
   rules:
     - exists:
         - mix.exs
-
 # ==================
 # Build
 # ==================
-
 cargo-build:
   stage: build
   image: rust:latest
@@ -162,7 +137,6 @@ cargo-build:
   rules:
     - exists:
         - Cargo.toml
-
 mix-build:
   stage: build
   image: elixir:latest
@@ -173,3 +147,8 @@ mix-build:
   rules:
     - exists:
         - mix.exs
+trufflehog:
+  stage: security
+  image: trufflesecurity/trufflehog:latest
+  script:
+    - trufflehog git file://. --only-verified --fail

--- a/affinescriptiser/Justfile
+++ b/affinescriptiser/Justfile
@@ -193,3 +193,6 @@ crg-badge:
       D) color="orange" ;; E) color="red" ;; F) color="critical" ;; \
       *) color="lightgrey" ;; esac; \
     echo "[![CRG $$grade](https://img.shields.io/badge/CRG-$$grade-$$color?style=flat-square)](https://github.com/hyperpolymath/standards/tree/main/component-readiness-grades)"
+
+secret-scan-trufflehog:
+    @command -v trufflehog >/dev/null && trufflehog filesystem . --only-verified || true

--- a/docs/decisions/0023-finality-types.adoc
+++ b/docs/decisions/0023-finality-types.adoc
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath (Jonathan D.A. Jewell) <j.d.a.jewell@open.ac.uk>
+= ADR-023: Finality types — assured irreversibility as AffineScript's dual to ephapax's accounted loss
+Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+:toc:
+:toclevels: 2
+:icons: font
+
+Status:: Draft (stub — design-only; no implementation authorised by this document)
+Date:: 2026-06-11
+Issue:: https://github.com/hyperpolymath/affinescript/issues/554[#554 (soundness gate)], https://github.com/hyperpolymath/affinescript/issues/553[#553 (ADR-022 sequencing)]
+Series:: Settled-decisions ledger; companion entry to be added to `.machine_readable/6a2/META.a2ml` at ratification.
+
+== The hard question, on page one
+
+*Deep/transitive freeze.* If `freeze x` coerces `x: T @ 1` to `T @ ω`, what
+happens to fields, captured references, and aliases reachable *through*
+`x`? Shallow freeze is unsound for assurance claims (a frozen aggregate
+with a thawable interior is not final); recursive freeze needs a
+reachability story the type system must carry. The literature is
+*viewpoint adaptation* (Pony's `iso`→`val` via `consume`), Clean's
+uniqueness one-way coercion, and OCaml's uniqueness/modes work. Any
+ratified version of this ADR must answer this before the coercion's
+typing rule is written. Related local wrinkle: `const mut` module-level
+bindings (#549) have no cross-function consumption story yet — freezing
+module state is in scope for this question, not exempt from it.
+
+== Context
+
+AffineScript's identity is affine-first: "affine is the permanent resting
+state" (DESIGN-VISION.adoc), explicitly contrasted with ephapax's
+affine-as-enabler-of-linear. The estate disambiguation doc
+(`nextgen-languages/docs/disambiguation/ephapax-vs-affinescript.md`)
+limits shared surface to the typed-wasm target and bans cross-applying
+mechanisms between the two languages.
+
+Finality types lean *into* that identity rather than against it.
+The upstream theorem already exists: echo-types' `no-section-weaken`
+(EchoLinear.agda) — no pure function reconstructs a value from its affine
+residue. Ephapax consumes the *witness* side of that theorem (residues,
+receipts, accounted loss). AffineScript consumes only the *negative*
+side: once a value crosses a finality boundary, the type system
+guarantees nothing brings it back.
+
+Duality, stated once: *ephapax = accounted loss; AffineScript = assured
+finality.* Same theorem, opposite poles.
+
+== Proposed family
+
+[cols="1,2,3"]
+|===
+|Kind |Lane |Sketch
+
+|`freeze`
+|*Quantity lane* (`lib/quantity.ml`, QTT `{0,1,ω}`)
+|One-way coercion `1 → ω`. No `thaw` exists, ever. Deliberately NOT the
+borrow lane: borrow-graph structures are slated for deletion by ADR-022
+M4, and `quantity.ml` is self-contained with branch snapshot/join
+machinery already present. Note `freeze ≠ unsafe forget` (which lowers to
+a stack discard, codegen.ml:1436-1438): freeze is a typed coercion with
+an assurance, forget is an escape hatch.
+
+|`seal`
+|Row lane (row polymorphism exists in the typechecker)
+|Irreversible row closure: a sealed record/effect row admits no further
+extension or restriction. Type-level only at v0.
+
+|`commit`
+|stdlib lowering (`Transaction.affine`)
+|First concrete instance and the first *emission* arm: transaction commit
+lowers to a `commit` receipt in the `typedwasm.receipts` carrier (see
+Carrier). Chosen first because the db-theory work (#522–#528,
+echo-types#174) already defines the obligation shape.
+
+|`revoke`
+|Capability lane
+|Capability invalidation with no re-grant from the revoked handle.
+Converges with the reserved `Encode.capabilities` wire slot
+(`lib/tw_section.mli`).
+|===
+
+== Carrier (Stage-E / CONV-04 log entry — no compiler work)
+
+The receipts RFC lives upstream in `hyperpolymath/typed-wasm`
+(`typedwasm.receipts`: digest/unit records; echo family v0 =
+`region_exit` / `drop` / `observe`; finality family *reserved* =
+`freeze` / `seal` / `commit` / `revoke`). Hard rule inherited here:
+*witness payloads never serialise.* AffineScript's first emission arm is
+`commit` receipts from `Transaction.affine` lowering. The control-arm
+asymmetry — AffineScript has no `region_exit`/`drop` events to emit
+(no reclamation machinery exists on any backend) — is the design, not a
+gap: AffineScript is the affine/discard control group; ephapax is the
+linear/witness treatment.
+
+Per the disambiguation doc's own rule (:106), the "What is shared"
+section there must be updated *before* the receipts carrier becomes
+shared surface.
+
+== Anti-hollowing rule (reverse direction)
+
+This repo receives at most *negative capabilities* (no-section
+consequences) and *digest/unit receipts*. It never grows witness shapes
+(`Σ`-typed preimages, `LEcho linear`, observation obligations). If a
+change request needs a witness, it belongs in ephapax — route it there.
+
+== Sequencing constraints (non-negotiable)
+
+. *No assurance claims while #554 is open.* A finality "guarantee"
+  built over a borrow checker with a live use-after-move false negative
+  is an overclaim of exactly the class the doc-truthing ratchet cannot
+  catch.
+. *Full `&mut`-at-freeze-point enforcement waits for ADR-022 (#553).*
+  Today the typechecker cannot even see exclusivity at a coercion point:
+  `&mut e` types as plain `TRef` (typecheck.ml:615-619, "exclusivity is a
+  static borrow-checker property only"). Until origins exist, freeze can
+  only be checked against the quantity environment, not against live
+  exclusive borrows.
+. *Prerequisite hygiene:* `quantity.ml`'s environment is keyed by
+  variable name, not symbol id (quantity.ml:196-205); nested-scope
+  shadowing already miscounts (over-reject direction). Re-key by symbol
+  id before `freeze` lands — a finality coercion must not depend on
+  name-collision behaviour.
+. *May land before any of the above:* this ADR; the reserved carrier
+  kind names (upstream RFC); the quantity-lane coercion *design* (typing
+  rule + degradation laws on paper).
+
+== Precedents to cite at ratification
+
+* Clean: uniqueness as a one-way coercion (unique → non-unique).
+* Pony: `iso` → `val` via `consume`; viewpoint adaptation for the deep
+  case.
+* OCaml: uniqueness/modes (Jane Street's mode system work).
+* Upstream theorem: echo-types `no-section-weaken` (EchoLinear.agda:51-54)
+  with its honest bound — type-level non-reconstructibility, NOT byte
+  zeroing, NOT runtime attestation. That disclosure discipline travels
+  with every consumer of the vocabulary, including this one.
+
+== Status of this stub
+
+Drafted 2026-06-11 on owner instruction following the whole-picture
+survey; concurrence recorded against the identity doc and ADR-022
+sequencing. Not ratified. No implementation. Lands via PR when the owner
+moves it; until then it is an uncommitted draft.

--- a/tools/wasm-export-call-zig/src/types.zig
+++ b/tools/wasm-export-call-zig/src/types.zig
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+//
+// Types shared between the wasm_export_call dispatcher and any host that
+// embeds it. The layout deliberately matches the Deno-ESM lowering's
+// `{ kind: "i32"|"i64"|"f32"|"f64", v }` semantics so the AS-side
+// `WasmValue` round-trips cleanly across either host.
+//
+// ABI stability: every type here is `extern struct` / `extern union` /
+// `enum(u8)` — the layouts are part of the public C ABI and must not
+// change without a major version bump of the crate.
+
+const std = @import("std");
+
+/// `WasmValue` discriminator. Numeric values are deliberately stable so
+/// downstream consumers can hard-code them in `.h` constants. `err` is
+/// reserved for the "no such export" failure path; it cannot appear as
+/// the kind of a value the host successfully marshals in.
+pub const WasmKind = enum(u8) {
+    i32 = 0,
+    i64 = 1,
+    f32 = 2,
+    f64 = 3,
+    /// Sentinel returned by `wasm_export_call` when the registry lookup
+    /// fails. The payload is zeroed; callers should branch on
+    /// `result.kind == .err` rather than inspect `payload`.
+    err = 0xff,
+};
+
+/// Tagged scalar matching the Deno-ESM `{ kind, v }` representation.
+///
+/// `i64` is preserved at full 64-bit precision; the JS-side carries it
+/// as `BigInt` to avoid the 2^53 safe-integer cliff. Choice of payload
+/// is selected by `kind`; reading the wrong variant is undefined at the
+/// ABI level (callers can recover via the AS-side `wv_kind`).
+pub const WasmValueRepr = extern struct {
+    kind: WasmKind,
+    /// Padding so the payload is naturally aligned on 8-byte
+    /// boundaries. The seven trailing bytes are not part of the
+    /// observable value; the dispatcher zeroes them on every return.
+    _pad: [7]u8 = [_]u8{0} ** 7,
+    payload: extern union {
+        i32_v: i32,
+        i64_v: i64,
+        f32_v: f32,
+        f64_v: f64,
+    },
+};
+
+/// Type of a per-export callback the host registers. Each callback
+/// receives the raw `WasmValueRepr[]` slice the AS-side passed in, and
+/// returns a single `WasmValueRepr` — the wasm scalar return.
+///
+/// The callback is the host's single chance to invoke the actual wasm
+/// export (typically via `wasmtime` / `wasmer` / `wasm3` / whatever
+/// runtime the embedder ships); this crate does not embed a wasm
+/// runtime of its own.
+pub const WasmExportCallback = *const fn (
+    args_ptr: [*]const WasmValueRepr,
+    args_len: usize,
+) callconv(.C) WasmValueRepr;
+
+/// One entry in a `WasmExportRegistry`. `name_ptr` + `name_len` is a
+/// byte slice; it does not need to be NUL-terminated. The dispatcher
+/// compares against the AS-side `String` (also a ptr+len) verbatim.
+pub const WasmExportEntry = extern struct {
+    name_ptr: [*]const u8,
+    name_len: usize,
+    callback: WasmExportCallback,
+};
+
+/// The "exports handle" the AS-side `WasmExports` opaque resolves to on
+/// this Zig host. The host constructs this once per wasm instance and
+/// passes a pointer to it as `exports_handle` whenever it invokes the
+/// dispatcher (typically by binding the dispatcher under `env` in the
+/// wasm instance's import object and threading the registry through a
+/// thread-local or a host-state pointer the runtime supports).
+pub const WasmExportRegistry = extern struct {
+    entries: [*]const WasmExportEntry,
+    count: usize,
+};
+
+/// Construct an error `WasmValueRepr` with kind `.err` and a zeroed
+/// payload. Used by the dispatcher's failure path; exposed publicly so
+/// host-side callbacks can return the same sentinel when they detect
+/// an internal invocation error (wasm trap, type mismatch, etc.).
+pub fn errValue() WasmValueRepr {
+    return WasmValueRepr{
+        .kind = .err,
+        ._pad = [_]u8{0} ** 7,
+        .payload = .{ .i64_v = 0 },
+    };
+}
+
+/// Constructor for an i32 result.
+pub fn fromI32(v: i32) WasmValueRepr {
+    return WasmValueRepr{
+        .kind = .i32,
+        ._pad = [_]u8{0} ** 7,
+        .payload = .{ .i32_v = v },
+    };
+}
+
+/// Constructor for an i64 result.
+pub fn fromI64(v: i64) WasmValueRepr {
+    return WasmValueRepr{
+        .kind = .i64,
+        ._pad = [_]u8{0} ** 7,
+        .payload = .{ .i64_v = v },
+    };
+}
+
+/// Constructor for an f32 result.
+pub fn fromF32(v: f32) WasmValueRepr {
+    return WasmValueRepr{
+        .kind = .f32,
+        ._pad = [_]u8{0} ** 7,
+        .payload = .{ .f32_v = v },
+    };
+}
+
+/// Constructor for an f64 result.
+pub fn fromF64(v: f64) WasmValueRepr {
+    return WasmValueRepr{
+        .kind = .f64,
+        ._pad = [_]u8{0} ** 7,
+        .payload = .{ .f64_v = v },
+    };
+}
+
+test "WasmValueRepr is 16 bytes on common targets" {
+    try std.testing.expectEqual(@as(usize, 16), @sizeOf(WasmValueRepr));
+}
+
+test "errValue has kind .err and zero payload" {
+    const v = errValue();
+    try std.testing.expectEqual(WasmKind.err, v.kind);
+    try std.testing.expectEqual(@as(i64, 0), v.payload.i64_v);
+}
+
+test "round-trip constructors preserve their kind tag" {
+    try std.testing.expectEqual(WasmKind.i32, fromI32(42).kind);
+    try std.testing.expectEqual(WasmKind.i64, fromI64(42).kind);
+    try std.testing.expectEqual(WasmKind.f32, fromF32(1.5).kind);
+    try std.testing.expectEqual(WasmKind.f64, fromF64(1.5).kind);
+}


### PR DESCRIPTION
Owner commit 2ceb06f pushed for preservation + CI adjudication per "what can go main goes main".

Contents (one signed commit):
- **TruffleHog standardization** across root + affinescript-vite + affinescriptiser workflow trees (its substance; net -393 lines).
- **docs/decisions/0023-finality-types.adoc** — ADR-023 finality-types DRAFT stub (Status: Draft, design-only, no implementation; sequencing constraints reference #554/#553). Rides along; ratification is a separate act.
- **tools/wasm-export-call-zig/src/types.zig** — WasmValue 4-variant types for the #497 Zig FFI dispatcher (WIP preservation; unwired).

If checks are green this is main-able as-is; if the mixed contents should split, say so and I'll surgically refile.

Refs #497, #563. ADR-023 context: assured-finality dual per the 2026-06-11 design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)