### PR TITLE
compiler: lower polymorphic len() to wasm (string + array length)

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1002,14 +1002,24 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
         in
         Ok (ctx_with_heap, code)
 
-      | ExprVar id when id.name = "string_length" && List.length args = 1 ->
+      | ExprVar id when (id.name = "string_length" || id.name = "len")
+                        && List.length args = 1 ->
         (* STDLIB-04e (#332) wasm-backend lowering. AS string layout is
            `[len: i32][bytes...]` at the pointer the arg evaluates to —
            reading the length is one i32.load at offset 0. The interp
            binding (lib/interp.ml) was wired in #362; this handler is
            the codegen sibling so tests/codegen/*.affine fixtures that
            call string_length (env_at / arg_at / env_count_and_at) can
-           compile end-to-end. *)
+           compile end-to-end.
+
+           `len` (the polymorphic length, issue #135) lowers identically:
+           AS arrays share the same `[len: i32][elems...]` header (the
+           list-concat handler above relies on exactly this), so reading
+           length is the same single i32.load whether `len` is applied to a
+           String or an array. Sharing the arm unblocks the stdlib string
+           layer (starts_with/ends_with/substring/split/join, which call
+           `len` on both strings and arrays) for the wasm backend — the
+           string-wall slice-8 residual flagged in the migration ledger. *)
         let* (ctx_with_arg, arg_code) = gen_expr ctx (List.hd args) in
         Ok (ctx_with_arg, arg_code @ [I32Load (2, 0)])
 


### PR DESCRIPTION
## Lower polymorphic `len()` to wasm (string + array length)

A string-wall residual found while verifying the migration corpus is actually unblocked: **`len()` did not lower to wasm** (`Codegen.UnboundVariable "len"`) — only `string_length` did.

AffineScript arrays and strings share the same `[len: i32][payload…]` header (the list-concat handler already relies on this), so `len()` is the **same single `i32.load` at offset 0** whether its argument is a `String` or an array. Merged into the existing `string_length` arm.

This unblocks the **stdlib string layer** on the wasm backend (`starts_with`/`ends_with`/`substring`/`split`/`join`/`pad_*` all call `len()` on strings; `join` also on arrays), which the corpus's `String.length` pattern (30 files) needs.

**Verified:** `len("abcd")`=4 and `len([10,20,30])`=3 lower and run; full `run_codegen_wasm_tests.sh` green (no regressions).

**Separately noted (not fixed here):** string `==`/`!=` still lower to *pointer* comparison, not value comparison (`string_sub(...) == "ab"` is wrongly `0`) — a #555-class interp-vs-wasm divergence, tracked for a follow-up slice. It only affects string-logic kernels; integer-brain extraction (strings kept host-side) is unaffected.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_