### PR TITLE
ci: auto-add new issues/PRs to master roadmap #35 (pilot)

### DIFF
--- a/.github/workflows/add-to-roadmap.yml
+++ b/.github/workflows/add-to-roadmap.yml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MPL-2.0
+# Auto-add new issues & PRs to the Hyperpolymath Master Roadmap (project #35).
+# Pilot wiring (2026-06-13). Requires repo secret ADD_TO_PROJECT_PAT:
+# a fine-grained PAT with Projects (read+write) on the hyperpolymath account.
+name: Add to roadmap 35
+on:
+  issues:
+    types: [opened, reopened, transferred]
+  pull_request_target:
+    types: [opened, reopened]
+permissions: {}
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/hyperpolymath/projects/35
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Pilot wiring for the per-repo → master roadmap (#35) automation.

Adds `.github/workflows/add-to-roadmap.yml` using `actions/add-to-project@v1.0.2`. New issues/PRs in this repo will be auto-added to https://github.com/users/hyperpolymath/projects/35.

**Draft — do not merge until** the repo secret `ADD_TO_PROJECT_PAT` exists (fine-grained PAT, Projects read+write). The workflow won't run on this PR (pull_request_target uses the base-branch copy).

Part of the estate boards epic (tracked on roadmap #35).