### PR TITLE
migration: 7 integer-brain kernels from string-gated idaptik modules

### DIFF
--- a/proposals/idaptik/migrated/Drone/Drone.affine
+++ b/proposals/idaptik/migrated/Drone/Drone.affine
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Drone -- the aerial-drone behaviour co-processor, the pure-integer core
+// re-decomposed from src/app/enemies/Drone.res (an 859-LOC enemy state machine).
+// Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), the JS host keeps the mutable drone
+// record, the string id, the option<float> lastKnownPlayerX, the Pixi container
+// /graphics, the async co-processor promise, every Math.random jitter, the actual
+// float positions, and all state-name / variant-name strings (stateToString,
+// variantToString). AffineScript owns the deterministic numeric brain: the
+// variant/state ordinal encodings, the per-variant stat table, the detection
+// classifier, the battery thresholds, and every alert/suspicion/distance-driven
+// STATE TRANSITION decision the ReScript updateState makes.
+//
+// The ReScript original entangles each decision with in-place mutation of timers
+// and positions (which stay host-side senses). We extract only the decisions:
+// "given the current state ordinal, variant ordinal, alert level, detection class
+// and the relevant scaled thresholds, what is the next state ordinal / boolean?"
+//
+//## Float boundary: every 0.0..1.0 / px float crosses in MILLI-UNITS (x1000)
+// battery 0.0..1.0 -> 0..1000; suspicion/proximity 0.0..1.0 -> 0..1000;
+// drain/charge rates per-second -> x1000; distances in px -> x1000; the JS host
+// passes round(value * 1000). Integer-valued floats (speed 60/100/35, detection
+// radius 120/80/100, noise radius 100/180/80) cross as plain Int (no scaling).
+// Arithmetic matches the ReScript exactly under this scaling.
+//
+//## Variant ordinal encoding (header contract for the JS host)
+//   code  variant     code  variant
+//     0   Recon         2   EMP_Drone
+//     1   Pursuit
+//
+//## State ordinal encoding (header contract for the JS host)
+//   code  state          code  state          code  state
+//     0   Patrolling       5   Charging        10   Repairing
+//     1   Hovering         6   Jammed          11   Reviving
+//     2   Tracking         7   Disabled        12   OpeningDoor
+//     3   Spotlighting     8   Delivering
+//     4   Returning        9   Rescuing
+// The constructor order of droneState IS the integer; the encoding is lossless
+// (thirteen distinct states <-> thirteen distinct codes). An ordinal outside the
+// band is not a state: predicates report safely and decoders return the
+// out-of-band sentinel -1, never an in-band code (no in-band collision).
+//
+//## Detection-class encoding (the detectionResult variant, payload dropped)
+//   0 NotDetected   1 InDetectionZone   2 SpotlightLock
+// The InDetectionZone proximity payload crosses separately as proximity_milli.
+
+// ---------------------------------------------------------------------------
+// Band canonicalisers (validity-preserving: identity on band, -1 off it)
+//
+// Both bands are CONTIGUOUS (variant 0..2, state 0..12), so the canonicaliser is
+// the identity on the band -- no enum round-trip is needed (it would be the
+// identity, the same flat shape DeviceType.affine uses). Out-of-band input is
+// mapped to the out-of-band sentinel -1 via an explicit `if valid {..} else {-1}`
+// guard, NEVER onto an in-band code, so no in-band collision is ever introduced
+// (this is a sentinel, not a clamp). echo-boundary certifies the bands injective.
+// ---------------------------------------------------------------------------
+
+//## Whether an ordinal names a defined variant. 1 = valid 0..2, 0 = out of band.
+pub fn is_valid_variant(code: Int) -> Int {
+  if code < 0 { return 0; }
+  if code > 2 { return 0; }
+  1
+}
+
+//## Variant ordinal (validity-preserving canonicaliser): identity on 0..2, else -1.
+pub fn variant_value(code: Int) -> Int {
+  if is_valid_variant(code) == 1 { code } else { -1 }
+}
+
+//## Whether an ordinal names a defined state. 1 = valid 0..12, 0 = out of band.
+pub fn is_valid_state(code: Int) -> Int {
+  if code < 0 { return 0; }
+  if code > 12 { return 0; }
+  1
+}
+
+//## State ordinal (validity-preserving canonicaliser): identity on 0..12, else -1.
+pub fn state_value(code: Int) -> Int {
+  if is_valid_state(code) == 1 { code } else { -1 }
+}
+
+// ---------------------------------------------------------------------------
+// Per-variant stat table  (the `switch variant` in Drone.make)
+//   Recon     speed 60   detRadius 120   noise 100   drain 0.008  (8 milli)
+//   Pursuit   speed 100  detRadius 80    noise 180   drain 0.015  (15 milli)
+//   EMP_Drone speed 35   detRadius 100   noise 80    drain 0.012  (12 milli)
+// Out-of-band variant -> -1 sentinel (host must pass a valid 0..2 variant).
+// ---------------------------------------------------------------------------
+
+//## Base movement speed in px/s (integer-valued float, no scaling).
+pub fn variant_speed(code: Int) -> Int {
+  let v = variant_value(code);
+  if v == 0 { return 60; }
+  if v == 1 { return 100; }
+  if v == 2 { return 35; }
+  -1
+}
+
+//## Ground detection-circle radius in px (integer-valued float, no scaling).
+pub fn variant_detection_radius(code: Int) -> Int {
+  let v = variant_value(code);
+  if v == 0 { return 120; }
+  if v == 1 { return 80; }
+  if v == 2 { return 100; }
+  -1
+}
+
+//## Noise radius in px -- how far the player can "hear" the drone.
+pub fn variant_noise_radius(code: Int) -> Int {
+  let v = variant_value(code);
+  if v == 0 { return 100; }
+  if v == 1 { return 180; }
+  if v == 2 { return 80; }
+  -1
+}
+
+//## Battery drain rate per second, in MILLI-units (0.008 -> 8 etc.).
+pub fn variant_drain_milli(code: Int) -> Int {
+  let v = variant_value(code);
+  if v == 0 { return 8; }
+  if v == 1 { return 15; }
+  if v == 2 { return 12; }
+  -1
+}
+
+// ---------------------------------------------------------------------------
+// Detection  (the detectPlayer classifier, floats in milli-units)
+// ---------------------------------------------------------------------------
+
+//## Can this drone detect at all? (detectPlayer early-exit)
+// NotDetected unconditionally while Disabled(7), Charging(5) or Jammed(6).
+// 1 = detection runs, 0 = blind this frame. Out-of-band state -> 0 (safe blind).
+pub fn can_detect(state: Int) -> Int {
+  let s = state_value(state);
+  if s == 7 { return 0; }
+  if s == 5 { return 0; }
+  if s == 6 { return 0; }
+  if s < 0 { return 0; }
+  1
+}
+
+//## Effective detection radius after crouch scaling, in MILLI-units.
+// detectPlayer: crouching shrinks the radius to *0.6 (harder to spot from above).
+// Input detection_radius is plain px; output is px*1000 (milli) so the proximity
+// division below stays exact. crouching is a 1/0 flag.
+pub fn effective_radius_milli(detection_radius: Int, crouching: Int) -> Int {
+  if crouching == 0 { return detection_radius * 1000; }
+  detection_radius * 600
+}
+
+//## Proximity 0..1000 within the detection circle (detectPlayer).
+// ReScript: proximity = 1.0 - groundDist / effectiveRadius. In milli-units, with
+// ground_dist and eff_radius BOTH already in milli, this is 1000 - dist*1000/radius.
+// Clamped to [0,1000]; a non-positive radius yields 0 (degenerate, host guards it).
+pub fn proximity_milli(ground_dist_milli: Int, eff_radius_milli: Int) -> Int {
+  if eff_radius_milli <= 0 { return 0; }
+  if ground_dist_milli >= eff_radius_milli { return 0; }
+  let p = 1000 - (ground_dist_milli * 1000) / eff_radius_milli;
+  if p < 0 { return 0; }
+  if p > 1000 { return 1000; }
+  p
+}
+
+//## Detection classifier (detectPlayer result -> 0/1/2).
+// Given the frame's gating, the scaled ground distance, the crouch-scaled radius
+// (milli), whether the spotlight is on (1/0), classify:
+//   0 NotDetected   1 InDetectionZone   2 SpotlightLock
+// SpotlightLock requires spotlightActive AND proximity > 0.3 (300 milli); else
+// inside the circle it is InDetectionZone; outside, NotDetected.
+pub fn detection_class(
+  state: Int,
+  ground_dist_milli: Int,
+  eff_radius_milli: Int,
+  spotlight_active: Int
+) -> Int {
+  if can_detect(state) == 0 { return 0; }
+  if eff_radius_milli <= 0 { return 0; }
+  if ground_dist_milli >= eff_radius_milli { return 0; }
+  let prox = proximity_milli(ground_dist_milli, eff_radius_milli);
+  if spotlight_active == 0 { return 1; }
+  if prox > 300 { return 2; }
+  1
+}
+
+// ---------------------------------------------------------------------------
+// Battery  (updateState's battery accounting, milli-units)
+//   battery 0.0..1.0 -> 0..1000;  lowBatteryThreshold 0.15 -> 150
+//   charge "full" 0.95 -> 950
+// ---------------------------------------------------------------------------
+
+//## Is the battery dead? (battery <= 0 after drain). 1 = dead -> Disabled.
+pub fn battery_dead(battery_milli: Int) -> Int {
+  if battery_milli <= 0 { return 1; }
+  0
+}
+
+//## Is the battery low enough to return-to-base? (battery <= 0.15 -> 150 milli).
+// Drone.lowBatteryThreshold is fixed at 0.15; passed as threshold_milli for the
+// host to override. 1 = should switch to Returning.
+pub fn battery_low(battery_milli: Int, threshold_milli: Int) -> Int {
+  if battery_milli <= threshold_milli { return 1; }
+  0
+}
+
+//## Is the battery recharged enough to resume patrol? (battery >= 0.95 -> 950).
+pub fn charge_complete(battery_milli: Int) -> Int {
+  if battery_milli >= 950 { return 1; }
+  0
+}
+
+// ---------------------------------------------------------------------------
+// State-machine transitions  (the heart of updateState, decisions only)
+// Each function answers "what is the next state ordinal?" for one decision
+// point; the host applies the timer/position mutations (senses) around it.
+// ---------------------------------------------------------------------------
+
+//## Movement arrival test (moveToward: arrived when |dx| < 5px). dist in milli.
+pub fn arrived(dist_milli: Int) -> Int {
+  if dist_milli < 5000 { return 1; }
+  0
+}
+
+//## Patrolling: a strong sighting escalates. (updateState Patrolling arm.)
+// On InDetectionZone with proximity > 0.4 (400 milli): high alert (alertLevel>=3)
+// OR a Pursuit drone goes straight to Tracking(2); otherwise to Hovering(1).
+// No qualifying sighting -> stay Patrolling(0).
+// detection_class: 0 NotDetected, 1 InDetectionZone, 2 SpotlightLock.
+pub fn patrol_next(
+  variant: Int,
+  alert_level: Int,
+  detection_class: Int,
+  proximity_milli: Int
+) -> Int {
+  if detection_class != 1 { return 0; }
+  if proximity_milli <= 400 { return 0; }
+  if alert_level >= 3 { return 2; }
+  if variant_value(variant) == 1 { return 2; }
+  1
+}
+
+//## Hovering: observe; escalate on sustained suspicion. (updateState Hovering.)
+// SpotlightLock(2) -> Tracking(2) immediately. InDetectionZone with proximity>0.3
+// (300 milli) AND the accumulated suspicion now exceeds 0.7 (700 milli) -> Tracking.
+// If the observation window expired (hover_timer >= 5s -> 5000 milli) with no
+// qualifying sighting -> back to Patrolling(0). Otherwise stay Hovering(1).
+// suspicion_milli is the post-accumulation suspicion the host has already updated.
+pub fn hover_next(
+  detection_class: Int,
+  proximity_milli: Int,
+  suspicion_milli: Int,
+  hover_timer_milli: Int
+) -> Int {
+  if detection_class == 2 { return 2; }
+  if detection_class == 1 {
+    if proximity_milli > 300 {
+      if suspicion_milli > 700 { return 2; }
+      return 1;
+    }
+  }
+  if hover_timer_milli >= 5000 { return 0; }
+  1
+}
+
+//## Tracking: follow; branch to Spotlighting/Delivering or lose visual.
+// (updateState Tracking arm, decision core.) With a live sighting (class 1 or 2):
+//   Pursuit(1) at alertLevel>=2 -> Spotlighting(3);
+//   EMP_Drone(2) with payload available and within 40px (40000 milli) -> Delivering(8);
+//   otherwise stay Tracking(2).
+// With NotDetected(0): the search window decides -- hover_timer >= 8s (8000 milli)
+//   gives up to Patrolling(0); otherwise stay Tracking(2).
+// has_payload is 1/0; dist_milli is |player - drone| in milli.
+pub fn tracking_next(
+  variant: Int,
+  alert_level: Int,
+  detection_class: Int,
+  has_payload: Int,
+  dist_milli: Int,
+  hover_timer_milli: Int
+) -> Int {
+  if detection_class == 0 {
+    if hover_timer_milli >= 8000 { return 0; }
+    return 2;
+  }
+  let v = variant_value(variant);
+  if v == 1 {
+    if alert_level >= 2 { return 3; }
+  }
+  if v == 2 {
+    if has_payload == 1 {
+      if dist_milli < 40000 { return 8; }
+    }
+  }
+  2
+}
+
+//## Spotlighting: stay locked or drop back. (updateState Spotlighting arm.)
+// With a live sighting (class 1 or 2): stay Spotlighting(3). With NotDetected(0):
+// the spotlight fades; once intensity reaches 0 (intensity_milli <= 0) the lock
+// drops to Tracking(2); otherwise hold Spotlighting(3) while it fades.
+// intensity_milli is the post-decay spotlight intensity the host has updated.
+pub fn spotlight_next(detection_class: Int, intensity_milli: Int) -> Int {
+  if detection_class == 0 {
+    if intensity_milli <= 0 { return 2; }
+    return 3;
+  }
+  3
+}
+
+//## Delivering: EMP dive completes after 1.5s. (updateState Delivering arm.)
+// timer_milli is the post-increment empDeliveryTimer in milli; once it reaches
+// 1.5s (1500 milli) the payload deploys and the drone returns -> Returning(4);
+// otherwise keep Delivering(8).
+pub fn delivering_next(timer_milli: Int) -> Int {
+  if timer_milli >= 1500 { return 4; }
+  8
+}
+
+//## Returning: dock when arrived at the charging pad. (updateState Returning.)
+// arrived is 1/0 from arrived(dist). On arrival -> Charging(5); else Returning(4).
+pub fn returning_next(arrived: Int) -> Int {
+  if arrived == 1 { return 5; }
+  4
+}
+
+//## Charging: resume patrol once recharged. (updateState Charging arm.)
+// charge_done is 1/0 from charge_complete(battery). Done -> Patrolling(0); else
+// keep Charging(5).
+pub fn charging_next(charge_done: Int) -> Int {
+  if charge_done == 1 { return 0; }
+  5
+}
+
+//## Helper task (Rescuing/Repairing/Reviving/OpeningDoor): finish on timer.
+// (updateState helper-states arm.) has_target is 1/0; with no target the task is
+// aborted -> Patrolling(0). With a target, once arrived AND the countdown timer is
+// spent (task_timer_milli <= 0) the task completes -> Patrolling(0). Otherwise the
+// drone stays in its current helper state (returned unchanged as current_state).
+pub fn helper_task_next(
+  current_state: Int,
+  has_target: Int,
+  arrived: Int,
+  task_timer_milli: Int
+) -> Int {
+  if has_target == 0 { return 0; }
+  if arrived == 1 {
+    if task_timer_milli <= 0 { return 0; }
+  }
+  state_value(current_state)
+}
+
+// ---------------------------------------------------------------------------
+// Interactions & orders  (applyEMP, hackTick, helper orders, distraction)
+// ---------------------------------------------------------------------------
+
+//## applyEMP: jam unless already disabled. Returns the resulting state ordinal:
+// Jammed(6) if it took effect, else the unchanged state (Disabled stays Disabled).
+// The boolean "did it take" is (next != current): host reads that as the .res bool.
+pub fn apply_emp_next(state: Int) -> Int {
+  let s = state_value(state);
+  if s == 7 { return 7; }
+  6
+}
+
+//## hackTick: does this tick complete the hack? (hackProgress >= 1.0 -> 1000 milli).
+// hackProgress accrues dt*0.08 per tick (~12.5s). progress_milli is the
+// post-increment progress. 1 = hack completes this tick (-> Disabled), 0 = ongoing.
+pub fn hack_complete(progress_milli: Int) -> Int {
+  if progress_milli >= 1000 { return 1; }
+  0
+}
+
+//## Audible-to-player gate (isAudibleTo). The state gate plus the distance test.
+// Silent while Disabled(7) or Charging(5). Otherwise audible iff |player-drone| <
+// noiseRadius. dist_milli and noise_radius_milli are in milli. 1 = player hears it.
+pub fn is_audible(state: Int, dist_milli: Int, noise_radius_milli: Int) -> Int {
+  let s = state_value(state);
+  if s == 7 { return 0; }
+  if s == 5 { return 0; }
+  if s < 0 { return 0; }
+  if dist_milli < noise_radius_milli { return 1; }
+  0
+}
+
+//## Helper-order eligibility & target state (orderRescue/Repair/Revive/OpenDoor).
+// task_kind picks the target helper state:
+//   0 -> Rescuing(9)   1 -> Repairing(10)   2 -> Reviving(11)   3 -> OpeningDoor(12)
+// Eligibility reproduces the ReScript guard EXACTLY, operator precedence included:
+//     variant == EMP_Drone && state == Patrolling  ||  state == Hovering
+// In ReScript `&&` binds tighter than `||`, so this parses as
+//     (variant == EMP_Drone && state == Patrolling) || (state == Hovering)
+// i.e. ANY variant in Hovering(1) is eligible; an EMP_Drone(2) is also eligible in
+// Patrolling(0). (This faithfully mirrors the source, latent precedence quirk and
+// all.) Eligible -> the task's target state; ineligible OR bad task_kind -> -1.
+pub fn helper_order_state(variant: Int, state: Int, task_kind: Int) -> Int {
+  let v = variant_value(variant);
+  let s = state_value(state);
+  // eligibility per the .res precedence: (v==2 && s==0) || (s==1)
+  let eligible_emp_patrol = if v == 2 { if s == 0 { 1 } else { 0 } } else { 0 };
+  let eligible_hover = if s == 1 { 1 } else { 0 };
+  if eligible_emp_patrol == 0 {
+    if eligible_hover == 0 { return -1; }
+  }
+  if task_kind == 0 { return 9; }
+  if task_kind == 1 { return 10; }
+  if task_kind == 2 { return 11; }
+  if task_kind == 3 { return 12; }
+  -1
+}
+
+//## respondToDistraction: pull to investigate. Eligible iff the distraction is in
+// range (dist < distractionRange) AND the drone is Patrolling(0) or Hovering(1).
+// Eligible -> Tracking(2); otherwise the unchanged state. dist/range in milli.
+pub fn distraction_next(state: Int, dist_milli: Int, range_milli: Int) -> Int {
+  let s = state_value(state);
+  if dist_milli >= range_milli { return s; }
+  if s == 0 { return 2; }
+  if s == 1 { return 2; }
+  s
+}
+
+// ---------------------------------------------------------------------------
+// Queries  (isActive, isHelperBusy, hasEMPPayload)
+// ---------------------------------------------------------------------------
+
+//## isActive: not Disabled(7) and not Charging(5). 1 = active, 0 = inert.
+// Out-of-band state -> 0 (treated inert).
+pub fn is_active(state: Int) -> Int {
+  let s = state_value(state);
+  if s < 0 { return 0; }
+  if s == 7 { return 0; }
+  if s == 5 { return 0; }
+  1
+}
+
+//## isHelperBusy: in a helper task state (Rescuing..OpeningDoor = 9..12).
+pub fn is_helper_busy(state: Int) -> Int {
+  let s = state_value(state);
+  if s < 9 { return 0; }
+  if s > 12 { return 0; }
+  1
+}
+
+//## hasEMPPayload: an EMP_Drone(2) that still holds its single-use payload.
+// payload_available is 1/0. 1 only when variant is EMP_Drone AND payload remains.
+pub fn has_emp_payload(variant: Int, payload_available: Int) -> Int {
+  if variant_value(variant) != 2 { return 0; }
+  if payload_available == 1 { return 1; }
+  0
+}

--- a/proposals/idaptik/migrated/Drone/drone.config.mjs
+++ b/proposals/idaptik/migrated/Drone/drone.config.mjs
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Drone.affine (idaptik aerial-drone behaviour brain;
+// scalar i32 ABI). Every oracle below is an INDEPENDENT JS reimplementation
+// derived from src/app/enemies/Drone.res semantics -- NOT a copy of the .affine
+// logic -- so the differential sweep is a genuine cross-check. Floats in the .res
+// cross in milli-units (x1000); the oracles work in the same scaled integers.
+//
+// State ordinals: 0 Patrolling 1 Hovering 2 Tracking 3 Spotlighting 4 Returning
+//   5 Charging 6 Jammed 7 Disabled 8 Delivering 9 Rescuing 10 Repairing
+//   11 Reviving 12 OpeningDoor.  Variant ordinals: 0 Recon 1 Pursuit 2 EMP_Drone.
+//   Detection class: 0 NotDetected 1 InDetectionZone 2 SpotlightLock.
+
+// --- shared oracle helpers (re-derived from Drone.res, kept independent) ---
+
+const validVariant = (c) => c >= 0 && c <= 2;
+const validState = (c) => c >= 0 && c <= 12;
+// canonicalisers: identity on band, -1 sentinel off it (Drone.res variant/state).
+const vv = (c) => (validVariant(c) ? c : -1);
+const sv = (c) => (validState(c) ? c : -1);
+
+export default {
+  affine: "Drone.affine",
+  cases: [
+    // -- band validity & canonicalisation --
+    {
+      name: "is_valid_variant over [-3..6]",
+      export: "is_valid_variant",
+      args: [[-3, 6]],
+      oracle: (c) => (validVariant(c) ? 1 : 0),
+    },
+    {
+      name: "variant_value over [-3..6]",
+      export: "variant_value",
+      args: [[-3, 6]],
+      oracle: (c) => vv(c),
+    },
+    {
+      name: "is_valid_state over [-3..16]",
+      export: "is_valid_state",
+      args: [[-3, 16]],
+      oracle: (c) => (validState(c) ? 1 : 0),
+    },
+    {
+      name: "state_value over [-3..16]",
+      export: "state_value",
+      args: [[-3, 16]],
+      oracle: (c) => sv(c),
+    },
+
+    // -- per-variant stat table (Drone.make switch; -1 for bad variant) --
+    {
+      name: "variant_speed over [-1..4]",
+      export: "variant_speed",
+      args: [[-1, 4]],
+      // Recon 60, Pursuit 100, EMP 35; else -1.
+      oracle: (c) => (c === 0 ? 60 : c === 1 ? 100 : c === 2 ? 35 : -1),
+    },
+    {
+      name: "variant_detection_radius over [-1..4]",
+      export: "variant_detection_radius",
+      args: [[-1, 4]],
+      oracle: (c) => (c === 0 ? 120 : c === 1 ? 80 : c === 2 ? 100 : -1),
+    },
+    {
+      name: "variant_noise_radius over [-1..4]",
+      export: "variant_noise_radius",
+      args: [[-1, 4]],
+      oracle: (c) => (c === 0 ? 100 : c === 1 ? 180 : c === 2 ? 80 : -1),
+    },
+    {
+      name: "variant_drain_milli over [-1..4]",
+      export: "variant_drain_milli",
+      args: [[-1, 4]],
+      // 0.008/0.015/0.012 -> 8/15/12 milli; else -1.
+      oracle: (c) => (c === 0 ? 8 : c === 1 ? 15 : c === 2 ? 12 : -1),
+    },
+
+    // -- detection --
+    {
+      name: "can_detect over states [-1..13]",
+      export: "can_detect",
+      args: [[-1, 13]],
+      // NotDetected while Disabled(7)/Charging(5)/Jammed(6) or out-of-band; else 1.
+      oracle: (s) => {
+        if (!validState(s)) return 0;
+        if (s === 7 || s === 5 || s === 6) return 0;
+        return 1;
+      },
+    },
+    {
+      name: "effective_radius_milli(radius, crouch)",
+      export: "effective_radius_milli",
+      args: [{ values: [0, 80, 100, 120, 250] }, { values: [0, 1] }],
+      // crouch shrinks radius to 0.6; output in milli (px*1000 or px*600).
+      oracle: (r, crouch) => (crouch === 0 ? r * 1000 : r * 600),
+    },
+    {
+      name: "proximity_milli(dist, radius) -- 1 - dist/radius in milli",
+      export: "proximity_milli",
+      args: [
+        { values: [0, 1000, 5000, 40000, 80000, 119000, 120000, 200000] },
+        { values: [0, 48000, 72000, 80000, 120000] },
+      ],
+      oracle: (dist, radius) => {
+        if (radius <= 0) return 0;
+        if (dist >= radius) return 0;
+        let p = 1000 - Math.trunc((dist * 1000) / radius);
+        if (p < 0) return 0;
+        if (p > 1000) return 1000;
+        return p;
+      },
+    },
+    {
+      name: "detection_class(state, dist, radius, spotlight)",
+      export: "detection_class",
+      args: [
+        { values: [0, 1, 2, 5, 6, 7, 13] }, // states incl. blind & out-of-band
+        { values: [0, 5000, 40000, 80000, 119000, 120000] },
+        { values: [0, 120000] },
+        { values: [0, 1] },
+      ],
+      oracle: (s, dist, radius, spot) => {
+        // gate
+        if (!validState(s)) return 0;
+        if (s === 7 || s === 5 || s === 6) return 0;
+        if (radius <= 0) return 0;
+        if (dist >= radius) return 0;
+        let prox = 1000 - Math.trunc((dist * 1000) / radius);
+        if (prox < 0) prox = 0;
+        if (prox > 1000) prox = 1000;
+        if (spot === 0) return 1;
+        return prox > 300 ? 2 : 1;
+      },
+    },
+
+    // -- battery --
+    {
+      name: "battery_dead over [-50..1050] step via values",
+      export: "battery_dead",
+      args: [{ values: [-50, -1, 0, 1, 150, 500, 1000] }],
+      oracle: (b) => (b <= 0 ? 1 : 0),
+    },
+    {
+      name: "battery_low(battery, threshold=150) sweep battery",
+      export: "battery_low",
+      args: [{ values: [0, 100, 149, 150, 151, 500, 1000] }, 150],
+      oracle: (b, t) => (b <= t ? 1 : 0),
+    },
+    {
+      name: "battery_low varying threshold too",
+      export: "battery_low",
+      args: [{ values: [0, 200, 300] }, { values: [150, 200, 250] }],
+      oracle: (b, t) => (b <= t ? 1 : 0),
+    },
+    {
+      name: "charge_complete (>=950)",
+      export: "charge_complete",
+      args: [{ values: [0, 500, 949, 950, 951, 1000] }],
+      oracle: (b) => (b >= 950 ? 1 : 0),
+    },
+
+    // -- transitions --
+    {
+      name: "arrived (|dx| < 5000 milli = 5px)",
+      export: "arrived",
+      args: [{ values: [0, 4999, 5000, 5001, 50000] }],
+      oracle: (d) => (d < 5000 ? 1 : 0),
+    },
+    {
+      name: "patrol_next(variant, alert, class, proximity)",
+      export: "patrol_next",
+      args: [
+        { values: [0, 1, 2, 7] }, // variant incl. out-of-band 7
+        { values: [0, 2, 3, 5] }, // alert level
+        { values: [0, 1, 2] }, // detection class
+        { values: [0, 400, 401, 1000] }, // proximity milli
+      ],
+      oracle: (variant, alert, cls, prox) => {
+        // Patrolling arm: only InDetectionZone(1) with proximity>0.4 escalates.
+        if (cls !== 1) return 0;
+        if (prox <= 400) return 0;
+        if (alert >= 3) return 2; // -> Tracking
+        if (vv(variant) === 1) return 2; // Pursuit -> Tracking
+        return 1; // -> Hovering
+      },
+    },
+    {
+      name: "hover_next(class, proximity, suspicion, hoverTimer)",
+      export: "hover_next",
+      args: [
+        { values: [0, 1, 2] }, // class
+        { values: [0, 300, 301, 1000] }, // proximity milli
+        { values: [0, 700, 701, 1000] }, // suspicion milli
+        { values: [0, 4999, 5000, 6000] }, // hover timer milli
+      ],
+      oracle: (cls, prox, susp, timer) => {
+        if (cls === 2) return 2; // SpotlightLock -> Tracking
+        if (cls === 1) {
+          if (prox > 300) {
+            if (susp > 700) return 2; // -> Tracking
+            return 1; // stay Hovering
+          }
+        }
+        if (timer >= 5000) return 0; // window expired -> Patrolling
+        return 1;
+      },
+    },
+    {
+      name: "tracking_next(variant, alert, class, payload, dist, timer)",
+      export: "tracking_next",
+      args: [
+        { values: [0, 1, 2] }, // variant
+        { values: [1, 2] }, // alert
+        { values: [0, 1, 2] }, // class
+        { values: [0, 1] }, // payload
+        { values: [39999, 40000] }, // dist milli
+        { values: [0, 8000] }, // timer milli
+      ],
+      oracle: (variant, alert, cls, payload, dist, timer) => {
+        if (cls === 0) {
+          if (timer >= 8000) return 0; // lost visual long enough -> Patrolling
+          return 2; // keep Tracking
+        }
+        const v = vv(variant);
+        if (v === 1) {
+          if (alert >= 2) return 3; // Pursuit spotlight -> Spotlighting
+        }
+        if (v === 2) {
+          if (payload === 1) {
+            if (dist < 40000) return 8; // EMP deliver -> Delivering
+          }
+        }
+        return 2; // stay Tracking
+      },
+    },
+    {
+      name: "spotlight_next(class, intensity)",
+      export: "spotlight_next",
+      args: [{ values: [0, 1, 2] }, { values: [-10, 0, 1, 1000] }],
+      oracle: (cls, inten) => {
+        if (cls === 0) {
+          if (inten <= 0) return 2; // faded -> Tracking
+          return 3; // still fading, hold Spotlighting
+        }
+        return 3; // live sighting, stay Spotlighting
+      },
+    },
+    {
+      name: "delivering_next(timer) -- complete at 1500 milli (1.5s)",
+      export: "delivering_next",
+      args: [{ values: [0, 1499, 1500, 1501, 3000] }],
+      oracle: (t) => (t >= 1500 ? 4 : 8),
+    },
+    {
+      name: "returning_next(arrived)",
+      export: "returning_next",
+      args: [{ values: [0, 1] }],
+      oracle: (a) => (a === 1 ? 5 : 4),
+    },
+    {
+      name: "charging_next(charge_done)",
+      export: "charging_next",
+      args: [{ values: [0, 1] }],
+      oracle: (d) => (d === 1 ? 0 : 5),
+    },
+    {
+      name: "helper_task_next(state, hasTarget, arrived, timer)",
+      export: "helper_task_next",
+      args: [
+        { values: [9, 10, 11, 12, 0, 13] }, // current state incl. out-of-band 13
+        { values: [0, 1] }, // has target
+        { values: [0, 1] }, // arrived
+        { values: [-5, 0, 5] }, // task timer milli
+      ],
+      oracle: (state, hasTarget, arrived, timer) => {
+        if (hasTarget === 0) return 0; // abort -> Patrolling
+        if (arrived === 1) {
+          if (timer <= 0) return 0; // task complete -> Patrolling
+        }
+        return sv(state); // stay in current helper state (canonicalised)
+      },
+    },
+
+    // -- interactions & orders --
+    {
+      name: "apply_emp_next(state) -- Jammed(6) unless Disabled(7)",
+      export: "apply_emp_next",
+      args: [{ values: [0, 2, 5, 6, 7, 12] }],
+      oracle: (s) => (sv(s) === 7 ? 7 : 6),
+    },
+    {
+      name: "hack_complete(progress) -- >=1000 milli (1.0)",
+      export: "hack_complete",
+      args: [{ values: [0, 500, 999, 1000, 1001] }],
+      oracle: (p) => (p >= 1000 ? 1 : 0),
+    },
+    {
+      name: "is_audible(state, dist, noise)",
+      export: "is_audible",
+      args: [
+        { values: [0, 2, 5, 7, 13] }, // states incl. silent & out-of-band
+        { values: [0, 79999, 80000, 100000] }, // dist milli
+        { values: [80000, 100000] }, // noise milli
+      ],
+      oracle: (s, dist, noise) => {
+        const c = sv(s);
+        if (c === 7 || c === 5 || c < 0) return 0;
+        return dist < noise ? 1 : 0;
+      },
+    },
+    {
+      name: "helper_order_state(variant, state, task_kind) -- .res precedence",
+      export: "helper_order_state",
+      args: [
+        { values: [0, 1, 2, 7] }, // variant incl. out-of-band 7
+        { values: [0, 1, 2, 5, 13] }, // state incl. out-of-band 13
+        { values: [0, 1, 2, 3, 4] }, // task kind incl. out-of-band 4
+      ],
+      oracle: (variant, state, kind) => {
+        const v = vv(variant);
+        const s = sv(state);
+        // .res guard, operator precedence preserved:
+        //   (v==EMP_Drone(2) && s==Patrolling(0)) || s==Hovering(1)
+        const eligible = (v === 2 && s === 0) || s === 1;
+        if (!eligible) return -1;
+        if (kind === 0) return 9;
+        if (kind === 1) return 10;
+        if (kind === 2) return 11;
+        if (kind === 3) return 12;
+        return -1; // bad task_kind
+      },
+    },
+    {
+      name: "distraction_next(state, dist, range)",
+      export: "distraction_next",
+      args: [
+        { values: [0, 1, 2, 5, 13] }, // state incl. out-of-band 13
+        { values: [0, 49999, 50000] }, // dist milli
+        { values: [50000, 60000] }, // range milli
+      ],
+      oracle: (state, dist, range) => {
+        const s = sv(state);
+        if (dist >= range) return s; // out of range -> unchanged
+        if (s === 0 || s === 1) return 2; // Patrolling/Hovering -> Tracking
+        return s; // other states unchanged
+      },
+    },
+
+    // -- queries --
+    {
+      name: "is_active over states [-1..13]",
+      export: "is_active",
+      args: [[-1, 13]],
+      oracle: (s) => {
+        const c = sv(s);
+        if (c < 0) return 0;
+        if (c === 7 || c === 5) return 0; // Disabled/Charging inert
+        return 1;
+      },
+    },
+    {
+      name: "is_helper_busy over states [-1..14]",
+      export: "is_helper_busy",
+      args: [[-1, 14]],
+      oracle: (s) => {
+        const c = sv(s);
+        if (c < 9) return 0;
+        if (c > 12) return 0;
+        return 1;
+      },
+    },
+    {
+      name: "has_emp_payload(variant, available)",
+      export: "has_emp_payload",
+      args: [{ values: [0, 1, 2, 7] }, { values: [0, 1] }],
+      oracle: (variant, avail) => {
+        if (vv(variant) !== 2) return 0;
+        return avail === 1 ? 1 : 0;
+      },
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/FirewallDevice/FirewallDevice.affine
+++ b/proposals/idaptik/migrated/FirewallDevice/FirewallDevice.affine
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// FirewallDevice -- the ACL packet-filter decision co-processor, the pure
+// integer core extracted from src/app/devices/FirewallDevice.res (checkPacket,
+// matchesSubnet's port/proto predicates, the action accounting). Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; they pass
+// primitives across the wasm boundary"), the JS host keeps every rule STRING
+// (sourceSubnet / destSubnet CIDR text, protocol text, description), the
+// mutable counters (blockedAttempts / passedPackets / bypassed), and every Pixi
+// Text/Graphics call; AffineScript owns only the integer allow/deny/log decision
+// over the parsed rule fields.
+//
+// The ReScript original models the verdict as an `aclAction = Allow | Deny | Log`
+// variant and decides it inside checkPacket: a rule applies when source, dest,
+// port and protocol all match, where the port test is `rule.port == 0 ||
+// rule.port == port` and the protocol test is `rule.protocol == "ANY" ||
+// rule.protocol == protocol`; an unmatched packet falls through to a default
+// Deny; Allow/Log bump passedPackets and Deny bumps blockedAttempts. We
+// re-decompose that variant as the canonical 0..2 integer band the constructor
+// order already implies, and we lift the four match predicates and the
+// pass/block accounting into pure integer tests. The STRING comparisons stay on
+// the JS side -- which is where the subnet and protocol strings live anyway: the
+// host parses each rule's protocol text to an integer code and resolves each
+// CIDR subnet match to a 0/1 flag, then crosses the boundary with integers only.
+// No strings, no floats, no effects, and no mutation cross; the integers ARE the
+// firewall's decision.
+//
+//## Action encoding (the header contract for the JS host)
+//   code  action   render colour (stays host-side)
+//     0   Deny     0xF44336
+//     1   Allow    0x4CAF50
+//     2   Log      0xFFEB3B
+// The encoding is LOSSLESS: three distinct actions map to three distinct codes,
+// so the host round-trips action <-> code with no collision. A code outside
+// 0..2 is not an action: is_valid_action reports 0 and clamp_action returns the
+// out-of-band sentinel -1 -- never an in-band code, so no in-band collision is
+// introduced (this is a sentinel, not a clamp; assail stays clean).
+//
+//## Protocol encoding (host parses the rule/packet protocol strings)
+//   code  protocol        code  protocol
+//     0   TCP               2   ICMP
+//     1   UDP             255   ANY (the wildcard; matches every protocol)
+// The brain never sees protocol text. It needs only equality and the ANY
+// wildcard, exactly mirroring `rule.protocol == "ANY" || rule.protocol ==
+// protocol`. The host is free to assign 3.. to further named protocols; the only
+// reserved code is 255 = ANY (proto_any), matching the source's "ANY" literal.
+//
+//## Port convention (mirrors the source exactly)
+//   rule_port 0 is the wildcard ("ANY port"), matching every packet port; any
+//   other rule_port matches only the identical packet port. This is the source's
+//   `rule.port == 0 || rule.port == port` verbatim.
+
+//## The canonical action band, as the aclAction constructor order has it. Kept
+//## as named values so the verdict reads as one taxonomy, not magic numbers
+//## scattered across the exports. Deny is 0 because it is also the default
+//## (no-match) policy, so default_action and action_deny coincide by design.
+pub fn action_deny() -> Int { 0 }
+pub fn action_allow() -> Int { 1 }
+pub fn action_log() -> Int { 2 }
+
+// The number of canonical ACL actions in the taxonomy.
+pub fn action_count() -> Int { 3 }
+
+// The ANY-protocol wildcard code. A rule whose protocol parses to this matches
+// every packet protocol, mirroring the source's `rule.protocol == "ANY"`.
+pub fn proto_any() -> Int { 255 }
+
+//## Pure exports (pub fn over Int only)
+
+// Whether a host integer names a defined ACL action. 1 = valid (0..2), 0 = out
+// of band. The host round-trips its Allow/Deny/Log variant through this band.
+pub fn is_valid_action(code: Int) -> Int {
+  if code < 0 { return 0; }
+  if code > 2 { return 0; }
+  1
+}
+
+// Canonicalise a host action integer: identity on a valid 0..2 code, the
+// out-of-band sentinel -1 otherwise. -1 is not an in-band action code, so an
+// out-of-band input can never be confused with Deny/Allow/Log (this is a
+// sentinel, not a clamp; it never collapses garbage onto an in-band verdict).
+pub fn clamp_action(code: Int) -> Int {
+  if is_valid_action(code) == 1 { return code; }
+  -1
+}
+
+// The port predicate of checkPacket: `rule.port == 0 || rule.port == port`.
+// A rule_port of 0 is the wildcard and matches any packet port; otherwise the
+// ports must be identical. Returns 1 on match, 0 on miss.
+pub fn port_matches(rule_port: Int, pkt_port: Int) -> Int {
+  if rule_port == 0 { return 1; }
+  if rule_port == pkt_port { return 1; }
+  0
+}
+
+// The protocol predicate of checkPacket: `rule.protocol == "ANY" ||
+// rule.protocol == protocol`, with the strings already parsed to integer codes
+// by the host. A rule_proto of 255 (ANY) is the wildcard and matches every
+// packet protocol; otherwise the codes must be identical. Returns 1/0.
+pub fn protocol_matches(rule_proto: Int, pkt_proto: Int) -> Int {
+  if rule_proto == 255 { return 1; }
+  if rule_proto == pkt_proto { return 1; }
+  0
+}
+
+// Whether a rule applies to a packet: the conjunction `sourceMatch && destMatch
+// && portMatch && protoMatch` from checkPacket. The host supplies each leg as a
+// 0/1 flag -- source/dest from its CIDR subnet parsing (the string sense), port
+// and proto ideally from port_matches / protocol_matches above. Re-decomposed as
+// guarded returns: the rule fails the moment any leg is not 1, mirroring the
+// short-circuit AND. Returns 1 when all four hold, 0 otherwise. Any leg that is
+// not exactly 1 (e.g. a malformed host flag) is treated as a miss.
+pub fn rule_applies(src_match: Int, dest_match: Int, port_match: Int, proto_match: Int) -> Int {
+  if src_match != 1 { return 0; }
+  if dest_match != 1 { return 0; }
+  if port_match != 1 { return 0; }
+  if proto_match != 1 { return 0; }
+  1
+}
+
+// The default (no-rule-matched) policy of checkPacket: "Default deny". Returns
+// the Deny code 0. Exposed as its own export so the host's fall-through path
+// reads as the rule it is, rather than a bare literal at the call site.
+pub fn default_action() -> Int { 0 }
+
+// The accounting verdict of checkPacket: which counter a resolved action bumps.
+// In the source, Allow and Log both increment passedPackets while Deny
+// increments blockedAttempts. So the packet PASSES under Allow (1) or Log (2)
+// and is BLOCKED under Deny (0). Returns 1 = passed (bump passedPackets), 0 =
+// blocked (bump blockedAttempts). An out-of-band action code is treated as
+// blocked -- the safe default, consistent with default_action being Deny.
+pub fn verdict_passes_packet(action_code: Int) -> Int {
+  if action_code == 1 { return 1; }
+  if action_code == 2 { return 1; }
+  0
+}

--- a/proposals/idaptik/migrated/FirewallDevice/firewalldevice.config.mjs
+++ b/proposals/idaptik/migrated/FirewallDevice/firewalldevice.config.mjs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for FirewallDevice.affine. The oracle re-derives the ACL
+// packet-filter decision INDEPENDENTLY from the original FirewallDevice.res, so a
+// codegen regression surfaces as a differential mismatch. Source references:
+//
+//   checkPacket (FirewallDevice.res:176-207):
+//     portMatch  = rule.port == 0 || rule.port == port
+//     protoMatch = rule.protocol == "ANY" || rule.protocol == protocol
+//     applies    = sourceMatch && destMatch && portMatch && protoMatch
+//     no match   -> Deny (default deny)
+//     Allow|Log  -> passedPackets++   (packet passed)
+//     Deny       -> blockedAttempts++ (packet blocked)
+//   actionToColor / aclAction order (FirewallDevice.res:31, 218-224):
+//     Deny = 0, Allow = 1, Log = 2  (canonical band; -1 = out-of-band sentinel)
+//   protocol codes (host-parsed): 255 = ANY wildcard, else a distinct per-proto code.
+
+// --- independent oracle, mirroring the .res decision, not the .affine ---
+
+const DENY = 0;
+const ALLOW = 1;
+const LOG = 2;
+const PROTO_ANY = 255;
+
+const oracleIsValidAction = (c) => (c >= 0 && c <= 2 ? 1 : 0);
+const oracleClampAction = (c) => (oracleIsValidAction(c) === 1 ? c : -1);
+
+// rule.port == 0 || rule.port == port
+const oraclePortMatches = (rulePort, pktPort) =>
+  rulePort === 0 || rulePort === pktPort ? 1 : 0;
+
+// rule.protocol == "ANY" || rule.protocol == protocol  (ANY parsed to 255)
+const oracleProtocolMatches = (ruleProto, pktProto) =>
+  ruleProto === PROTO_ANY || ruleProto === pktProto ? 1 : 0;
+
+// sourceMatch && destMatch && portMatch && protoMatch, each leg a strict-1 flag
+const oracleRuleApplies = (s, d, p, q) =>
+  s === 1 && d === 1 && p === 1 && q === 1 ? 1 : 0;
+
+// Allow|Log -> passedPackets (1); Deny / anything else -> blockedAttempts (0)
+const oracleVerdictPasses = (a) => (a === ALLOW || a === LOG ? 1 : 0);
+
+export default {
+  affine: "FirewallDevice.affine",
+  cases: [
+    { name: "action_deny()", export: "action_deny", args: [], oracle: () => DENY },
+    { name: "action_allow()", export: "action_allow", args: [], oracle: () => ALLOW },
+    { name: "action_log()", export: "action_log", args: [], oracle: () => LOG },
+    { name: "action_count()", export: "action_count", args: [], oracle: () => 3 },
+    { name: "proto_any()", export: "proto_any", args: [], oracle: () => PROTO_ANY },
+    {
+      name: "is_valid_action over [-3..5]",
+      export: "is_valid_action",
+      args: [[-3, 5]],
+      oracle: (c) => oracleIsValidAction(c),
+    },
+    {
+      name: "clamp_action over [-3..5]",
+      export: "clamp_action",
+      args: [[-3, 5]],
+      oracle: (c) => oracleClampAction(c),
+    },
+    {
+      name: "port_matches over rule[0..5] x pkt[0..5]",
+      export: "port_matches",
+      args: [[0, 5], [0, 5]],
+      oracle: (rulePort, pktPort) => oraclePortMatches(rulePort, pktPort),
+    },
+    {
+      name: "protocol_matches over {TCP,UDP,ICMP,ANY} x {TCP,UDP,ICMP,ANY}",
+      export: "protocol_matches",
+      args: [{ values: [0, 1, 2, 255] }, { values: [0, 1, 2, 255] }],
+      oracle: (ruleProto, pktProto) => oracleProtocolMatches(ruleProto, pktProto),
+    },
+    {
+      name: "rule_applies over src,dest,port,proto each [0..2]",
+      export: "rule_applies",
+      args: [[0, 2], [0, 2], [0, 2], [0, 2]],
+      oracle: (s, d, p, q) => oracleRuleApplies(s, d, p, q),
+    },
+    { name: "default_action()", export: "default_action", args: [], oracle: () => DENY },
+    {
+      name: "verdict_passes_packet over [-2..4]",
+      export: "verdict_passes_packet",
+      args: [[-2, 4]],
+      oracle: (a) => oracleVerdictPasses(a),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/GuardNPC/GuardNPC.affine
+++ b/proposals/idaptik/migrated/GuardNPC/GuardNPC.affine
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// GuardNPC -- the guard-NPC decision core, the pure-integer brain re-decomposed
+// from src/app/enemies/GuardNPC.res (1870 LOC). The ReScript original is a large
+// mutable entity (`t`) carrying string ids, Pixi Container/Graphics handles,
+// float positions, option<antiHackerPsych>/rivalHackerAI/chiefAI/assassinAI
+// sub-records, an async wasm coprocessor ref, and per-frame mutation. None of
+// that crosses the boundary.
+//
+// Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), the host KEEPS: every string id and
+// label (stateToString, rankToString, reverseTarget device ids, deviceQueue),
+// all rendering (renderGuard, rankColor, rankSize, vision-cone geometry), the
+// float pathfinding/movement integration (guard.x +. dir *. speed *. dt and the
+// SafeAngle.fromAtan2 bearing), Math.random jitter, all mutable records and
+// arrays, the Promise-based coprocessor load, and every Pixi effect. The
+// AffineScript brain owns ONLY the deterministic integer decisions: the
+// state/rank ordinal taxonomies, the detection-class ladder, the per-rank
+// suspicion thresholds / decay rates / pursuit multipliers, the anti-hacker
+// courage arithmetic and panic predicate, the full-detection response band, the
+// assassin spawn gate, the trap-effect classifier and trap-kind rotation, and
+// the waypoint-advance modulus.
+//
+//## Float boundary: distances, ranges, speeds and courage cross as MILLI-UNITS
+// Every float the brain needs is floored host-side to an Int scaled by 1000
+// (a "milli-unit"): the JS caller passes round(value * 1000). Pixel distances
+// (already large) cross as round(px * 1000); 0.0..1.0 factors (courage,
+// proximity, suspicion, speed multipliers) cross as round(factor * 1000), so
+// 0.6 -> 600, 0.85 -> 850, 1.0 -> 1000. The integer formulae below are exact
+// for these milli operands and reproduce the ReScript float comparisons byte
+// for byte at the thresholds (strict `>` stays strict, `>=` stays `>=`).
+//
+//## State ordinal encoding (the header contract for the JS host)
+//   code  state            code  state            code  state
+//     0   Patrolling         6   Panicking         12   Racing
+//     1   Investigating      7   Fleeing           13   Hiding
+//     2   Alerted            8   CallingBackup     14   Ambushing
+//     3   Returning          9   Commanding        15   Stalking
+//     4   Stationary        10   Hacking           16   SettingTrap
+//     5   ReverseHacking    11   Sabotaging        17   KnockedDown
+// The 18 valid codes are 0..17; the encoding is lossless. Any input outside
+// 0..17 clamps to the nearest valid ordinal (0 or 17) via a declared clamp.
+//
+//## Rank ordinal encoding (the header contract for the JS host)
+//   code  rank             code  rank
+//     0   BasicGuard         4   EliteGuard
+//     1   SecurityGuard      5   SecurityChief
+//     2   AntiHacker         6   RivalHacker
+//     3   Sentinel           7   Assassin
+// The 8 valid codes are 0..7. Out-of-band clamps to the nearest valid ordinal.
+
+// =========================================================================
+// State taxonomy
+// =========================================================================
+
+enum State {
+  Patrolling, Investigating, Alerted, Returning, Stationary, ReverseHacking,
+  Panicking, Fleeing, CallingBackup, Commanding, Hacking, Sabotaging,
+  Racing, Hiding, Ambushing, Stalking, SettingTrap, KnockedDown,
+  InvalidState(Int)
+}
+
+fn state_of(code: Int) -> State {
+  if code == 0 { return Patrolling; }
+  if code == 1 { return Investigating; }
+  if code == 2 { return Alerted; }
+  if code == 3 { return Returning; }
+  if code == 4 { return Stationary; }
+  if code == 5 { return ReverseHacking; }
+  if code == 6 { return Panicking; }
+  if code == 7 { return Fleeing; }
+  if code == 8 { return CallingBackup; }
+  if code == 9 { return Commanding; }
+  if code == 10 { return Hacking; }
+  if code == 11 { return Sabotaging; }
+  if code == 12 { return Racing; }
+  if code == 13 { return Hiding; }
+  if code == 14 { return Ambushing; }
+  if code == 15 { return Stalking; }
+  if code == 16 { return SettingTrap; }
+  if code == 17 { return KnockedDown; }
+  InvalidState(code)
+}
+
+// @clamp:declared -- out-of-band state clamps to nearest valid ordinal (0 or 17).
+// Controlled-loss by design: the 18 valid codes 0..17 are injective; only the
+// out-of-band InvalidState(v) is squashed, never an in-band code.
+fn clamp_state_ordinal(v: Int) -> Int {
+  if v < 0 { return 0; }
+  17
+}
+
+fn state_ordinal_of(s: State) -> Int {
+  match s {
+    Patrolling => 0,
+    Investigating => 1,
+    Alerted => 2,
+    Returning => 3,
+    Stationary => 4,
+    ReverseHacking => 5,
+    Panicking => 6,
+    Fleeing => 7,
+    CallingBackup => 8,
+    Commanding => 9,
+    Hacking => 10,
+    Sabotaging => 11,
+    Racing => 12,
+    Hiding => 13,
+    Ambushing => 14,
+    Stalking => 15,
+    SettingTrap => 16,
+    KnockedDown => 17,
+    InvalidState(v) => clamp_state_ordinal(v)
+  }
+}
+
+//## Number of canonical guard states.
+pub fn state_count() -> Int { 18 }
+
+//## State ordinal (canonicalise a host integer to a valid state code).
+pub fn state_value(code: Int) -> Int {
+  state_ordinal_of(state_of(code))
+}
+
+// =========================================================================
+// Rank taxonomy
+// =========================================================================
+
+enum Rank {
+  BasicGuard, SecurityGuard, AntiHacker, Sentinel, EliteGuard, SecurityChief,
+  RivalHacker, Assassin, InvalidRank(Int)
+}
+
+fn rank_of(code: Int) -> Rank {
+  if code == 0 { return BasicGuard; }
+  if code == 1 { return SecurityGuard; }
+  if code == 2 { return AntiHacker; }
+  if code == 3 { return Sentinel; }
+  if code == 4 { return EliteGuard; }
+  if code == 5 { return SecurityChief; }
+  if code == 6 { return RivalHacker; }
+  if code == 7 { return Assassin; }
+  InvalidRank(code)
+}
+
+// @clamp:declared -- out-of-band rank clamps to nearest valid ordinal (0 or 7).
+fn clamp_rank_ordinal(v: Int) -> Int {
+  if v < 0 { return 0; }
+  7
+}
+
+fn rank_ordinal_of(r: Rank) -> Int {
+  match r {
+    BasicGuard => 0,
+    SecurityGuard => 1,
+    AntiHacker => 2,
+    Sentinel => 3,
+    EliteGuard => 4,
+    SecurityChief => 5,
+    RivalHacker => 6,
+    Assassin => 7,
+    InvalidRank(v) => clamp_rank_ordinal(v)
+  }
+}
+
+//## Number of canonical guard ranks.
+pub fn rank_count() -> Int { 8 }
+
+//## Rank ordinal (canonicalise a host integer to a valid rank code).
+pub fn rank_value(code: Int) -> Int {
+  rank_ordinal_of(rank_of(code))
+}
+
+// =========================================================================
+// Detection ladder (detectPlayer's pure integer core)
+// =========================================================================
+//
+// detectPlayer in the .res first does isInVisionCone (float cone geometry +
+// SafeAngle bearing -- stays host-side), then on a hit it computes:
+//   effectiveRange = crouching ? range*0.6 : range
+//   if distance > effectiveRange -> NotDetected
+//   proximityFactor = 1 - distance/effectiveRange
+//   proximityFactor > 0.6 -> FullDetection, else Peripheral(proximityFactor)
+// All of that (after the cone test) is exact integer arithmetic in milli-units.
+
+//## Crouch-scaled effective range (×0.6 == ×600/1000 when crouching).
+// range_milli is round(vision.range * 1000); crouching is 1/0.
+pub fn effective_range_milli(range_milli: Int, crouching: Int) -> Int {
+  if crouching == 1 { return range_milli * 600 / 1000; }
+  range_milli
+}
+
+//## Detection class given distance and the already-scaled effective range.
+// Returns the detectionResult band:  0 = NotDetected, 1 = Peripheral,
+// 2 = FullDetection. Mirrors detectPlayer after the cone hit. Inputs are
+// milli-units (round(px * 1000)). proximityFactor = 1 - distance/effRange, so
+// proximityFactor > 0.6 == distance < effRange * 400 / 1000 (the 0.4 boundary).
+// On effective_range_milli == 0 every in-cone hit is at/over range -> NotDetected.
+pub fn detection_class(distance_milli: Int, effective_range_milli: Int) -> Int {
+  if effective_range_milli <= 0 { return 0; }
+  if distance_milli > effective_range_milli { return 0; }
+  if distance_milli < effective_range_milli * 400 / 1000 { return 2; }
+  1
+}
+
+// =========================================================================
+// Suspicion thresholds, decay, and pursuit multipliers (per rank)
+// =========================================================================
+
+//## Peripheral suspicion threshold to begin Investigating (milli-units).
+// detectPlayer Peripheral branch: BasicGuard 0.85, SecurityGuard 0.65,
+// EliteGuard 0.5, SecurityChief 0.6, default 0.7.
+pub fn peripheral_threshold_milli(rank: Int) -> Int {
+  let r = rank_ordinal_of(rank_of(rank));
+  if r == 0 { return 850; }
+  if r == 1 { return 650; }
+  if r == 4 { return 500; }
+  if r == 5 { return 600; }
+  700
+}
+
+//## Suspicion decay rate per second when NotDetected (milli-units).
+// detectPlayer NotDetected branch: BasicGuard 0.3, EliteGuard 0.1, default 0.2.
+pub fn decay_rate_milli(rank: Int) -> Int {
+  let r = rank_ordinal_of(rank_of(rank));
+  if r == 0 { return 300; }
+  if r == 4 { return 100; }
+  200
+}
+
+//## Investigating pursuit speed multiplier (milli-units).
+// updatePatrol Investigating: BasicGuard 1.2, EliteGuard 1.8, default 1.5.
+pub fn investigate_speed_mult_milli(rank: Int) -> Int {
+  let r = rank_ordinal_of(rank_of(rank));
+  if r == 0 { return 1200; }
+  if r == 4 { return 1800; }
+  1500
+}
+
+//## Alerted pursuit speed multiplier (milli-units).
+// updatePatrol Alerted: BasicGuard 1.5, SecurityGuard 2.0, EliteGuard 2.5,
+// SecurityChief 1.8, default 1.5.
+pub fn alerted_speed_mult_milli(rank: Int) -> Int {
+  let r = rank_ordinal_of(rank_of(rank));
+  if r == 0 { return 1500; }
+  if r == 1 { return 2000; }
+  if r == 4 { return 2500; }
+  if r == 5 { return 1800; }
+  1500
+}
+
+// =========================================================================
+// Anti-hacker psychology (updateAntiHacker's pure integer core)
+// =========================================================================
+
+//## Anti-hacker courage (milli-units), clamped to 0..1000.
+// updateAntiHacker: courage = clamp(0, 1, baseCourage(0.3) + backupBonus(+0.4
+// if backupArrived) + alertPenalty(-0.15 if alertLevel>=4) + proximityPenalty
+// (-0.2 if playerDist<120px)). backup is 1/0; player_dist_milli is round(px*1000),
+// so the 120px gate is player_dist_milli < 120000.
+pub fn courage_milli(backup: Int, alert_level: Int, player_dist_milli: Int) -> Int {
+  let mut c = 300;
+  if backup == 1 { c = c + 400; }
+  if alert_level >= 4 { c = c - 150; }
+  if player_dist_milli < 120000 { c = c - 200; }
+  if c < 0 { return 0; }
+  if c > 1000 { return 1000; }
+  c
+}
+
+//## Panic predicate: courage below the panic threshold.
+// updateAntiHacker / detectPlayer FullDetection: psych.courage < psych.panicThreshold.
+// Both operands are milli-units (panic_threshold default 250). 1 = panic, 0 = hold.
+pub fn should_panic(courage_milli: Int, panic_threshold_milli: Int) -> Int {
+  if courage_milli < panic_threshold_milli { 1 } else { 0 }
+}
+
+//## Anti-hacker FullDetection response band.
+// detectPlayer FullDetection, AntiHacker arm: if courage < panicThreshold ->
+// Panicking (state 6); else if hasRadio and not backupArrived -> CallingBackup
+// (state 8); else hold (sentinel -1, no transition). has_radio / backup are 1/0.
+// The host applies the returned state code (or leaves state unchanged on -1).
+pub fn antihacker_full_detection_state(
+  courage_milli: Int,
+  panic_threshold_milli: Int,
+  has_radio: Int,
+  backup: Int
+) -> Int {
+  if courage_milli < panic_threshold_milli { return 6; }
+  if has_radio == 1 {
+    if backup == 0 { return 8; }
+  }
+  -1
+}
+
+//## Generic FullDetection target-state band by rank.
+// detectPlayer FullDetection switch (non-AntiHacker arms): BasicGuard ->
+// Investigating(1), SecurityChief -> Commanding(9), default -> Alerted(2).
+// AntiHacker(2) is routed through antihacker_full_detection_state instead and
+// returns the sentinel -1 here. (Sentinel/Elite/SecurityGuard/RivalHacker take
+// the default Alerted band; RivalHacker/Assassin never reach detectPlayer.)
+pub fn full_detection_state_for_rank(rank: Int) -> Int {
+  let r = rank_ordinal_of(rank_of(rank));
+  if r == 0 { return 1; }
+  if r == 2 { return -1; }
+  if r == 5 { return 9; }
+  2
+}
+
+// =========================================================================
+// Assassin spawn gate + trap classifier
+// =========================================================================
+
+//## Assassin spawn gate (shouldSpawnAssassin): difficulty >= 3 (Hard+).
+pub fn should_spawn_assassin(difficulty: Int) -> Int {
+  if difficulty >= 3 { 1 } else { 0 }
+}
+
+//## Trap-kind rotation (updateAssassin SettingTrap): mod(trapCount, 5) chooses
+// the trap type. 0 Tripwire, 1 Garrotte, 2 DisabledLight, 3 LockedDoor,
+// 4 EMPDevice. Identity band 0..4; the host maps the code to its trapType.
+pub fn trap_kind_for(trap_count: Int) -> Int {
+  let m = trap_count % 5;
+  if m < 0 { return m + 5; }
+  m
+}
+
+//## Trap-effect classifier (checkPlayerTrapCollision's pure integer core).
+// Given the trap kind (0..4 as above), the player-to-trap distance in
+// milli-units (round(px*1000)) and whether the player is sprinting (1/0),
+// returns the trapEffect band:
+//   0 TrapNone     1 TrapTrip      2 TrapLethal
+//   3 TrapSpotted  4 TrapDarkness  5 TrapEMP
+// Per-kind ranges from the .res: Tripwire 20px, Garrotte 15px (lethal if
+// sprinting, else spotted), DisabledLight 30px, EMPDevice 25px, LockedDoor
+// environmental (never proximity -> TrapNone). Boundaries are strict `<`,
+// matching the ReScript `dist < N`.
+pub fn trap_effect(trap_kind: Int, dist_milli: Int, sprinting: Int) -> Int {
+  if trap_kind == 0 {
+    if dist_milli < 20000 { return 1; }
+    return 0;
+  }
+  if trap_kind == 1 {
+    if dist_milli < 15000 {
+      if sprinting == 1 { return 2; }
+      return 3;
+    }
+    return 0;
+  }
+  if trap_kind == 2 {
+    if dist_milli < 30000 { return 4; }
+    return 0;
+  }
+  if trap_kind == 4 {
+    if dist_milli < 25000 { return 5; }
+    return 0;
+  }
+  0
+}
+
+// =========================================================================
+// Misc integer machinery
+// =========================================================================
+
+//## Waypoint advance (updatePatrol / updateAssassin): mod(current+1, len).
+// On len <= 0 there is no next waypoint; the host guards that case, so the brain
+// returns 0 (the canonical "no waypoint" index).
+pub fn next_waypoint(current: Int, len: Int) -> Int {
+  if len <= 0 { return 0; }
+  // NB: `let` binding (not a bare `(current + 1) % len`) -- a statement that
+  // begins with `(` immediately after an `if { ... }` block is otherwise parsed
+  // as the block being *applied* to `(current + 1)`, a Unit-not-a-function error.
+  let succ = current + 1;
+  succ % len
+}
+
+//## Lifetime-counter increment (undosCompleted, killAttempts, etc.).
+pub fn increment_counter(count: Int) -> Int {
+  count + 1
+}

--- a/proposals/idaptik/migrated/GuardNPC/guardnpc.config.mjs
+++ b/proposals/idaptik/migrated/GuardNPC/guardnpc.config.mjs
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for GuardNPC.affine (idaptik guard-NPC decision brain;
+// scalar i32 ABI, every export Int-in/Int-out). Each oracle is an INDEPENDENT JS
+// reimplementation re-derived from src/app/enemies/GuardNPC.res semantics (NOT
+// from the .affine), so a codegen or re-decomposition regression surfaces as a
+// differential mismatch. Float operands are milli-units (round(value * 1000)),
+// matching the GuardNPC.affine header contract.
+
+// --- shared oracle helpers (re-derived from GuardNPC.res) -------------------
+
+// guardState ordinal band: 18 valid codes 0..17, out-of-band clamps to 0 or 17.
+const clampState = (c) => (c < 0 ? 0 : c > 17 ? 17 : c);
+// guardRank ordinal band: 8 valid codes 0..7, out-of-band clamps to 0 or 7.
+const clampRank = (c) => (c < 0 ? 0 : c > 7 ? 7 : c);
+
+export default {
+  affine: "GuardNPC.affine",
+  cases: [
+    // --- state taxonomy ----------------------------------------------------
+    {
+      name: "state_count()",
+      export: "state_count",
+      args: [],
+      oracle: () => 18,
+    },
+    {
+      name: "state_value over [-3..20]",
+      export: "state_value",
+      args: [[-3, 20]],
+      oracle: (c) => clampState(c),
+    },
+    // --- rank taxonomy -----------------------------------------------------
+    {
+      name: "rank_count()",
+      export: "rank_count",
+      args: [],
+      oracle: () => 8,
+    },
+    {
+      name: "rank_value over [-3..11]",
+      export: "rank_value",
+      args: [[-3, 11]],
+      oracle: (c) => clampRank(c),
+    },
+    // --- detection ladder --------------------------------------------------
+    {
+      // detectPlayer: effectiveRange = crouching ? range*0.6 : range.
+      // milli, integer division (floor for the non-negative operands here).
+      name: "effective_range_milli(range_milli {0,150000,220000,300000}, crouching {0,1})",
+      export: "effective_range_milli",
+      args: [{ values: [0, 150000, 220000, 300000] }, { values: [0, 1] }],
+      oracle: (range_milli, crouching) =>
+        crouching === 1 ? Math.trunc((range_milli * 600) / 1000) : range_milli,
+    },
+    {
+      // detectPlayer after the cone hit: NotDetected(0)/Peripheral(1)/Full(2).
+      // proximityFactor = 1 - distance/effRange; >0.6 == distance < effRange*0.4.
+      name: "detection_class(distance_milli, effective_range_milli)",
+      export: "detection_class",
+      args: [
+        { values: [0, 20000, 50000, 60000, 80000, 90000, 120000, 200000, 300000] },
+        { values: [0, 90000, 150000, 220000] },
+      ],
+      oracle: (distance_milli, eff) => {
+        if (eff <= 0) return 0;
+        if (distance_milli > eff) return 0;
+        if (distance_milli < Math.trunc((eff * 400) / 1000)) return 2;
+        return 1;
+      },
+    },
+    // --- per-rank suspicion thresholds / decay / pursuit -------------------
+    {
+      // detectPlayer Peripheral threshold: 0.85/0.65/0.5/0.6/0.7 by rank, milli.
+      name: "peripheral_threshold_milli over rank [-1..8]",
+      export: "peripheral_threshold_milli",
+      args: [[-1, 8]],
+      oracle: (rank) => {
+        const r = clampRank(rank);
+        if (r === 0) return 850;
+        if (r === 1) return 650;
+        if (r === 4) return 500;
+        if (r === 5) return 600;
+        return 700;
+      },
+    },
+    {
+      // detectPlayer NotDetected decay: 0.3/0.1/0.2 by rank, milli.
+      name: "decay_rate_milli over rank [-1..8]",
+      export: "decay_rate_milli",
+      args: [[-1, 8]],
+      oracle: (rank) => {
+        const r = clampRank(rank);
+        if (r === 0) return 300;
+        if (r === 4) return 100;
+        return 200;
+      },
+    },
+    {
+      // updatePatrol Investigating speedMult: 1.2/1.8/1.5 by rank, milli.
+      name: "investigate_speed_mult_milli over rank [-1..8]",
+      export: "investigate_speed_mult_milli",
+      args: [[-1, 8]],
+      oracle: (rank) => {
+        const r = clampRank(rank);
+        if (r === 0) return 1200;
+        if (r === 4) return 1800;
+        return 1500;
+      },
+    },
+    {
+      // updatePatrol Alerted speedMult: 1.5/2.0/2.5/1.8/1.5 by rank, milli.
+      name: "alerted_speed_mult_milli over rank [-1..8]",
+      export: "alerted_speed_mult_milli",
+      args: [[-1, 8]],
+      oracle: (rank) => {
+        const r = clampRank(rank);
+        if (r === 0) return 1500;
+        if (r === 1) return 2000;
+        if (r === 4) return 2500;
+        if (r === 5) return 1800;
+        return 1500;
+      },
+    },
+    // --- anti-hacker psychology -------------------------------------------
+    {
+      // updateAntiHacker: courage = clamp(0,1, 0.3 +0.4(backup) -0.15(alert>=4)
+      // -0.2(dist<120px)). milli; dist<120px == dist_milli<120000.
+      name: "courage_milli(backup {0,1}, alert_level {0,3,4,5}, player_dist_milli)",
+      export: "courage_milli",
+      args: [
+        { values: [0, 1] },
+        { values: [0, 3, 4, 5] },
+        { values: [0, 50000, 119999, 120000, 200000] },
+      ],
+      oracle: (backup, alert_level, player_dist_milli) => {
+        let c = 300;
+        if (backup === 1) c += 400;
+        if (alert_level >= 4) c -= 150;
+        if (player_dist_milli < 120000) c -= 200;
+        if (c < 0) return 0;
+        if (c > 1000) return 1000;
+        return c;
+      },
+    },
+    {
+      // updateAntiHacker panic check: courage < panicThreshold (milli).
+      name: "should_panic(courage_milli, panic_threshold_milli {250})",
+      export: "should_panic",
+      args: [{ values: [0, 100, 249, 250, 251, 500, 1000] }, { values: [250 ] }],
+      oracle: (courage_milli, panic_threshold_milli) =>
+        courage_milli < panic_threshold_milli ? 1 : 0,
+    },
+    {
+      // detectPlayer FullDetection AntiHacker arm: panic(6) / callBackup(8) / hold(-1).
+      name: "antihacker_full_detection_state(courage, threshold {250}, has_radio {0,1}, backup {0,1})",
+      export: "antihacker_full_detection_state",
+      args: [
+        { values: [100, 250, 400] },
+        { values: [250] },
+        { values: [0, 1] },
+        { values: [0, 1] },
+      ],
+      oracle: (courage, threshold, has_radio, backup) => {
+        if (courage < threshold) return 6;
+        if (has_radio === 1 && backup === 0) return 8;
+        return -1;
+      },
+    },
+    {
+      // detectPlayer FullDetection switch (non-AntiHacker): Basic->Investigating(1),
+      // AntiHacker->routed elsewhere(-1), Chief->Commanding(9), default Alerted(2).
+      name: "full_detection_state_for_rank over rank [-1..8]",
+      export: "full_detection_state_for_rank",
+      args: [[-1, 8]],
+      oracle: (rank) => {
+        const r = clampRank(rank);
+        if (r === 0) return 1;
+        if (r === 2) return -1;
+        if (r === 5) return 9;
+        return 2;
+      },
+    },
+    // --- assassin spawn + traps -------------------------------------------
+    {
+      // shouldSpawnAssassin: missionDifficulty >= 3 (Hard+).
+      name: "should_spawn_assassin over difficulty [0..6]",
+      export: "should_spawn_assassin",
+      args: [[0, 6]],
+      oracle: (difficulty) => (difficulty >= 3 ? 1 : 0),
+    },
+    {
+      // updateAssassin SettingTrap: mod(trapCount, 5) selects trap type 0..4.
+      name: "trap_kind_for over trap_count [0..12]",
+      export: "trap_kind_for",
+      args: [[0, 12]],
+      oracle: (trap_count) => ((trap_count % 5) + 5) % 5,
+    },
+    {
+      // checkPlayerTrapCollision: per-kind distance bands. milli; strict `<`.
+      // 0 None, 1 Trip, 2 Lethal, 3 Spotted, 4 Darkness, 5 EMP.
+      name: "trap_effect(trap_kind {0..4}, dist_milli, sprinting {0,1})",
+      export: "trap_effect",
+      args: [
+        { values: [0, 1, 2, 3, 4] },
+        { values: [0, 14999, 15000, 19999, 20000, 24999, 25000, 29999, 30000, 50000] },
+        { values: [0, 1] },
+      ],
+      oracle: (trap_kind, dist_milli, sprinting) => {
+        if (trap_kind === 0) return dist_milli < 20000 ? 1 : 0;
+        if (trap_kind === 1) {
+          if (dist_milli < 15000) return sprinting === 1 ? 2 : 3;
+          return 0;
+        }
+        if (trap_kind === 2) return dist_milli < 30000 ? 4 : 0;
+        if (trap_kind === 4) return dist_milli < 25000 ? 5 : 0;
+        return 0; // LockedDoor (3) is environmental, never proximity-triggered
+      },
+    },
+    // --- misc integer machinery -------------------------------------------
+    {
+      // updatePatrol / updateAssassin: mod(current+1, len); len<=0 -> 0.
+      name: "next_waypoint(current {0..5}, len {0,1,3,4})",
+      export: "next_waypoint",
+      args: [{ values: [0, 1, 2, 3, 4, 5] }, { values: [0, 1, 3, 4] }],
+      oracle: (current, len) => (len <= 0 ? 0 : (current + 1) % len),
+    },
+    {
+      name: "increment_counter over [0..20]",
+      export: "increment_counter",
+      args: [[0, 20]],
+      oracle: (count) => count + 1,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Inventory/Inventory.affine
+++ b/proposals/idaptik/migrated/Inventory/Inventory.affine
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Inventory -- the slot-and-weight co-processor, the pure-integer core extracted
+// from src/shared/Inventory.res. Per the DESIGN-VISION ("AffineScript is the
+// brain, JS/Pixi the senses; only primitives cross the wasm boundary"), the JS
+// host keeps every contaminant the toolkit carries: the item id/name/description
+// strings, the itemKind/itemCondition/portType/compatibility variants, the
+// per-item mutable condition/usesRemaining records, the float weights/lengths,
+// the Promise-driven coprocessor loader, and -- crucially -- the inventory STATE
+// (the `slots` array and `totalWeight`). The brain owns only the stateless
+// slot-and-weight kernels the bridge already calls across the boundary.
+//
+// This file is the AffineScript side of the contract that
+// src/shared/InventoryCoprocessor.res ALREADY declares: it mirrors that bridge's
+// @send signatures one-for-one (slotCount, isSlotLocked, findEmptySlot,
+// filledCount, unlockedCount, remainingCapacity, addWeight, fitsWeight, canAdd),
+// in the same argument order, as pure scalar functions. The ReScript original
+// holds the model in `ref`s and mutates the slots array in place; we
+// re-decompose those mutations away -- every kernel takes the current state as
+// explicit integer parameters and RETURNS the answer, holding NO module state
+// (rule 3: no module-level mutable state). The host reads each result back.
+//
+//## SHAPE-A (the model never lives in wasm)
+// The inventory `t` (slots/maxWeight/tier/totalWeight) stays host-side. The
+// brain is queried with the relevant fields as primitives; it computes and
+// returns, the host stores. Only scalars cross.
+//
+//## Slot-state encoding (the header contract for the JS host) -- base-3
+// The ReScript `slot` is { item: option<item>, locked: bool }. The item payload
+// (name, kind, weight, condition...) is a sense and stays host-side; the brain
+// sees only the slot's STATE as a base-3 digit, low digit = slot index 0,
+// mirroring InventoryCoprocessor.res's SLOT alphabet and packSlots helper:
+//   digit  state    meaning
+//     0    EMPTY    unlocked and holding no item
+//     1    FILLED   holding an item
+//     2    LOCKED   locked (progression-gated), holds no item
+// `packed` is the base-3 number sum_i digit_i * 3^i. Idaptik kits are six slots,
+// so packed in [0, 3^6) for a real inventory; the count parameter bounds every
+// scan, so an over-long packed value cannot read a phantom slot.
+//
+//## Slot layout per tier (Inventory.make)
+// Every tier has SIX slots. The lock layout is the only difference:
+//   tier ordinal   tier         locked slot indices
+//     0            Accessible   none (all six unlocked)
+//     1            Realistic    4, 5
+//     2            Hardcore     4, 5
+// A tier ordinal outside 0..2 is not a real tier: slot_count returns 0 and
+// is_slot_locked returns 0, so a malformed tier can address no slot layout.
+//
+//## Weight encoding -- floored milli-kilograms (Int, ×1000 host-side)
+// The ReScript weights (item.weight, totalWeight, maxWeight) are f64 kilograms.
+// Float arithmetic in the brain hits a known compiler codegen bug (float literal
+// operands emit integer opcodes) and the float ABI is i32-narrowed, so per
+// rule 2 the host floors each weight to integer milli-kilograms (×1000) before
+// the call and the brain works in pure Int. maxWeight 3.0 kg -> 3000; a 0.15 kg
+// cable -> 150. The comparisons are integer-exact and order-preserving, so the
+// 1-milligram quantisation is below the game's display precision (two decimals).
+// No float crosses this boundary.
+//
+// The find/filled/unlocked scans are O(count) while-loops with a guard on every
+// step (k < count); there is no array indexing -- a slot's digit is recovered by
+// the integer extraction (packed / 3^k) % 3, never by a subscript. No `for..in`,
+// no nth/get, no string operation appears in the brain.
+
+//## Slot-state digit alphabet (mirror of InventoryCoprocessor SLOT scope)
+fn slot_empty() -> Int { 0 }
+fn slot_filled() -> Int { 1 }
+fn slot_locked() -> Int { 2 }
+
+//## Tier validity. A real tier occupies ordinal 0..2 (Accessible/Realistic/
+// Hardcore). Out-of-band ordinals are defended at every kernel.
+fn valid_tier(tier: Int) -> Int {
+  if tier < 0 { return 0; }
+  if tier > 2 { return 0; }
+  1
+}
+
+//## 3^k by repeated tripling -- the place value of slot index k in the base-3
+// packing. The proven small-non-negative-power idiom (mirrors LaptopState's
+// bit_of doubling); avoids any shift/pow builtin.
+fn place_of(k: Int) -> Int {
+  let mut value = 1;
+  let mut i = 0;
+  while i < k {
+    value = value * 3;
+    i = i + 1;
+  }
+  value
+}
+
+//## The base-3 digit at slot index k of a packed slot word.
+fn slot_digit(packed: Int, k: Int) -> Int {
+  let place = place_of(k);
+  (packed / place) % 3
+}
+
+//## Pure exports (mirror InventoryCoprocessor.res @send signatures)
+
+// slotCount: the number of slots a tier's kit has. Inventory.make builds six
+// slots for every tier, so the count is six on any valid tier; an out-of-band
+// tier has no layout and returns 0.
+pub fn slot_count(tier: Int) -> Int {
+  if valid_tier(tier) == 0 { return 0; }
+  6
+}
+
+// isSlotLocked: whether slot `idx` starts locked under `tier`. 1 locked, 0 not.
+// Mirrors Inventory.make: Accessible locks nothing; Realistic and Hardcore lock
+// the last two slots (indices 4 and 5). An out-of-band tier or an index outside
+// 0..5 is not a real slot and reads 0 (unlocked) -- the host pairs this with
+// slot_count to stay in range.
+pub fn is_slot_locked(tier: Int, idx: Int) -> Int {
+  if valid_tier(tier) == 0 { return 0; }
+  if idx < 0 { return 0; }
+  if idx > 5 { return 0; }
+  if tier == 0 { return 0; }
+  if idx >= 4 { 1 } else { 0 }
+}
+
+// findEmptySlot: index of the first EMPTY (unlocked, item-free) slot in the
+// packed slot word, scanning indices 0..count-1; -1 when none is free. This is
+// the re-decomposition of Inventory.findEmptySlot's forEachWithIndex search for
+// the first slot with no item and not locked. -1 is the out-of-band sentinel the
+// bridge already documents ("-1 when none is free"); it is not a valid slot
+// index, so a "no free slot" answer can never be confused with a real index
+// (a sentinel, not a clamp).
+pub fn find_empty_slot(packed: Int, count: Int) -> Int {
+  let mut k = 0;
+  while k < count {
+    if slot_digit(packed, k) == slot_empty() { return k; }
+    k = k + 1;
+  }
+  -1
+}
+
+// filledCount: how many slots hold an item (digit == FILLED). Re-decomposition
+// of getFilledCount (filter Option.isSome). Scans 0..count-1.
+pub fn filled_count(packed: Int, count: Int) -> Int {
+  let mut acc = 0;
+  let mut k = 0;
+  while k < count {
+    if slot_digit(packed, k) == slot_filled() { acc = acc + 1; }
+    k = k + 1;
+  }
+  acc
+}
+
+// unlockedCount: how many slots are not locked (digit != LOCKED). Re-decomposition
+// of getUnlockedCount (filter !slot.locked). EMPTY and FILLED are both unlocked;
+// only LOCKED is excluded. Scans 0..count-1.
+pub fn unlocked_count(packed: Int, count: Int) -> Int {
+  let mut acc = 0;
+  let mut k = 0;
+  while k < count {
+    if slot_digit(packed, k) != slot_locked() { acc = acc + 1; }
+    k = k + 1;
+  }
+  acc
+}
+
+// remainingCapacity: maxWeight - totalWeight, in floored milli-kilograms.
+// Re-decomposition of Inventory.remainingCapacity (maxWeight -. totalWeight).
+// Can go negative if the host's accumulated total ever exceeds max (it should
+// not, since the addItem gate forbids it), in which case the negative value is
+// the genuine over-capacity overshoot.
+pub fn remaining_capacity(max_milli: Int, total_milli: Int) -> Int {
+  max_milli - total_milli
+}
+
+// addWeight: the fold step of recalculateWeight -- accumulate one item's weight
+// onto the running total, in milli-kilograms. Re-decomposition of the
+// Array.reduce step `acc +. item.weight`.
+pub fn add_weight(acc_milli: Int, item_milli: Int) -> Int {
+  acc_milli + item_milli
+}
+
+// fitsWeight: the weight half of the addItem gate. 1 when the item fits, 0 when
+// too heavy. Re-decomposition of `inv.totalWeight +. item.weight > inv.maxWeight`
+// (the ReScript `tooHeavy` test) negated: it fits exactly when the new total is
+// at or below max. All three weights are floored milli-kilograms.
+pub fn fits_weight(total_milli: Int, item_milli: Int, max_milli: Int) -> Int {
+  if total_milli + item_milli > max_milli { 0 } else { 1 }
+}
+
+// canAdd: the full addItem eligibility -- 1 when the item fits by weight AND an
+// empty unlocked slot exists, 0 otherwise. Re-decomposition of the whole
+// Inventory.addItem decision (the `tooHeavy` gate composed with findEmptySlot
+// returning Some). Lets the host get the verdict in one call rather than
+// threading fits_weight and find_empty_slot together itself.
+pub fn can_add(packed: Int, count: Int, total_milli: Int, item_milli: Int, max_milli: Int) -> Int {
+  if fits_weight(total_milli, item_milli, max_milli) == 0 { return 0; }
+  if find_empty_slot(packed, count) < 0 { return 0; }
+  1
+}

--- a/proposals/idaptik/migrated/Inventory/inventory.config.mjs
+++ b/proposals/idaptik/migrated/Inventory/inventory.config.mjs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Inventory.affine (idaptik slot-and-weight co-processor;
+// scalar i32 ABI). The oracles are an INDEPENDENT JS reimplementation derived
+// from src/shared/Inventory.res -- NOT from the .affine -- so a codegen
+// regression surfaces as a differential mismatch.
+//
+// Slot state is a base-3 word, low digit = slot 0 (EMPTY=0, FILLED=1, LOCKED=2),
+// mirroring InventoryCoprocessor.res's SLOT alphabet. Weights are floored
+// milli-kilograms (Int, the host's ×1000 floor of the f64 kg in Inventory.res).
+//
+// Independent oracle helpers (re-derived from the .res semantics):
+
+// The base-3 digit at slot index k of a packed slot word (no shared code with
+// the .affine extraction: plain Math here).
+const digitAt = (packed, k) => Math.floor(packed / 3 ** k) % 3;
+
+// slotCount: Inventory.make always builds 6 slots; an out-of-band tier has none.
+const slotCount = (tier) => (tier >= 0 && tier <= 2 ? 6 : 0);
+
+// isSlotLocked: from Inventory.make's per-tier slot arrays. Accessible (0) locks
+// nothing; Realistic (1) and Hardcore (2) lock the last two slots (idx 4, 5).
+const isSlotLocked = (tier, idx) => {
+  if (tier < 0 || tier > 2) return 0;
+  if (idx < 0 || idx > 5) return 0;
+  if (tier === 0) return 0;
+  return idx >= 4 ? 1 : 0;
+};
+
+// findEmptySlot: first EMPTY (digit 0) slot in 0..count-1, else -1 (mirrors
+// findEmptySlot's first None-and-unlocked search; a LOCKED or FILLED digit is
+// skipped just as a locked or occupied ReScript slot is).
+const findEmptySlot = (packed, count) => {
+  for (let k = 0; k < count; k++) {
+    if (digitAt(packed, k) === 0) return k;
+  }
+  return -1;
+};
+
+// filledCount: digits equal to FILLED (getFilledCount = filter Option.isSome).
+const filledCount = (packed, count) => {
+  let n = 0;
+  for (let k = 0; k < count; k++) if (digitAt(packed, k) === 1) n++;
+  return n;
+};
+
+// unlockedCount: digits not equal to LOCKED (getUnlockedCount = filter !locked;
+// EMPTY and FILLED are both unlocked).
+const unlockedCount = (packed, count) => {
+  let n = 0;
+  for (let k = 0; k < count; k++) if (digitAt(packed, k) !== 2) n++;
+  return n;
+};
+
+// fitsWeight: negation of Inventory.addItem's tooHeavy test
+// (totalWeight +. item.weight > maxWeight), in milli-kg.
+const fitsWeight = (total, item, max) => (total + item > max ? 0 : 1);
+
+// canAdd: full addItem eligibility = fits by weight AND an empty slot exists.
+const canAdd = (packed, count, total, item, max) =>
+  fitsWeight(total, item, max) === 1 && findEmptySlot(packed, count) !== -1 ? 1 : 0;
+
+export default {
+  affine: "Inventory.affine",
+  cases: [
+    {
+      name: "slot_count over tier [-2..5]",
+      export: "slot_count",
+      args: [[-2, 5]],
+      oracle: (tier) => slotCount(tier),
+    },
+    {
+      name: "is_slot_locked over tier [-1..4] x idx [-1..7]",
+      export: "is_slot_locked",
+      args: [[-1, 4], [-1, 7]],
+      oracle: (tier, idx) => isSlotLocked(tier, idx),
+    },
+    {
+      name: "find_empty_slot over packed [0..120] x count [0..6]",
+      export: "find_empty_slot",
+      args: [[0, 120], [0, 6]],
+      oracle: (packed, count) => findEmptySlot(packed, count),
+    },
+    {
+      name: "filled_count over packed [0..120] x count [0..6]",
+      export: "filled_count",
+      args: [[0, 120], [0, 6]],
+      oracle: (packed, count) => filledCount(packed, count),
+    },
+    {
+      name: "unlocked_count over packed [0..120] x count [0..6]",
+      export: "unlocked_count",
+      args: [[0, 120], [0, 6]],
+      oracle: (packed, count) => unlockedCount(packed, count),
+    },
+    {
+      name: "remaining_capacity over max [0..3000 step] x total [0..3000 step]",
+      export: "remaining_capacity",
+      args: [{ values: [0, 500, 1500, 3000, 3200] }, { values: [0, 150, 1500, 3000, 3500] }],
+      oracle: (max, total) => max - total,
+    },
+    {
+      name: "add_weight over acc [0..3000] x item [0..500]",
+      export: "add_weight",
+      args: [{ values: [0, 150, 1500, 2850, 3000] }, { values: [0, 20, 100, 150, 500] }],
+      oracle: (acc, item) => acc + item,
+    },
+    {
+      name: "fits_weight over total x item x max (milli-kg)",
+      export: "fits_weight",
+      args: [
+        { values: [0, 1500, 2850, 3000, 3001] },
+        { values: [0, 20, 150, 200, 1000] },
+        { values: [3000] },
+      ],
+      oracle: (total, item, max) => fitsWeight(total, item, max),
+    },
+    {
+      name: "can_add over packed x count x total x item x max",
+      export: "can_add",
+      args: [
+        { values: [0, 1, 2, 13, 26, 121] },
+        { values: [0, 3, 6] },
+        { values: [0, 2850, 3000] },
+        { values: [0, 150, 200] },
+        { values: [3000] },
+      ],
+      oracle: (packed, count, total, item, max) => canAdd(packed, count, total, item, max),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/PasswordCracker/PasswordCracker.affine
+++ b/proposals/idaptik/migrated/PasswordCracker/PasswordCracker.affine
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// PasswordCracker -- the pure crack-SCORING kernel re-decomposed from
+// src/app/tools/PasswordCracker.res. The ReScript original entangles five
+// things: a STRING wordlist (commonPasswords), a STRING-keyed dictionary walk
+// (simpleHash over each candidate, compared to a target), a non-deterministic
+// draw (Math.random()), per-security-level difficulty FORMULAE, and STRING
+// rendering of the verdict. Per the DESIGN-VISION ("AffineScript is the brain,
+// JS/Pixi the senses; only primitives cross the wasm boundary"), neither the
+// wordlist nor the strings are the unit of migration -- they stay host-side. The
+// host owns every string: it walks the wordlist, reads each character's code
+// (via string_char_code_at, which is sound), and feeds the integer code points
+// to this kernel. What crosses is the deterministic INTEGER ARITHMETIC: the djb2
+// hash recurrence, the low-16-bit brute-force mask, the difficulty numbers, and
+// the brute-force success verdict. The kernel is stateless and total.
+//
+//## Why this split, not a port of simpleHash/dictionaryAttack
+// simpleHash iterates a STRING; the loop body is the only arithmetic. We invert
+// the control: the brain exposes the seed and the per-character STEP, and the
+// HOST runs the loop (it holds the string and reads the char codes). This is the
+// same brain/senses inversion Random.affine uses for xmur3 -- the string walk is
+// a sense, the i32 mixing is the brain. dictionaryAttack's hash compare, the
+// Math.random() draw, and the "cr4ck3d_" string concat are senses; the
+// difficulty tables and the verdict comparison are the brain.
+//
+//## The djb2 recurrence (the header contract for the JS host)
+// ReScript simpleHash:  hash := 5381; for each char c: hash := hash*33 + c.
+// The host calls hash_seed() once, then folds each char code through hash_step.
+// NOTE on i32 semantics: in this wasm backend `*` is i32.mul (32-bit truncating
+// multiply, == JS Math.imul) and `+` wraps at i32, so hash_step is the i32-exact
+// djb2 step. The ReScript path uses unbounded JS numbers and only the bridge
+// (hash_step) is i32; the two agree wherever the bridge is the source of truth,
+// which is exactly when the co-processor flag is ON. The masked brute-force
+// value (mask_low16) reads only the low 16 bits, so it is identical either way.
+//
+//## Difficulty bands (the header contract for the JS host)
+// Security-level ordinal (PasswordCracker.res securityLevelOrdinal):
+//   0 Open   1 Weak   2 Medium   3 Strong
+//   max_attempts:    Open 5     Weak 50    Medium 500   Strong 5000
+//   success_chance:  MILLI-units (×1000 of the .res Float): 950 / 800 / 400 / 50
+//   time_per_attempt: whole ms (the .res Floats are integral): 100 / 200 / 500 / 1000
+// An out-of-band ordinal yields 0 for every field -- the neutral "no attempts,
+// no chance, no time" reading, never a fabricated in-band figure.
+//
+//## Brute-force verdict (the header contract for the JS host)
+// ReScript fallback: succeeds := roll < successChance *. 0.3, where roll is the
+// Math.random() draw in [0,1). The host pre-floors the draw to MILLI-units
+// (roll_milli = floor(roll*1000), 0..999) and passes it plus the level ordinal.
+// To compare without fractions we scale both sides by 10:
+//   roll < sc*0.3   <=>   roll_milli < sc_milli*0.3   <=>   roll_milli*10 < sc_milli*3
+// crack_succeeds returns 1 when the draw beats the scaled chance, else 0. The
+// strict `<` matches the ReScript exactly (a draw on the boundary fails).
+
+//## djb2 seed: the initial accumulator. ReScript: ref(5381).
+pub fn hash_seed() -> Int { 5381 }
+
+//## djb2 step: fold one character code `c` into the accumulator `acc`.
+// ReScript: hash := hash*33 + c. `*` is i32.mul and `+` wraps at i32, so this is
+// the i32-exact djb2 recurrence the bridge folds the host's char codes through.
+pub fn hash_step(acc: Int, c: Int) -> Int {
+  acc * 33 + c
+}
+
+//## The brute-force masked value: the low 16 bits of a target hash.
+// ReScript: Int.Bitwise.land(targetHash, 0xFFFF). `&` is i32.and; masking the
+// low 16 bits always yields 0..65535 regardless of the input's sign.
+pub fn mask_low16(h: Int) -> Int {
+  h & 0xFFFF
+}
+
+//## max_attempts per security ordinal (0..3). Out-of-band -> 0.
+pub fn max_attempts(level: Int) -> Int {
+  if level == 0 { return 5; }      // Open
+  if level == 1 { return 50; }     // Weak
+  if level == 2 { return 500; }    // Medium
+  if level == 3 { return 5000; }   // Strong
+  0
+}
+
+//## success_chance per security ordinal, in MILLI-units (×1000). Out-of-band->0.
+// .res Floats 0.95 / 0.80 / 0.40 / 0.05 -> 950 / 800 / 400 / 50.
+pub fn success_chance(level: Int) -> Int {
+  if level == 0 { return 950; }    // Open   (0.95)
+  if level == 1 { return 800; }    // Weak   (0.80)
+  if level == 2 { return 400; }    // Medium (0.40)
+  if level == 3 { return 50; }     // Strong (0.05)
+  0
+}
+
+//## time_per_attempt per security ordinal, in whole milliseconds. Out-of-band->0.
+// .res Floats 100.0 / 200.0 / 500.0 / 1000.0 -> integral ms.
+pub fn time_per_attempt(level: Int) -> Int {
+  if level == 0 { return 100; }    // Open
+  if level == 1 { return 200; }    // Weak
+  if level == 2 { return 500; }    // Medium
+  if level == 3 { return 1000; }   // Strong
+  0
+}
+
+//## Brute-force success verdict: 1 if the draw beats the scaled chance, else 0.
+// ReScript: roll < successChance *. 0.3, with roll the Math.random() draw. In
+// milli-units, scaled by 10 to stay integral: roll_milli*10 < sc_milli*3.
+// success_chance(level) supplies sc_milli (0 off-band, so the test is never met
+// for an unknown level -- a conservative "did not crack").
+pub fn crack_succeeds(roll_milli: Int, level: Int) -> Int {
+  let sc_milli = success_chance(level);
+  if roll_milli * 10 < sc_milli * 3 { return 1; }
+  0
+}

--- a/proposals/idaptik/migrated/PasswordCracker/passwordcracker.config.mjs
+++ b/proposals/idaptik/migrated/PasswordCracker/passwordcracker.config.mjs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for PasswordCracker.affine (idaptik crack-scoring kernel;
+// scalar i32 ABI). The oracles re-derive the djb2 recurrence, the low-16 mask,
+// the difficulty tables, and the brute-force verdict independently from
+// PasswordCracker.res in plain JS, so a codegen regression surfaces as a
+// differential mismatch.
+//
+// i32 NOTE: the wasm `*` is i32.mul (== Math.imul) and `+` wraps at i32, so the
+// oracle's hash_step uses Math.imul and `| 0` to model the same 32-bit truncation
+// the kernel performs. (The ReScript simpleHash uses unbounded JS numbers; the
+// bridge's hash_step is the i32 source of truth, and that is what the kernel
+// reproduces and what this oracle checks.)
+//
+// Difficulty bands (securityLevelOrdinal 0 Open .. 3 Strong):
+//   max_attempts:     5 / 50 / 500 / 5000
+//   success_chance:   MILLI-units of the .res Float 0.95/0.80/0.40/0.05 = 950/800/400/50
+//   time_per_attempt: whole ms of 100.0/200.0/500.0/1000.0 = 100/200/500/1000
+//   off-band -> 0 for every field.
+// Verdict crack_succeeds(roll_milli, level): the .res `roll < successChance*0.3`
+// in milli, scaled by 10 to stay integral: roll_milli*10 < sc_milli*3.
+
+// --- independent reimplementations from PasswordCracker.res ---
+
+function hashSeed() {
+  return 5381; // .res: ref(5381)
+}
+
+function hashStep(acc, c) {
+  // .res: hash := hash*33 + c. The kernel does this with i32.mul + i32 wrap, so
+  // model it with Math.imul and final | 0.
+  return (Math.imul(acc, 33) + c) | 0;
+}
+
+function maskLow16(h) {
+  // .res: Int.Bitwise.land(targetHash, 0xFFFF)
+  return (h | 0) & 0xffff;
+}
+
+function maxAttempts(level) {
+  switch (level) {
+    case 0: return 5;
+    case 1: return 50;
+    case 2: return 500;
+    case 3: return 5000;
+    default: return 0;
+  }
+}
+
+function successChanceMilli(level) {
+  // .res success chances 0.95/0.80/0.40/0.05 -> milli.
+  switch (level) {
+    case 0: return Math.round(0.95 * 1000); // 950
+    case 1: return Math.round(0.80 * 1000); // 800
+    case 2: return Math.round(0.40 * 1000); // 400
+    case 3: return Math.round(0.05 * 1000); // 50
+    default: return 0;
+  }
+}
+
+function timePerAttempt(level) {
+  switch (level) {
+    case 0: return 100;
+    case 1: return 200;
+    case 2: return 500;
+    case 3: return 1000;
+    default: return 0;
+  }
+}
+
+function crackSucceeds(rollMilli, level) {
+  // .res: roll < successChance *. 0.3. Scale by 10 to keep integral:
+  // roll_milli*10 < sc_milli*3.
+  const sc = successChanceMilli(level);
+  return rollMilli * 10 < sc * 3 ? 1 : 0;
+}
+
+// Representative inputs. Char codes span the printable-ASCII band passwords use
+// (plus a couple of extremes); accumulators include values that force i32 wrap.
+const CHAR_CODES = [0, 32, 45, 48, 57, 65, 90, 97, 122, 126, 255, 1000, 65535];
+const ACC_VALUES = [5381, 0, 1, 12345, 2000000000, -2000000000, 178956970];
+// roll in [0,1) -> milli draws 0..999, plus the band edges that straddle each
+// scaled threshold (sc*0.3 = 285 / 240 / 120 / 15).
+const ROLL_VALUES = [
+  0, 14, 15, 16, 119, 120, 121, 239, 240, 241, 284, 285, 286, 500, 950, 999,
+];
+const LEVELS = [-1, 0, 1, 2, 3, 4];
+
+export default {
+  affine: "PasswordCracker.affine",
+  cases: [
+    {
+      name: "hash_seed()",
+      export: "hash_seed",
+      args: [],
+      oracle: () => hashSeed(),
+    },
+    {
+      name: "hash_step(acc, c) over i32-wrapping accs x char codes",
+      export: "hash_step",
+      args: [{ values: ACC_VALUES }, { values: CHAR_CODES }],
+      oracle: (acc, c) => hashStep(acc, c),
+    },
+    {
+      name: "mask_low16(h) over a spread of i32 hashes",
+      export: "mask_low16",
+      args: [{ values: [0, 1, 0xffff, 0x10000, 0x12345, -1, -65536, 2000000000, -2000000000] }],
+      oracle: (h) => maskLow16(h),
+    },
+    {
+      name: "max_attempts over levels [-1..4]",
+      export: "max_attempts",
+      args: [{ values: LEVELS }],
+      oracle: (l) => maxAttempts(l),
+    },
+    {
+      name: "success_chance (milli) over levels [-1..4]",
+      export: "success_chance",
+      args: [{ values: LEVELS }],
+      oracle: (l) => successChanceMilli(l),
+    },
+    {
+      name: "time_per_attempt over levels [-1..4]",
+      export: "time_per_attempt",
+      args: [{ values: LEVELS }],
+      oracle: (l) => timePerAttempt(l),
+    },
+    {
+      name: "crack_succeeds(roll_milli, level) across thresholds",
+      export: "crack_succeeds",
+      args: [{ values: ROLL_VALUES }, { values: LEVELS }],
+      oracle: (r, l) => crackSucceeds(r, l),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/PortScanner/PortScanner.affine
+++ b/proposals/idaptik/migrated/PortScanner/PortScanner.affine
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// PortScanner -- the pure port-scan classification kernel re-decomposed from
+// src/app/tools/PortScanner.res. The ReScript original entangles four things: a
+// well-known-service STRING table (port/protocol/service/version records), a
+// per-device open-port SELECTION over that table, the numeric scan totals
+// (open / closed / filtered counts), and a simulated wall-clock DELAY. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only primitives
+// cross the wasm boundary"), the service records and their strings are NOT the
+// unit of migration -- they never become integers and stay host-side. What
+// crosses is the deterministic ARITHMETIC the scan reports: how many ports a
+// given device kind opens, the closed-port complement, and the filtered count
+// and delay a security level implies. The kernel is stateless and total: every
+// Int the boundary admits yields a defined Int, never a trap.
+//
+//## Why this split, not a port of getOpenPorts/scan
+// getOpenPorts builds an array of serviceInfo records (strings inside) keyed by
+// device type; `scan` reads Date.now() twice and routes the totals. The record
+// array and the clock are senses. The arithmetic that remains -- the open-port
+// COUNT per device, the closed complement, and the filtered/delay tables per
+// security level -- is what the co-processor owns. The host reconstructs the
+// openPorts record array itself (it owns the string table); it asks the brain
+// only for the four numbers `scan` puts in the scanResult.
+//
+//## Device-type encoding (the header contract for the JS host)
+// The host passes the device-type id in DeviceTypes.deviceType *bridge* order
+// (PortScannerCoprocessorBridge.js DEVICE_TYPE), NOT the shared DeviceType.res
+// order. The two differ; this kernel speaks the bridge's eight-id band:
+//   0 Laptop    2 Server     4 Terminal      6 UPS
+//   1 Router    3 IotCamera  5 PowerStation  7 Firewall
+// The open-port COUNTS are the lengths of getOpenPorts' filtered arrays:
+//   Laptop 1, Router 2, Server 3, IotCamera 2, Terminal 1,
+//   PowerStation 2, UPS 2, Firewall 3.
+// An id outside 0..7 is not a known device kind: open_port_count returns the
+// safe default 0 (no in-band count is fabricated for an unknown device), so the
+// closed count is the full 65535 -- the conservative "we saw nothing open"
+// reading, never a trap.
+//
+//## Security-level encoding (the header contract for the JS host)
+// Security-level id in DeviceTypes.securityLevel order (also the bridge's
+// SECURITY_LEVEL order -- they agree):
+//   0 Open   1 Weak   2 Medium   3 Strong
+// filtered_port_count: Open 0, Weak 100, Medium 500, Strong 2000.
+// scan_delay_ms: Open 50, Weak 200, Medium 500, Strong 1500. The ReScript
+// delays are Floats (50.0 ..) but are whole milliseconds, so they cross as raw
+// Int -- no milli-scaling needed (a delay is already an integer count of ms).
+// An out-of-band level yields 0 for both (no delay, no filtering) -- the
+// neutral identity, never a fabricated in-band figure.
+
+//## Open-port count per device-type id (bridge DEVICE_TYPE order)
+// Flat guarded returns mirroring getOpenPorts' array lengths. Unknown id -> 0.
+pub fn open_port_count(dev: Int) -> Int {
+  if dev == 0 { return 1; }   // Laptop      -> [ssh]
+  if dev == 1 { return 2; }   // Router      -> [ssh, http]
+  if dev == 2 { return 3; }   // Server      -> [ssh, http, https]
+  if dev == 3 { return 2; }   // IotCamera   -> [http, rtsp]
+  if dev == 4 { return 1; }   // Terminal    -> [ssh]
+  if dev == 5 { return 2; }   // PowerStation-> [snmp, http]
+  if dev == 6 { return 2; }   // UPS         -> [snmp, http]
+  if dev == 7 { return 3; }   // Firewall    -> [ssh, http, https]
+  0
+}
+
+//## Closed-port count for a device-type id.
+// ReScript: 65535 - Array.length(openPorts). Derived from open_port_count so
+// the complement is consistent by construction. Unknown id -> 65535 (open=0).
+pub fn closed_port_count(dev: Int) -> Int {
+  65535 - open_port_count(dev)
+}
+
+//## Filtered-port count for a security-level id (0..3). Unknown -> 0.
+pub fn filtered_port_count(sec: Int) -> Int {
+  if sec == 0 { return 0; }      // Open
+  if sec == 1 { return 100; }    // Weak
+  if sec == 2 { return 500; }    // Medium
+  if sec == 3 { return 2000; }   // Strong
+  0
+}
+
+//## Simulated scan delay in whole milliseconds for a security-level id (0..3).
+// The ReScript values are Float but integral milliseconds, so they cross as raw
+// Int. Unknown level -> 0 (no simulated delay).
+pub fn scan_delay_ms(sec: Int) -> Int {
+  if sec == 0 { return 50; }     // Open
+  if sec == 1 { return 200; }    // Weak
+  if sec == 2 { return 500; }    // Medium
+  if sec == 3 { return 1500; }   // Strong
+  0
+}

--- a/proposals/idaptik/migrated/PortScanner/portscanner.config.mjs
+++ b/proposals/idaptik/migrated/PortScanner/portscanner.config.mjs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for PortScanner.affine (idaptik port-scan classifier;
+// scalar i32 ABI). The oracles re-derive the four scan figures independently
+// from PortScanner.res in plain JS, so a codegen regression surfaces as a
+// differential mismatch.
+//
+// Device-type ids are PortScannerCoprocessorBridge.js DEVICE_TYPE order:
+//   0 Laptop 1 Router 2 Server 3 IotCamera 4 Terminal 5 PowerStation 6 UPS 7 Firewall
+// The open-port counts are the lengths of getOpenPorts' filtered arrays in the
+// .res: Server/Firewall map [ssh,http,https] (3); Router [ssh,http] (2);
+// IotCamera [http,rtsp] (2); PowerStation/UPS [snmp,http] (2); Laptop/Terminal
+// [ssh] (1). Anything off-band -> 0 (host saw nothing open).
+//
+// Security-level ids are DeviceTypes.securityLevel order (= bridge order):
+//   0 Open 1 Weak 2 Medium 3 Strong
+// filtered: 0/100/500/2000; delay(ms): 50/200/500/1500. Off-band -> 0.
+
+// Independent reimplementation: open ports per bridge device id (NOT the kernel).
+function openPorts(dev) {
+  switch (dev) {
+    case 0: return 1; // Laptop
+    case 1: return 2; // Router
+    case 2: return 3; // Server
+    case 3: return 2; // IotCamera (http + rtsp)
+    case 4: return 1; // Terminal
+    case 5: return 2; // PowerStation (snmp + http)
+    case 6: return 2; // UPS (snmp + http)
+    case 7: return 3; // Firewall
+    default: return 0;
+  }
+}
+function closedPorts(dev) {
+  return 65535 - openPorts(dev);
+}
+function filteredPorts(sec) {
+  switch (sec) {
+    case 0: return 0;    // Open
+    case 1: return 100;  // Weak
+    case 2: return 500;  // Medium
+    case 3: return 2000; // Strong
+    default: return 0;
+  }
+}
+function scanDelayMs(sec) {
+  // .res Floats 50.0/200.0/500.0/1500.0 -> whole ms integers.
+  switch (sec) {
+    case 0: return 50;
+    case 1: return 200;
+    case 2: return 500;
+    case 3: return 1500;
+    default: return 0;
+  }
+}
+
+export default {
+  affine: "PortScanner.affine",
+  cases: [
+    {
+      name: "open_port_count over device ids [-2..10]",
+      export: "open_port_count",
+      args: [[-2, 10]],
+      oracle: (dev) => openPorts(dev),
+    },
+    {
+      name: "closed_port_count over device ids [-2..10]",
+      export: "closed_port_count",
+      args: [[-2, 10]],
+      oracle: (dev) => closedPorts(dev),
+    },
+    {
+      name: "filtered_port_count over security ids [-2..6]",
+      export: "filtered_port_count",
+      args: [[-2, 6]],
+      oracle: (sec) => filteredPorts(sec),
+    },
+    {
+      name: "scan_delay_ms over security ids [-2..6]",
+      export: "scan_delay_ms",
+      args: [[-2, 6]],
+      oracle: (sec) => scanDelayMs(sec),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/SecurityDog/SecurityDog.affine
+++ b/proposals/idaptik/migrated/SecurityDog/SecurityDog.affine
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// SecurityDog -- the pure-integer decision core for the guard-dog / robo-dog
+// enemies, re-decomposed from src/app/enemies/SecurityDog.res. A SecurityDog is
+// either a biological GuardDog (omnidirectional scent, food-distractible, barks)
+// or a RoboDog (camera+IR cone, hackable, EMP-vulnerable, battery-limited). Each
+// frame the dog detects the player, runs an 8-state machine (Patrol -> Track ->
+// Bark -> ...) and answers a handful of interaction gates (distract / EMP / hack
+// / stomp).
+//
+// Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), every SENSE stays host-side: the Pixi
+// Container/Graphics, the SafeAngle.fromAtan2 trigonometry, the Math.sqrt
+// distance, all float positions/timers/suspicion, the waypoint array, the
+// device-id string, the FeaturePacks flag and the async coprocessor handle. The
+// brain owns only the deterministic DECISIONS -- no strings, no arrays, no
+// floats, no promises, no module-level mutable state cross the boundary.
+//
+// FLOAT BOUNDARY (rule: floors stay host-side). The host computes the float
+// geometry (distance via sqrt, target angle via atan2, the per-frame timer
+// accumulation) and floors each to integer milli-units before calling the brain:
+//   * distances / ranges  -> milli-pixels  (pixels  x 1000)
+//   * angles              -> milli-radians (radians x 1000)
+//   * timers / durations  -> milliseconds  (seconds x 1000)
+//   * scent strength       -> milli-units   (0..1000, where 1000 == 1.0)
+// Detection-model ranges are integer-valued in the source (180, 200, 120, ...),
+// so they are returned directly in milli-pixels; only the runtime distance and
+// angle are floored by the host. Every comparison and the strength formula then
+// run in exact integer arithmetic, byte-identical to the ReScript float compares
+// at the floored resolution.
+//
+//## Variant encoding (header contract)         ## State encoding
+//   0  GuardDog                                    0  Patrolling
+//   1  RoboDog                                      1  Tracking
+// out-of-band -> -1                                 2  Barking
+//                                                   3  Distracted
+//## Facing encoding                                 4  Investigating
+//   0  Left   1  Right                              5  Returning
+//                                                   6  Disabled
+//## Detection-result encoding                       7  Stunned
+//   0  NotDetected                              out-of-band -> -1
+//   1  ScentDetected (carries strength out-of-band, see detect_guarddog)
+//   2  VisualDetected
+//   3  HeardMovement
+
+// ---------------------------------------------------------------------------
+// Closed-band validity (every code below is a contiguous enum; the host can
+// never address a phantom variant / state / result).
+// ---------------------------------------------------------------------------
+
+pub fn variant_count() -> Int { 2 }
+pub fn state_count() -> Int { 8 }
+pub fn detection_count() -> Int { 4 }
+
+fn valid_variant(v: Int) -> Int {
+  if v < 0 { return 0; }
+  if v > 1 { return 0; }
+  1
+}
+
+fn valid_state(s: Int) -> Int {
+  if s < 0 { return 0; }
+  if s > 7 { return 0; }
+  1
+}
+
+// ---------------------------------------------------------------------------
+// Detection-model range table (detectionModel constants, in milli-pixels and
+// milli-radians). guardDogDetection / roboDogDetection are fixed records; the
+// brain returns each field so the host need not hardcode the magic numbers.
+// An out-of-band variant returns the out-of-band sentinel -1.
+// ---------------------------------------------------------------------------
+
+// scentRange: GuardDog 180000, RoboDog 0 (no scent).
+pub fn scent_range_mu(variant: Int) -> Int {
+  if valid_variant(variant) == 0 { return -1; }
+  if variant == 0 { return 180000; }
+  0
+}
+
+// cameraRange: GuardDog 0, RoboDog 200000.
+pub fn camera_range_mu(variant: Int) -> Int {
+  if valid_variant(variant) == 0 { return -1; }
+  if variant == 1 { return 200000; }
+  0
+}
+
+// cameraHalfAngle: GuardDog 0, RoboDog 500 milli-rad (~0.5 rad).
+pub fn camera_half_angle_mu(variant: Int) -> Int {
+  if valid_variant(variant) == 0 { return -1; }
+  if variant == 1 { return 500; }
+  0
+}
+
+// irRange: GuardDog 0, RoboDog 120000.
+pub fn ir_range_mu(variant: Int) -> Int {
+  if valid_variant(variant) == 0 { return -1; }
+  if variant == 1 { return 120000; }
+  0
+}
+
+// hearingRange: GuardDog 200000, RoboDog 150000.
+pub fn hearing_range_mu(variant: Int) -> Int {
+  if valid_variant(variant) == 0 { return -1; }
+  if variant == 0 { return 200000; }
+  150000
+}
+
+// movementSpeed: GuardDog 75000, RoboDog 55000 (milli-pixels / second). The make
+// constructor's per-variant speed; the host scales by dt host-side.
+pub fn speed_mu(variant: Int) -> Int {
+  if valid_variant(variant) == 0 { return -1; }
+  if variant == 0 { return 75000; }
+  55000
+}
+
+// ---------------------------------------------------------------------------
+// Scent strength (GuardDog ScentDetected payload): 1.0 - distance/scentRange,
+// in milli-units (0..1000). distance_mu and range_mu share milli-pixel units.
+// Clamped to [0, 1000]; a non-positive range (only the no-scent RoboDog) yields
+// 0. Guarded so a degenerate input can never produce an out-of-band strength.
+// ---------------------------------------------------------------------------
+pub fn scent_strength_milli(distance_mu: Int, range_mu: Int) -> Int {
+  if range_mu <= 0 { return 0; }
+  if distance_mu < 0 { return 1000; }
+  if distance_mu >= range_mu { return 0; }
+  let s = 1000 - (distance_mu * 1000) / range_mu;
+  if s < 0 { return 0; }
+  if s > 1000 { return 1000; }
+  s
+}
+
+// ---------------------------------------------------------------------------
+// Angle normalisation (RoboDog camera cone): fold an absolute angle difference
+// into [0, pi]. Mirrors `if angleDiff > pi { 2*pi - angleDiff } else angleDiff`,
+// in milli-radians. pi ~= 3141 mrad, 2*pi ~= 6283 mrad (the host passes these so
+// the brain carries no float literals). A negative difference is folded to 0.
+// ---------------------------------------------------------------------------
+pub fn angle_norm_mu(angle_diff_mu: Int, pi_mu: Int, two_pi_mu: Int) -> Int {
+  if angle_diff_mu < 0 { return 0; }
+  if angle_diff_mu > pi_mu { return two_pi_mu - angle_diff_mu; }
+  angle_diff_mu
+}
+
+// Effective camera range under crouch: cameraRange * 0.5 when crouching, else
+// cameraRange (in milli-pixels). crouching is a 1/0 flag.
+pub fn effective_camera_range_mu(camera_range_mu_in: Int, crouching: Int) -> Int {
+  if camera_range_mu_in < 0 { return -1; }
+  if crouching != 0 { return camera_range_mu_in / 2; }
+  camera_range_mu_in
+}
+
+// ---------------------------------------------------------------------------
+// detectPlayer -- the detection classifier. Returns the detection-result code
+// (0 NotDetected, 1 ScentDetected, 2 VisualDetected, 3 HeardMovement). The host
+// has already computed and floored the distance and, for RoboDog, the normalised
+// cone angle and effective range. The guard early-out (Disabled/Stunned/
+// Distracted -> NotDetected) is the host's responsibility before calling, but is
+// also defended here via the state argument so the kernel is self-contained.
+//
+//   state          current dog state ordinal (0..7)
+//   variant        0 GuardDog / 1 RoboDog
+//   distance_mu    floored player distance, milli-pixels
+//   sprinting      1/0 player sprinting (loud)
+//   norm_angle_mu  RoboDog: folded cone angle (milli-rad); ignored for GuardDog
+//   eff_range_mu   RoboDog: crouch-adjusted camera range (milli-pixels)
+// The per-variant range constants are read from the tables above internally, so
+// the host passes only the runtime-computed distance/angle and the flags.
+// ---------------------------------------------------------------------------
+pub fn detect_class(state: Int, variant: Int, distance_mu: Int, sprinting: Int, norm_angle_mu: Int, eff_range_mu: Int) -> Int {
+  if valid_variant(variant) == 0 { return 0; }
+  // Disabled (6), Stunned (7), Distracted (3) never detect.
+  if state == 6 { return 0; }
+  if state == 7 { return 0; }
+  if state == 3 { return 0; }
+
+  if variant == 0 {
+    // GuardDog: omnidirectional scent, then hearing of a sprinter.
+    let scent = scent_range_mu(0);
+    let hearing = hearing_range_mu(0);
+    if distance_mu < scent { return 1; }
+    if sprinting != 0 {
+      if distance_mu < hearing { return 3; }
+    }
+    return 0;
+  }
+
+  // RoboDog: camera cone, then omnidirectional IR, then hearing.
+  let half = camera_half_angle_mu(1);
+  let ir = ir_range_mu(1);
+  let hearing = hearing_range_mu(1);
+  if norm_angle_mu < half {
+    if distance_mu < eff_range_mu { return 2; }
+  }
+  if distance_mu < ir { return 2; }
+  if sprinting != 0 {
+    if distance_mu < hearing { return 3; }
+  }
+  0
+}
+
+// ---------------------------------------------------------------------------
+// State machine. next_state encodes updateState's transition table: given the
+// current state, the detection-result class just produced, and the floored
+// timers/distances the arm consults, it returns the next state ordinal. Pure
+// integer thresholds; the host owns the movement integration and the float
+// suspicion decay.
+//
+//   state          current state ordinal (0..7)
+//   detection      detection-result class (0..3) from detect_class
+//   strength_milli ScentDetected strength (0..1000); 0 when not scent
+//   dist_to_target_mu  |targetX - dogX| toward the tracked point, milli-pixels
+//   bark_timer_ms      ms spent in the current Barking burst
+//   pause_timer_ms     ms accumulated at an Investigating/Returning hold
+//   has_target         1/0 whether lastScentX is set (Some vs None)
+//
+// Threshold provenance (SecurityDog.res updateState):
+//   Patrolling: scent strength > 0.3 (300 milli) -> Tracking;
+//               VisualDetected -> Barking; HeardMovement -> Investigating.
+//   Tracking:   dist < 30px (30000 mu) -> Barking; lost target -> Returning.
+//   Barking:    barkTimer >= 4s (4000 ms) -> Tracking.
+//   Investigating: dist < 10px (10000) and pause >= 2.5s (2500) -> Returning;
+//               scent s > 0.4 (400) -> Tracking; Visual -> Barking; lost -> Returning.
+//   Returning:  dist < 5px (5000) -> Patrolling.
+//   Disabled/Stunned: absorbing (host clears them via EMP/hack/battery/stomp).
+// ---------------------------------------------------------------------------
+pub fn next_state(state: Int, detection: Int, strength_milli: Int, dist_to_target_mu: Int, bark_timer_ms: Int, pause_timer_ms: Int, has_target: Int) -> Int {
+  if valid_state(state) == 0 { return -1; }
+
+  // Patrolling (0)
+  if state == 0 {
+    if detection == 1 {
+      if strength_milli > 300 { return 1; }
+      return 0;
+    }
+    if detection == 2 { return 2; }
+    if detection == 3 { return 4; }
+    return 0;
+  }
+
+  // Tracking (1)
+  if state == 1 {
+    if has_target == 0 { return 5; }
+    if dist_to_target_mu < 30000 { return 2; }
+    return 1;
+  }
+
+  // Barking (2)
+  if state == 2 {
+    if bark_timer_ms >= 4000 { return 1; }
+    return 2;
+  }
+
+  // Distracted (3): the host's distraction timer drives the exit; the brain
+  // holds the state until the host signals expiry (distraction_expired).
+  if state == 3 { return 3; }
+
+  // Investigating (4)
+  if state == 4 {
+    if has_target == 0 { return 5; }
+    if detection == 1 {
+      if strength_milli > 400 { return 1; }
+    }
+    if detection == 2 { return 2; }
+    if dist_to_target_mu < 10000 {
+      if pause_timer_ms >= 2500 { return 5; }
+    }
+    return 4;
+  }
+
+  // Returning (5)
+  if state == 5 {
+    if dist_to_target_mu < 5000 { return 0; }
+    return 5;
+  }
+
+  // Disabled (6) / Stunned (7): absorbing.
+  state
+}
+
+// Distraction-timer expiry: the Distracted state exits to Returning (5) when the
+// host's floored distraction timer has run out (<= 0 ms remaining), else holds.
+pub fn distraction_expired(state: Int, distract_timer_ms: Int) -> Int {
+  if state != 3 { return state; }
+  if distract_timer_ms <= 0 { return 5; }
+  3
+}
+
+// ---------------------------------------------------------------------------
+// RoboDog pre-state early exits (updateState's leading guards). Returns the
+// forced state when an exit fires, else -1 meaning "no early exit, run the main
+// machine". empActive / hacked / batteryEmpty are 1/0 flags the host derives
+// from its float empTimer / hacked bool / batteryLevel.
+//   empActive   -> Stunned (7); when it has just expired the host passes
+//                  emp_just_expired=1 to flip to Returning (5) instead.
+//   hacked      -> Disabled (6).
+//   batteryEmpty-> Disabled (6).
+// ---------------------------------------------------------------------------
+pub fn robodog_early_exit(variant: Int, emp_active: Int, emp_just_expired: Int, hacked: Int, battery_empty: Int) -> Int {
+  if variant != 1 { return -1; }
+  if emp_active != 0 {
+    if emp_just_expired != 0 { return 5; }
+    return 7;
+  }
+  if hacked != 0 { return 6; }
+  if battery_empty != 0 { return 6; }
+  -1
+}
+
+// ---------------------------------------------------------------------------
+// Interaction gates. Each returns 1 (action succeeds) or 0 (refused), mirroring
+// the bool returns in SecurityDog.res. The host supplies the floored distance
+// and the variant/state; no float or string crosses.
+// ---------------------------------------------------------------------------
+
+// distractWithFood: GuardDog only, not Disabled(6)/Stunned(7), food within
+// scent range. 1 = the dog takes the food (host then sets Distracted + timer).
+pub fn can_distract(variant: Int, state: Int, food_dist_mu: Int) -> Int {
+  if variant != 0 { return 0; }
+  if state == 6 { return 0; }
+  if state == 7 { return 0; }
+  let scent = scent_range_mu(0);
+  if food_dist_mu < scent { return 1; }
+  0
+}
+
+// applyEMP: RoboDog only, not already Disabled(6). 1 = EMP lands (host sets
+// Stunned + empTimer).
+pub fn can_emp(variant: Int, state: Int) -> Int {
+  if variant != 1 { return 0; }
+  if state == 6 { return 0; }
+  1
+}
+
+// hackTick: RoboDog only, not already hacked. Given the floored cumulative hack
+// progress in milli-units (0..1000, where the host advances by ~dt*100/s), 1 =
+// the hack completed this tick (progress reached 1000 -> Disabled), 0 = still in
+// progress / refused.
+pub fn hack_complete(variant: Int, hacked: Int, progress_milli: Int) -> Int {
+  if variant != 1 { return 0; }
+  if hacked != 0 { return 0; }
+  if progress_milli >= 1000 { return 1; }
+  0
+}
+
+// respondToDistraction (PBX pull): only while Patrolling(0) and within range.
+// 1 = the dog diverts to Investigating(4).
+pub fn can_respond_distraction(state: Int, dist_mu: Int, range_mu: Int) -> Int {
+  if state != 0 { return 0; }
+  if dist_mu < range_mu { return 1; }
+  0
+}
+
+// ---------------------------------------------------------------------------
+// Combat / query helpers (pure state classification).
+// ---------------------------------------------------------------------------
+
+// applyHeadStomp -> Disabled(6); applyBodyStomp -> Stunned(7). Returned as the
+// post-stomp state so the host writes one value back.
+pub fn head_stomp_state() -> Int { 6 }
+pub fn body_stomp_state() -> Int { 7 }
+
+// isAggressiveContact: Tracking(1) or Barking(2) -> 1, else 0. The "alert and
+// not incapacitated" predicate.
+pub fn is_aggressive(state: Int) -> Int {
+  if valid_state(state) == 0 { return 0; }
+  if state == 1 { return 1; }
+  if state == 2 { return 1; }
+  0
+}
+
+// Simple state predicates (isBarking / isDisabled / isDistracted / isTracking).
+pub fn is_barking(state: Int) -> Int { if state == 2 { 1 } else { 0 } }
+pub fn is_disabled(state: Int) -> Int { if state == 6 { 1 } else { 0 } }
+pub fn is_distracted(state: Int) -> Int { if state == 3 { 1 } else { 0 } }
+pub fn is_tracking(state: Int) -> Int { if state == 1 { 1 } else { 0 } }
+
+// Facing from horizontal delta sign: dx > 0 -> Right(1), else Left(0). The
+// pure integer sign decision behind every `dog.facing = if dx > 0 { Right }`.
+pub fn facing_for_delta(dx_mu: Int) -> Int {
+  if dx_mu > 0 { 1 } else { 0 }
+}
+
+// Movement direction sign: dx > 0 -> +1, else -1. Behind every
+// `direction = if dx > 0 { 1.0 } else { -1.0 }`.
+pub fn direction_for_delta(dx_mu: Int) -> Int {
+  if dx_mu > 0 { 1 } else { -1 }
+}

--- a/proposals/idaptik/migrated/SecurityDog/securitydog.config.mjs
+++ b/proposals/idaptik/migrated/SecurityDog/securitydog.config.mjs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for SecurityDog.affine (the guard-dog / robo-dog decision
+// core extracted from src/app/enemies/SecurityDog.res). The brain is Int-only,
+// so parity runs directly against the deliverable.
+//
+// Every oracle is an INDEPENDENT re-derivation of the SecurityDog.res semantics
+// in plain JS (the detection classifier, the 8-state machine transition table,
+// the interaction gates and the sign helpers) -- not a copy of the .affine. A
+// codegen regression surfaces as a differential mismatch. Units mirror the
+// brain: distances/ranges in milli-pixels, angles in milli-radians, timers in
+// milliseconds, scent strength in milli-units (0..1000).
+
+// --- detection-model range table (detectionModel records) ------------------
+function validVariant(v) { return v === 0 || v === 1; }
+function validState(s) { return s >= 0 && s <= 7; }
+
+function scentRange(v) {
+  if (!validVariant(v)) return -1;
+  return v === 0 ? 180000 : 0;
+}
+function cameraRange(v) {
+  if (!validVariant(v)) return -1;
+  return v === 1 ? 200000 : 0;
+}
+function cameraHalfAngle(v) {
+  if (!validVariant(v)) return -1;
+  return v === 1 ? 500 : 0;
+}
+function irRange(v) {
+  if (!validVariant(v)) return -1;
+  return v === 1 ? 120000 : 0;
+}
+function hearingRange(v) {
+  if (!validVariant(v)) return -1;
+  return v === 0 ? 200000 : 150000;
+}
+function speed(v) {
+  if (!validVariant(v)) return -1;
+  return v === 0 ? 75000 : 55000;
+}
+
+// --- scent strength: 1.0 - distance/scentRange, milli-units ----------------
+function scentStrength(distance, range) {
+  if (range <= 0) return 0;
+  if (distance < 0) return 1000;
+  if (distance >= range) return 0;
+  const s = 1000 - Math.trunc((distance * 1000) / range);
+  if (s < 0) return 0;
+  if (s > 1000) return 1000;
+  return s;
+}
+
+// --- angle normalisation: fold into [0, pi], milli-radians -----------------
+function angleNorm(diff, pi, twoPi) {
+  if (diff < 0) return 0;
+  if (diff > pi) return twoPi - diff;
+  return diff;
+}
+function effectiveCameraRange(camRange, crouching) {
+  if (camRange < 0) return -1;
+  if (crouching !== 0) return Math.trunc(camRange / 2);
+  return camRange;
+}
+
+// --- detectPlayer classifier -----------------------------------------------
+// 0 NotDetected, 1 ScentDetected, 2 VisualDetected, 3 HeardMovement.
+function detectClass(state, variant, distance, sprinting, normAngle, effRange) {
+  if (!validVariant(variant)) return 0;
+  if (state === 6 || state === 7 || state === 3) return 0; // Disabled/Stunned/Distracted
+  if (variant === 0) {
+    const scent = scentRange(0);
+    const hearing = hearingRange(0);
+    if (distance < scent) return 1;
+    if (sprinting !== 0 && distance < hearing) return 3;
+    return 0;
+  }
+  const half = cameraHalfAngle(1);
+  const ir = irRange(1);
+  const hearing = hearingRange(1);
+  if (normAngle < half && distance < effRange) return 2;
+  if (distance < ir) return 2;
+  if (sprinting !== 0 && distance < hearing) return 3;
+  return 0;
+}
+
+// --- updateState transition table ------------------------------------------
+function nextState(state, detection, strength, distToTarget, barkTimer, pauseTimer, hasTarget) {
+  if (!validState(state)) return -1;
+  switch (state) {
+    case 0: // Patrolling
+      if (detection === 1) return strength > 300 ? 1 : 0;
+      if (detection === 2) return 2;
+      if (detection === 3) return 4;
+      return 0;
+    case 1: // Tracking
+      if (hasTarget === 0) return 5;
+      if (distToTarget < 30000) return 2;
+      return 1;
+    case 2: // Barking
+      if (barkTimer >= 4000) return 1;
+      return 2;
+    case 3: // Distracted
+      return 3;
+    case 4: // Investigating
+      if (hasTarget === 0) return 5;
+      if (detection === 1 && strength > 400) return 1;
+      if (detection === 2) return 2;
+      if (distToTarget < 10000 && pauseTimer >= 2500) return 5;
+      return 4;
+    case 5: // Returning
+      if (distToTarget < 5000) return 0;
+      return 5;
+    default: // Disabled(6) / Stunned(7) absorbing
+      return state;
+  }
+}
+
+function distractionExpired(state, timer) {
+  if (state !== 3) return state;
+  if (timer <= 0) return 5;
+  return 3;
+}
+
+function robodogEarlyExit(variant, empActive, empJustExpired, hacked, batteryEmpty) {
+  if (variant !== 1) return -1;
+  if (empActive !== 0) return empJustExpired !== 0 ? 5 : 7;
+  if (hacked !== 0) return 6;
+  if (batteryEmpty !== 0) return 6;
+  return -1;
+}
+
+// --- interaction gates ------------------------------------------------------
+function canDistract(variant, state, foodDist) {
+  if (variant !== 0) return 0;
+  if (state === 6 || state === 7) return 0;
+  return foodDist < scentRange(0) ? 1 : 0;
+}
+function canEmp(variant, state) {
+  if (variant !== 1) return 0;
+  if (state === 6) return 0;
+  return 1;
+}
+function hackComplete(variant, hacked, progress) {
+  if (variant !== 1) return 0;
+  if (hacked !== 0) return 0;
+  return progress >= 1000 ? 1 : 0;
+}
+function canRespondDistraction(state, dist, range) {
+  if (state !== 0) return 0;
+  return dist < range ? 1 : 0;
+}
+
+// --- combat / query helpers -------------------------------------------------
+function isAggressive(state) {
+  if (!validState(state)) return 0;
+  return state === 1 || state === 2 ? 1 : 0;
+}
+function facingForDelta(dx) { return dx > 0 ? 1 : 0; }
+function directionForDelta(dx) { return dx > 0 ? 1 : -1; }
+
+export default {
+  affine: "SecurityDog.affine",
+  cases: [
+    { name: "variant_count()", export: "variant_count", args: [], oracle: () => 2 },
+    { name: "state_count()", export: "state_count", args: [], oracle: () => 8 },
+    { name: "detection_count()", export: "detection_count", args: [], oracle: () => 4 },
+
+    { name: "scent_range_mu over variant [-1..3]", export: "scent_range_mu", args: [[-1, 3]], oracle: (v) => scentRange(v) },
+    { name: "camera_range_mu over variant [-1..3]", export: "camera_range_mu", args: [[-1, 3]], oracle: (v) => cameraRange(v) },
+    { name: "camera_half_angle_mu over variant [-1..3]", export: "camera_half_angle_mu", args: [[-1, 3]], oracle: (v) => cameraHalfAngle(v) },
+    { name: "ir_range_mu over variant [-1..3]", export: "ir_range_mu", args: [[-1, 3]], oracle: (v) => irRange(v) },
+    { name: "hearing_range_mu over variant [-1..3]", export: "hearing_range_mu", args: [[-1, 3]], oracle: (v) => hearingRange(v) },
+    { name: "speed_mu over variant [-1..3]", export: "speed_mu", args: [[-1, 3]], oracle: (v) => speed(v) },
+
+    {
+      name: "scent_strength_milli: distance x range (edges + out-of-band)",
+      export: "scent_strength_milli",
+      args: [
+        { values: [-1, 0, 1000, 45000, 90000, 135000, 179999, 180000, 200000] },
+        { values: [0, 180000, 200000] },
+      ],
+      oracle: (d, r) => scentStrength(d, r),
+    },
+    {
+      name: "angle_norm_mu: diff folded into [0,pi] (pi=3141, 2pi=6283)",
+      export: "angle_norm_mu",
+      args: [
+        { values: [-100, 0, 500, 3141, 3142, 4000, 6283] },
+        { values: [3141] },
+        { values: [6283] },
+      ],
+      oracle: (diff, pi, twoPi) => angleNorm(diff, pi, twoPi),
+    },
+    {
+      name: "effective_camera_range_mu: camRange x crouch (0/1) + oob",
+      export: "effective_camera_range_mu",
+      args: [{ values: [-1, 0, 120000, 200000] }, [0, 1]],
+      oracle: (c, crouch) => effectiveCameraRange(c, crouch),
+    },
+
+    {
+      name: "detect_class GuardDog: state x distance x sprint",
+      export: "detect_class",
+      args: [
+        { values: [0, 1, 3, 6, 7] },          // representative states incl. early-outs
+        { values: [0] },                       // GuardDog
+        { values: [0, 90000, 179999, 180000, 199999, 200000, 250000] },
+        [0, 1],                                // sprinting
+        { values: [0] },                       // norm angle (ignored for GuardDog)
+        { values: [0] },                       // eff range (ignored for GuardDog)
+      ],
+      oracle: (s, v, d, sp, na, er) => detectClass(s, v, d, sp, na, er),
+    },
+    {
+      name: "detect_class RoboDog: state x distance x sprint x angle x effRange",
+      export: "detect_class",
+      args: [
+        { values: [0, 1, 3, 6, 7] },
+        { values: [1] },                       // RoboDog
+        { values: [0, 100000, 119999, 120000, 150000, 199999, 200000, 250000] },
+        [0, 1],
+        { values: [0, 499, 500, 1000] },       // folded cone angle vs half=500
+        { values: [100000, 200000] },          // effective range
+      ],
+      oracle: (s, v, d, sp, na, er) => detectClass(s, v, d, sp, na, er),
+    },
+
+    {
+      name: "next_state: full table x detection x strength x dist x timers x hasTarget",
+      export: "next_state",
+      args: [
+        [-1, 8],                               // state incl. out-of-band shoulders
+        { values: [0, 1, 2, 3] },              // detection class
+        { values: [0, 300, 301, 400, 401, 1000] },
+        { values: [0, 4999, 5000, 9999, 10000, 29999, 30000] },
+        { values: [0, 3999, 4000] },
+        { values: [0, 2499, 2500] },
+        [0, 1],
+      ],
+      oracle: (st, det, str, dt, bt, pt, ht) => nextState(st, det, str, dt, bt, pt, ht),
+    },
+    {
+      name: "distraction_expired: state x timer",
+      export: "distraction_expired",
+      args: [[-1, 8], { values: [-100, 0, 1, 5000] }],
+      oracle: (s, t) => distractionExpired(s, t),
+    },
+    {
+      name: "robodog_early_exit: variant x emp x empExpired x hacked x battery",
+      export: "robodog_early_exit",
+      args: [[-1, 2], [0, 1], [0, 1], [0, 1], [0, 1]],
+      oracle: (v, e, ee, h, b) => robodogEarlyExit(v, e, ee, h, b),
+    },
+
+    {
+      name: "can_distract: variant x state x foodDist",
+      export: "can_distract",
+      args: [[-1, 2], [-1, 8], { values: [0, 90000, 179999, 180000, 200000] }],
+      oracle: (v, s, d) => canDistract(v, s, d),
+    },
+    {
+      name: "can_emp: variant x state",
+      export: "can_emp",
+      args: [[-1, 2], [-1, 8]],
+      oracle: (v, s) => canEmp(v, s),
+    },
+    {
+      name: "hack_complete: variant x hacked x progress",
+      export: "hack_complete",
+      args: [[-1, 2], [0, 1], { values: [0, 500, 999, 1000, 1500] }],
+      oracle: (v, h, p) => hackComplete(v, h, p),
+    },
+    {
+      name: "can_respond_distraction: state x dist x range",
+      export: "can_respond_distraction",
+      args: [[-1, 8], { values: [0, 50000, 99999, 100000, 150000] }, { values: [100000] }],
+      oracle: (s, d, r) => canRespondDistraction(s, d, r),
+    },
+
+    { name: "head_stomp_state()", export: "head_stomp_state", args: [], oracle: () => 6 },
+    { name: "body_stomp_state()", export: "body_stomp_state", args: [], oracle: () => 7 },
+    { name: "is_aggressive over state [-1..8]", export: "is_aggressive", args: [[-1, 8]], oracle: (s) => isAggressive(s) },
+    { name: "is_barking over state [-1..8]", export: "is_barking", args: [[-1, 8]], oracle: (s) => (s === 2 ? 1 : 0) },
+    { name: "is_disabled over state [-1..8]", export: "is_disabled", args: [[-1, 8]], oracle: (s) => (s === 6 ? 1 : 0) },
+    { name: "is_distracted over state [-1..8]", export: "is_distracted", args: [[-1, 8]], oracle: (s) => (s === 3 ? 1 : 0) },
+    { name: "is_tracking over state [-1..8]", export: "is_tracking", args: [[-1, 8]], oracle: (s) => (s === 1 ? 1 : 0) },
+    { name: "facing_for_delta over [-5..5]", export: "facing_for_delta", args: [[-5, 5]], oracle: (dx) => facingForDelta(dx) },
+    { name: "direction_for_delta over [-5..5]", export: "direction_for_delta", args: [[-5, 5]], oracle: (dx) => directionForDelta(dx) },
+  ],
+};


### PR DESCRIPTION
## Migration wave: 7 integer-brain kernels from string-gated idaptik modules

First applied wave of the now-unblocked **string-gated corpus**. Phase B classified 71 string-gated files; closing the string wall (slices 1–8) plus the `len()` lowering (#583) opened the integer-brain extraction path. Seven kernels re-decomposed from idaptik `.res` modules into AffineScript brains under `proposals/idaptik/migrated/`, fanned out across 6 parallel agents and **re-verified by me before commit**.

Each is a four-gate deliverable — G1 compile, G2 independent-oracle parity sweep, G4 assail. Strings / floats / promises / mutable state stay **host-side** per the C1–C12 recipe; only the pure-integer decision core crosses to wasm.

| Kernel | Exports | Parity | Assail |
|---|---|---|---|
| PortScanner | 4 | 44/44 | clean |
| PasswordCracker | 7 | 215/215 | clean |
| FirewallDevice | 12 | 164/164 | clean |
| Inventory | 9 | 2840/2840 | clean |
| Drone | 32 | 1192/1192 | clean |
| SecurityDog | 29 | 31533/31533 | clean |
| GuardNPC | 19 | 359/359 | clean |

**Re-decompositions, not transliterations** — e.g. PasswordCracker inverts the djb2 string-loop so the host walks the string and the brain does i32 math (`Math.imul`/`|0` modelled in the oracle); Inventory packs slot-state into a base-3 Int instead of a mutable array; FirewallDevice keeps CIDR/protocol *string* parsing host-side and decides over integer flags. Floats cross as floored milli-units; out-of-band inputs return guarded `-1` sentinels (assail-clean, no in-band collapse). Each oracle is an independent JS reimplementation from the `.res` semantics, not copied from the `.affine`.

**Deduped:** `SecurityAI` dropped — already tracked as `migrated/securityai/` (with a boundary proof) from an earlier wave; `GlobalNetworkData` likewise pre-existed and was left untouched.

**Two compiler quirks surfaced** (flagged for the playbook, not fixed here): `total` is a reserved keyword (parse error as an identifier); and an `if { … }` block immediately followed by a parenthesized expression parses as a function application. Both have trivial source-side workarounds.

Builds on #583 (`len`, merged) and the string-wall slices (#574/#575/#578).

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_