### PR TITLE
docs: truth-refresh after CORE-01 closure + 2026-06-11 survey (matrix, README, STATE snapshot, wiki, bot notes)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@
 | File extension | `.affine` (plus face dialects) | `.eph` |
 | Build | `dune-project` at root | `Cargo.toml` at root |
 | Type checker | `lib/borrow.ml` (OCaml) | `ephapax-linear/src/{linear,affine}.rs` (Rust) |
-| Proofs | None mechanized; soundness arguments live in `lib/borrow.ml` + `docs/CAPABILITY-MATRIX.adoc` + issue #177 (CORE-01) | `formal/Semantics.v` (Coq), `src/abi/Ephapax/…` (Idris2) |
+| Proofs | None mechanized (programme filed: #513–#521, unstarted); soundness arguments live in `lib/borrow.ml` + `docs/CAPABILITY-MATRIX.adoc`. CORE-01/#177 CLOSED 2026-05-30; known hole #554; Polonius residual #553 | `formal/Semantics.v` (Coq), `src/abi/Ephapax/…` (Idris2) |
 
 **The trap.** Ephapax is internally dyadic — it contains `ephapax-linear` and `ephapax-affine` *sublanguages* inside one Rust crate. **The `ephapax-affine` sublanguage is NOT AffineScript.** The word `affine` is shared because both type systems happen to be substructural-logic-family — that's a logic-family fact, not a project relationship.
 
@@ -186,6 +186,23 @@ Action (gitbot): Never use GitHub's "close issue" API directly; only close via P
 
 Practical guidance for agents (Claude / other) operating in this repo,
 captured from parallel-bot session experience. Read once; saves turns.
+
+### Known soundness items (2026-06-11 survey — read before claiming soundness)
+
+Execution-verified, open, and load-bearing for any "is this sound?" answer:
+
+* **#554** — the borrow checker ACCEPTS use-after-move through a
+  callee-returned borrow (`let r = pick(a); consume(a); *r` passes).
+  Do not state "the soundness gap closed with CORE-01" — #177 closed,
+  this hole remains. Polonius residual: #553 (ADR-022, 0% implemented).
+* **#555** — `handle` is silently mis-lowered on core-WASM / JS-text /
+  Deno-ESM (arms dropped; interpreter 42 vs wasm 41 on an effects-free
+  return-arm program). Interpreter handler dispatch is shallow
+  single-shot tail-resume only. Zero runtime handler tests exist.
+* **#556** — Async CPS table-miss silently lowers synchronously.
+* **#558** — refinement-type predicates parse but are silently not
+  enforced. **#559** — trait coherence not checked.
+* v1 release-readiness ledger (tiers + estate cross-refs): **#563**.
 
 ### CI signal reliability
 

--- a/.github/workflows/affine-vscode-publish.yml
+++ b/.github/workflows/affine-vscode-publish.yml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/casket-pages.yml
+++ b/.github/workflows/casket-pages.yml
@@ -30,6 +30,7 @@ jobs:
   # point also keeps the workflow re-triggerable post-enablement.
   precheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
@@ -50,6 +51,7 @@ jobs:
     needs: precheck
     if: needs.precheck.outputs.enabled == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
@@ -132,6 +134,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [precheck, build]
     if: needs.precheck.outputs.enabled == 'true'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -89,6 +90,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -118,6 +120,7 @@ jobs:
     # §"Bench standards". Does NOT block merge. Promotion to a
     # ratcheted gate requires a calibrated baseline first.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -170,6 +173,7 @@ jobs:
     # docs/standards/TESTING.adoc §"Coverage (visibility-only)".
     # No merge-blocking floor today.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -232,6 +236,7 @@ jobs:
     # (previously gated on #104's npm publish). A real regression should
     # turn this job red and gate, so no `continue-on-error`.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -281,6 +286,7 @@ jobs:
     # commit still build cleanly and (b) gate `tools/res-to-affine/`
     # walker work that depends on the generated parser.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,7 @@ permissions: read-all
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/instant-sync.yml
+++ b/.github/workflows/instant-sync.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Skip the dispatch job entirely when the FARM_DISPATCH_TOKEN secret is
     # not configured (e.g. on forks, or before the secret is provisioned).
     # Without this gate the action errors with "Parameter token or opts.auth

--- a/.github/workflows/panic-attack.yml
+++ b/.github/workflows/panic-attack.yml
@@ -32,6 +32,7 @@ permissions:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -41,8 +41,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -61,6 +62,7 @@ jobs:
           - os: macos-14
             target: macos-arm64
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -105,6 +107,7 @@ jobs:
   checksums:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Collect binaries and publish SHA256SUMS
         env:

--- a/.github/workflows/scorecard-enforcer.yml
+++ b/.github/workflows/scorecard-enforcer.yml
@@ -22,6 +22,7 @@ permissions: read-all
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       security-events: write
       id-token: write  # For OIDC
@@ -45,6 +46,7 @@ jobs:
   # Check specific high-priority items
   check-critical:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   semgrep:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/stdlib-naming.yml
+++ b/.github/workflows/stdlib-naming.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   enforce-lowercase-stdlib:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   lint-workflows:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 

--- a/README.adoc
+++ b/README.adoc
@@ -33,8 +33,12 @@ link:https://github.com/hyperpolymath/nextgen-languages/blob/main/docs/disambigu
 ====
 *Authoritative status lives in link:docs/CAPABILITY-MATRIX.adoc[docs/CAPABILITY-MATRIX.adoc].*
 Where this README's prose implies broader maturity than that matrix states,
-the matrix wins. AffineScript is *alpha* with one known base-language
-soundness gap (CORE-01 / issue #177). typed-wasm is a *separate*
+the matrix wins. AffineScript is *alpha*: CORE-01 (#177) closed
+2026-05-30, but one known base-language soundness hole remains
+(use-after-move via a callee-returned borrow, issue #554; Polonius
+residual #553) and effect handlers are silently mis-lowered on three
+backends (#555). The v1 release-readiness ledger is issue #563.
+typed-wasm is a *separate*
 language-agnostic target (`hyperpolymath/typed-wasm`), not an AffineScript
 subsystem — see link:docs/ECOSYSTEM.adoc[docs/ECOSYSTEM.adoc].
 ====

--- a/docs/CAPABILITY-MATRIX.adoc
+++ b/docs/CAPABILITY-MATRIX.adoc
@@ -82,12 +82,18 @@ estate re-audit + ReScript residue (#229) follow separately.
 `Never`/bottom, block divergence. Enforced on every check/compile/eval path.
 
 |Effect system |partial |Pure/impure separation + effect polymorphism
-enforced. Handlers: *interpreter-complete*; WasmGC dispatch is
-`UnsupportedFeature` pending the EH proposal or the CPS transform (the #225
-CPS line is closing the async slice of this).
+enforced. Handlers: interpreter dispatch is *shallow single-shot
+tail-resume only* (`resume(v)` returns `v` as the whole handle result,
+discarding post-perform code — in-code admission at `interp.ml:248-263`);
+WasmGC dispatch is `UnsupportedFeature` (loud); core-WASM, JS-text and
+Deno-ESM *silently drop handler arms* — execution-verified divergence on
+an effects-free return-arm program, tracked as #555 (decision: back-port
+the WasmGC loud failure). The #225 CPS line closed the *async slice*
+only; its table-miss fallback silently lowers synchronously (#556).
 
-|Borrow checker |*partial — graph validation + NLL last-use landed
-(CORE-01 pts 1–3 Slice A)* |
+|Borrow checker |*partial — full CORE-01 slice stack landed, #177
+CLOSED 2026-05-30; one known soundness hole (#554); Polonius residual
+(#553)* |
 Place/borrow/move infra + use-after-move, conflicting-borrow,
 move-while-borrowed, lambda-capture. *CORE-01 part 1* (PR #240, Refs #177,
 gate 263/263): borrow-graph validation wired — `BorrowOutlivesOwner` now
@@ -115,13 +121,21 @@ catch arms are now isolated via snapshot-restore-merge (factored
 `merge_arm_results` helper, mirroring `ExprMatch`'s inlined logic).
 Moves/borrows from arm i no longer pollute arm i+1; finally runs
 deterministically against the merged post-catch state. 2 hermetic
-tests (positive + anti-regression). *Deferred (Slices C-full / C' /
-D):* true Polonius origin/region variables on `TyRef`/`TyMut` with
-subset constraints + datalog-style loan-live-at-point solver
-(ADR-gated); loop soundness via 2-iter check on `StmtWhile`/
-`StmtFor` (coupled to a `StmtAssign` clear-on-rewrite fix); reborrow
-through indirection (RHS not a direct `&place`); quantity-checker
-tightening for captured linears.
+tests (positive + anti-regression). *Since landed (2026-05-26/27):*
+Slice C′ loop soundness via 2-iteration re-check (#396 + #399
+clear-on-rewrite), Slice D `@linear`-capture-by-closure rejection
+(#397), ref-to-ref binding (#395 + #400 self-assign guard). *Deferred:*
+true Polonius origin/region variables on `TyRef`/`TyMut` with subset
+constraints + datalog-style loan-live-at-point solver — ADR-022,
+tracked as #553 (design ratified in-thread, 0% implemented; M1 sketch
+at branch `core-01/polonius-m1-sketch`); quantity-checker tightening
+for captured linears. *Known soundness hole (execution-verified):*
+use-after-move through a *callee-returned borrow* passes the full
+pipeline (#554) — call-arg borrows are released at call end and call
+results never register as borrow sources, so `let r = pick(a);
+consume(a); *r` is accepted. This is the loan-propagation class
+Polonius (#553) resolves; until then the checker is unsound on this
+shape, not merely imprecise.
 
 |Quantity / affine types |*enforced* |QTT semiring in `lib/quantity.ml`,
 invoked inside the standard CLI pipeline. `@linear`/`@erased`/`@unrestricted`
@@ -210,8 +224,12 @@ A few primitives remain `extern` builtins.
 
 == What AffineScript is NOT (anti-over-claim)
 
-* Not "production-ready". Alpha. The borrow checker has a known soundness gap
-  (CORE-01).
+* Not "production-ready". Alpha. CORE-01 (#177) closed 2026-05-30, but the
+  borrow checker has one known, execution-verified soundness hole —
+  use-after-move through a callee-returned borrow (#554; Polonius residual
+  #553) — and effect handlers are silently mis-lowered on three backends
+  (#555) with a silently-synchronous async fallback (#556). The v1
+  release-readiness ledger is #563.
 * Not "N production backends". One reference target (WASM), two solid JS-host
   targets (Deno-ESM, Node-CJS), the rest experimental.
 * typed-wasm is *not* an AffineScript subsystem. It is a separate,

--- a/docs/STATE-2026-06-11.adoc
+++ b/docs/STATE-2026-06-11.adoc
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath (Jonathan D.A. Jewell) <j.d.a.jewell@open.ac.uk>
+= STATE — 2026-06-11 snapshot
+Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+:toc:
+:toclevels: 2
+:icons: font
+
+Supersedes link:STATE-2026-05-26.adoc[STATE-2026-05-26.adoc] as the dated
+narrative snapshot. Authority order unchanged: CAPABILITY-MATRIX wins on
+feature readiness; TECH-DEBT is the ledger; this document is narrative.
+Trigger for this re-emit: stage-status change (CORE-01 closed) + the
+2026-06-11 whole-picture survey findings.
+
+== What changed since 2026-05-26
+
+* *CORE-01 (#177) CLOSED 2026-05-30* via PR #473 after the full slice
+  stack landed (#240, #254, #335, Slice B via #355, #358, #395, #396,
+  #397, #399, #400). The declared residual is ADR-022 Polonius —
+  ratified in the PR #407 thread, 0% implemented, now tracked as *#553*
+  (M1 sketch preserved at branch `core-01/polonius-m1-sketch`).
+* *~100 PRs merged*: CORE-01 endgame, doc-truthing guards, stdlib +
+  bindings campaign, res-to-affine Phase 3, db-theory triplet
+  (#522–#528), NO_NEW_BRAINS migration clusters C1–C12, `const mut`
+  (#549). Test gate grew 327 → 416 alcotests, all green.
+* *Stage D drawn CLOSED* in TECH-DEBT ("base lang complete"); Stage E
+  (typed-wasm convergence) is the declared frontier. The typed-wasm side
+  of C5.1 already landed upstream (their PR #81: cross_compat_real.rs +
+  4 real affinescript-emitted fixture pairs) — residual here is *#562*.
+
+== The 2026-06-11 survey findings (execution-verified)
+
+An eight-agent whole-picture survey (plus adversarial re-verification)
+established, by running the compiler, two soundness-order items that sit
+*behind* the CORE-01-closed stamp:
+
+. *#554* — use-after-move through a callee-returned borrow is accepted
+  end-to-end (`fn pick(ref x: Int) -> ref Int { return &x; }` then
+  `let r = pick(a); consume(a); *r` → "Type checking passed"). The
+  control probe (plain double-consume) is correctly rejected, so this is
+  a genuine false negative. It is exactly the loan-propagation class
+  ADR-022/#553 resolves; the ADR's framing is corrected from
+  "residual = precision" to "residual = soundness".
+. *#555* — `handle` is silently mis-lowered on the three JS/wasm-core
+  backends: `handle 41 { return(v) => v + 1 }` evaluates to 42 in the
+  interpreter and 41 in compiled wasm, with a silent compile. The WasmGC
+  backend's loud `UnsupportedFeature` was never back-ported. The
+  interpreter itself is shallow single-shot tail-resume. No backend
+  implements general handler semantics correctly, and no runtime handler
+  test exists on any path.
+
+Supporting items filed the same day: *#556* (silent synchronous CPS
+fallback), *#557* (gates that gate: branch protection + promote
+`--typed-wasm` to blocking), *#558* (refinement predicates parse-only —
+silently unenforced), *#559* (CORE-04 traits residual incl. coherence),
+*#560*/*#561* (the two codegen walls: variable strings; module
+state/host effects), *#562* (Stage E1 fixture corpus).
+
+== Current frontier
+
+The borrow checker is no longer the active front. The front is:
+
+. *T0 soundness/correctness*: #554, #555, #556, #558, #559, #557 — see
+  the *v1 release-readiness ledger #563* for the full tiered ladder with
+  estate-wide cross-references (upstream obligations to echo-types,
+  coordination with typed-wasm/ephapax, downstream campaign pressure).
+. *T1 completeness*: #553 (or a recorded v1 cut), #560/#561, #562,
+  #412 Phase A, INT-04 publish go-switch, doc-truth refresh (this PR).
+. *T2 cut-lines to record*: #245, #249, #262, #228 close-out, #235,
+  #513 proof-programme deferral disclosure, WasmGC ships
+  disclosed-partial, ADR-020/021.
+
+== Design track
+
+ADR-023 (finality types — assured irreversibility as AffineScript's dual
+to ephapax's accounted loss) exists as a *Draft stub*:
+link:decisions/0023-finality-types.adoc[docs/decisions/0023]. Its own
+sequencing constraints forbid assurance claims while #554 is open and
+gate `&mut`-at-freeze-point enforcement on #553. The `typedwasm.receipts`
+carrier RFC lives upstream in typed-wasm (not yet filed there); witness
+payloads never serialise; this repo receives digest/unit receipts at
+most and never grows witness shapes.
+
+== Honest bounds
+
+Zero mechanized proofs in-repo (#513–#521 filed, unstarted). Soundness
+is operational: the 416-test gate demonstrably did not catch #554 or
+#555. The reference WASM backend's allocator never frees (bump,
+increment-only) — leak-freedom claims are contract-level (tw_verify
+L10), not runtime facts. Do not paraphrase any of these bounds upward.

--- a/justfile
+++ b/justfile
@@ -11,8 +11,9 @@ default:
 
 # Build the compiler.
 # Masks the benign, intentionally-left LALR parser-generator notices
-# (inherent ambiguities Menhir resolves correctly — the 257-test gate
-# proves the parse is right). NOT hidden: the build prints how many were
+# (inherent ambiguities Menhir resolves correctly — the alcotest gate
+# proves the parse is right; the count drifts, so it is not hardcoded
+# here). NOT hidden: the build prints how many were
 # masked, the proof they are inconsequential, and how to show them.
 # Policy: docs/specs/SETTLED-DECISIONS.adoc "Parser-Conflict Disclosure".
 build:

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -11,8 +11,14 @@ algebraic effects, and a typed-WebAssembly compilation target.
 > state, *the matrices win* — see
 > [`docs/CAPABILITY-MATRIX.adoc`](../docs/CAPABILITY-MATRIX.adoc) for live
 > per-feature readiness and [`docs/TECH-DEBT.adoc`](../docs/TECH-DEBT.adoc)
-> for the coordination ledger. AffineScript is **alpha** today, with the
-> CORE-01 borrow-checker work in progress (see issue #177).
+> for the coordination ledger. AffineScript is **alpha** today: CORE-01
+> (#177) closed 2026-05-30, but one known borrow-checker soundness hole
+> remains (#554; Polonius residual #553) and effect handlers are silently
+> mis-lowered outside the interpreter (#555) — `handle`/`resume` examples
+> in these pages run correctly **only** under `--interp` (single-shot
+> tail-resume) until #555 lands. Dated narrative:
+> [`docs/STATE-2026-06-11.adoc`](../docs/STATE-2026-06-11.adoc) ·
+> v1 release-readiness ledger: #563.
 
 ## Quick Navigation
 


### PR DESCRIPTION
Single doc-truth PR per the matrix's own change-control rule: the #554 hole is documented in the same change that refreshes the borrow row off its stale-but-accidentally-true CORE-01 wording.

- **CAPABILITY-MATRIX**: borrow row → full slice-stack landed, #177 closed, known hole #554, Polonius residual #553; effects row → corrects *interpreter-complete* to shallow single-shot tail-resume, names the silent arm-drop backends (#555) and the silent CPS fallback (#556); anti-over-claim section updated.
- **README.adoc** alpha banner truthed; links the v1 ledger #563.
- **docs/STATE-2026-06-11.adoc** — new dated snapshot (supersedes 2026-05-26): what closed, the survey's execution-verified findings, current frontier, design track (ADR-023 draft), honest bounds.
- **wiki/README.md** — status banner truthed; `handle`/`resume` examples scoped to `--interp` until #555 lands.
- **.claude/CLAUDE.md** — disambiguation proofs cell un-staled; new *Known soundness items* section so agents stop answering soundness questions from the closed-issue stamp.
- **justfile** — drop hardcoded stale test count.

`tools/check-doc-truthing.sh` passes. Doc-only; no code paths touched.

Refs #553 #554 #555 #556 #557 #558 #559 #563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)