### PR TITLE
ci: remove redundant broken local trufflehog job from secret-scanner

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -13,14 +13,3 @@ jobs:
   scan:
     uses: hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@3e4bd4c93911750727e2e4c66dff859e00079da0
     secrets: inherit
-  trufflehog:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          fetch-depth: 0
-      - name: TruffleHog Secret Scan
-        uses: trufflesecurity/trufflehog@main
-        with:
-          extra_args: --only-verified --fail


### PR DESCRIPTION
## Problem

`secret-scanner.yml` carried a local `trufflehog:` job that was both redundant and broken:

- **Redundant** — the reusable `scan` job already runs `scan / trufflehog`.
- **Unpinned action** — `trufflesecurity/trufflehog@main` fails the governance *workflow security linter* (SHA-pinned actions required).
- **Duplicate flag** — `extra_args: --only-verified --fail` repeats the `--fail` the action injects itself, producing the runtime error `flag 'fail' cannot be repeated`.

## Fix

Delete the redundant local `trufflehog:` job. Secret scanning is fully retained via the pinned reusable `scan` job (`secret-scanner-reusable.yml@3e4bd4c`), which runs trufflehog, gitleaks, and the rust/shell secret scanners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
