### PR TITLE
ci: SHA-pin actions/add-to-project (fix roadmap auto-add startup_failure)

### DIFF
--- a/.github/workflows/add-to-roadmap.yml
+++ b/.github/workflows/add-to-roadmap.yml
@@ -13,7 +13,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/users/hyperpolymath/projects/35
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## What

SHA-pin `actions/add-to-project` in `.github/workflows/add-to-roadmap.yml`.

## Why

The roadmap-automation workflow (added in the board-automation pilot) referenced
`actions/add-to-project@v1.0.2` — a **tag**. This repo enforces
`sha_pinning_required=true` on Actions, so the tag ref produced a
`startup_failure`: the workflow never ran, and new issues/PRs were **not** being
added to roadmap project #35. Confirmed via a throwaway test issue
(hypatia#477) whose run failed at startup while sibling SHA-pinned workflows
succeeded.

Pinned to the `v1.0.2` commit `244f685bbc3b7adfa8466e08b698b5577571133e`
(comment retains the human-readable version). This is the only change needed to
make the pilot loop live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
