### PR TITLE
migration: 6 integer-brain kernels (wave 2) from string-gated idaptik modules

### DIFF
--- a/proposals/idaptik/migrated/CharacterSelectScreen/CharacterSelectScreen.affine
+++ b/proposals/idaptik/migrated/CharacterSelectScreen/CharacterSelectScreen.affine
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// CharacterSelectScreen -- the pure-integer layout/format core extracted from
+// src/app/screens/CharacterSelectScreen.res. The screen itself is overwhelmingly
+// senses: Pixi Graphics card draws, Text styling, the 6-card grid render, the
+// confirm-button wiring, Storage.setString, and the attribute-bar geometry. Per
+// the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), every STRING (the class display names,
+// the descriptions, the "..." ellipsis literal, the stored "jessica-class"
+// value) and every Pixi object STAYS host-side. The per-background attribute-
+// bonus matrix that drawAttrBars folds is NOT duplicated here -- it already
+// lives in the JessicaBackground co-processor.
+//
+// Two separable integer decisions remain, and they are this brain:
+//
+//   1. Card-description TRUNCATION (lines 282-287 of the .res). The ReScript is
+//        if String.length(desc) > 45 { String.slice(desc, 0, 42) ++ "..." }
+//        else { desc }
+//      The string never crosses the boundary -- the host keeps `desc`, hands the
+//      brain only its LENGTH (an Int), and the brain returns the slice END index
+//      and an ellipsis flag. The host then slices [0, end) of its own string and
+//      appends "..." iff the flag is 1. AffineScript owns the cut arithmetic; the
+//      host owns the bytes. (String subscript / string == are avoided entirely --
+//      the brain sees a length, not a string, which is also why the v0.1.x wasm
+//      backend's broken string ops are never reached.)
+//
+//   2. Card-grid PLACEMENT (lines 245-246 of the .res). The ReScript is
+//        let col = mod(idx, 3)
+//        let row = idx / 3
+//      the 3-column row-major index math for the 3x2 card grid. The float pixel
+//      coordinates cx/cy that multiply these by (cardW+gap) STAY host-side (they
+//      are senses, and floats); the brain owns only the integer col/row, which is
+//      exactly the pure arithmetic the layout decision reduces to.
+//
+//## Truncation contract (the header contract for the JS host)
+//   THRESHOLD = 45 : a description longer than this is truncated.
+//   CUT       = 42 : the slice end index used when truncating (leaves room for
+//                    the 3-char "..." the host appends).
+//   csel_needs_ellipsis(len) -> 1 when len > 45, else 0.
+//   csel_slice_end(len)      -> 42 when len > 45, else len (no truncation: the
+//                               host slices its whole string, i.e. uses it as-is).
+//   A negative length is not a real string length; both kernels treat it as the
+//   no-truncation case (flag 0, end = len), so an off-domain input can never
+//   manufacture a spurious cut.
+//
+//## Grid contract (the second contract, for the card placement)
+//   COLS = 3 : the grid is 3 columns wide, row-major, matching JessicaBackground
+//              .all's 6 entries laid out 3x2.
+//   csel_card_col(idx) -> idx % 3   (the column, 0..2, for the idx-th card).
+//   csel_card_row(idx) -> idx / 3   (the row, 0-based, for the idx-th card).
+//   idx is a dense array index (0..5 for the six backgrounds) and is always
+//   non-negative in the .res forEach; the kernels are the bare arithmetic.
+//
+// PURE: integers only, no floats, no strings, no arrays, no effects, no I/O.
+
+//## Truncation threshold: the length above which a description is cut.
+pub fn csel_trunc_threshold() -> Int { 45 }
+
+//## Truncation cut: the slice end index used when a description is cut. Leaves
+// three characters of room for the host's "..." suffix (45 threshold - 3 dots).
+pub fn csel_trunc_cut() -> Int { 42 }
+
+//## Whether the host must append the "..." ellipsis: 1 when the description
+// length exceeds the threshold, else 0. A non-positive length is never longer
+// than the threshold, so it yields 0 (no truncation).
+pub fn csel_needs_ellipsis(len: Int) -> Int {
+  if len > 45 { 1 } else { 0 }
+}
+
+//## The slice end index the host applies to its description string: the fixed
+// CUT (42) when the string is over-long, otherwise the string's own length (a
+// no-op slice -- the host keeps the whole string). The host slices [0, end).
+pub fn csel_slice_end(len: Int) -> Int {
+  if len > 45 { 42 } else { len }
+}
+
+//## The grid is three columns wide (JessicaBackground.all's 6 cards as 3x2).
+pub fn csel_grid_cols() -> Int { 3 }
+
+//## The column (0..2) of the idx-th card in the row-major 3-column grid.
+pub fn csel_card_col(idx: Int) -> Int {
+  idx % 3
+}
+
+//## The row (0-based) of the idx-th card in the row-major 3-column grid.
+pub fn csel_card_row(idx: Int) -> Int {
+  idx / 3
+}

--- a/proposals/idaptik/migrated/CharacterSelectScreen/characterselectscreen.config.mjs
+++ b/proposals/idaptik/migrated/CharacterSelectScreen/characterselectscreen.config.mjs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for CharacterSelectScreen.affine (idaptik character-select
+// description-truncation + card-grid placement; scalar i32 ABI). The oracle
+// re-derives each function from the ORIGINAL CharacterSelectScreen.res semantics
+// (NOT from the .affine) so a codegen regression surfaces as a differential
+// mismatch.
+//
+// Truncation, from CharacterSelectScreen.res lines 282-287:
+//   let shortDesc = if String.length(desc) > 45 {
+//     String.slice(desc, ~start=0, ~end=42) ++ "..."
+//   } else { desc }
+// The host keeps `desc`; the brain sees only its length and returns the slice
+// end + ellipsis flag. ReScript String.slice with start=0 end=42 yields the
+// first 42 chars; the non-truncated branch uses the whole string, i.e. an end
+// index equal to its length.
+//
+// Grid placement, from CharacterSelectScreen.res lines 245-246:
+//   let col = mod(idx, 3)
+//   let row = idx / 3
+// ReScript `mod` and integer `/` on non-negative dense array indices.
+
+// Independent re-derivation of the truncation decision from the .res.
+const THRESHOLD = 45;
+const CUT = 42;
+const needsEllipsis = (len) => (len > THRESHOLD ? 1 : 0);
+const sliceEnd = (len) => (len > THRESHOLD ? CUT : len);
+
+// Independent re-derivation of the grid placement from the .res.
+// ReScript mod/(/) truncate toward zero; over the swept non-negative domain
+// this coincides with JS % and Math.trunc of the quotient.
+const cardCol = (idx) => idx % 3;
+const cardRow = (idx) => Math.trunc(idx / 3);
+
+export default {
+  affine: "CharacterSelectScreen.affine",
+  cases: [
+    {
+      name: "csel_trunc_threshold()",
+      export: "csel_trunc_threshold",
+      args: [],
+      oracle: () => THRESHOLD,
+    },
+    {
+      name: "csel_trunc_cut()",
+      export: "csel_trunc_cut",
+      args: [],
+      oracle: () => CUT,
+    },
+    {
+      name: "csel_needs_ellipsis over len[0..60]",
+      export: "csel_needs_ellipsis",
+      args: [[0, 60]],
+      oracle: (len) => needsEllipsis(len),
+    },
+    {
+      name: "csel_needs_ellipsis boundary 44/45/46 + negative",
+      export: "csel_needs_ellipsis",
+      args: [{ values: [-3, 0, 44, 45, 46, 100] }],
+      oracle: (len) => needsEllipsis(len),
+    },
+    {
+      name: "csel_slice_end over len[0..60]",
+      export: "csel_slice_end",
+      args: [[0, 60]],
+      oracle: (len) => sliceEnd(len),
+    },
+    {
+      name: "csel_slice_end boundary 44/45/46 + negative",
+      export: "csel_slice_end",
+      args: [{ values: [-3, 0, 44, 45, 46, 100] }],
+      oracle: (len) => sliceEnd(len),
+    },
+    {
+      name: "csel_grid_cols()",
+      export: "csel_grid_cols",
+      args: [],
+      oracle: () => 3,
+    },
+    {
+      name: "csel_card_col over idx[0..11]",
+      export: "csel_card_col",
+      args: [[0, 11]],
+      oracle: (idx) => cardCol(idx),
+    },
+    {
+      name: "csel_card_row over idx[0..11]",
+      export: "csel_card_row",
+      args: [[0, 11]],
+      oracle: (idx) => cardRow(idx),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Coprocessor_Compute/Coprocessor_Compute.affine
+++ b/proposals/idaptik/migrated/Coprocessor_Compute/Coprocessor_Compute.affine
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Coprocessor_Compute -- the pure-integer scalar kernels of the idaptik compute
+// co-processor, the brain extracted from src/shared/Coprocessor_Compute.res. The
+// ReScript file is a backend registry whose `cmd*` wrappers marshal an
+// array<int> and return an executionResult record (status + data + metrics +
+// message). All of that -- the array<int> framing, the status-400/413 guards,
+// the resourceMetrics, every message string, and the FeaturePacks/wasm-handle
+// routing -- is the host's job (the senses). What crosses the wasm boundary is
+// only the SCALAR integer result of each deterministic kernel, exactly what the
+// `CoprocessorComputeCoprocessor.*` bridge (e.g. `gcd`, `isPrime`, `fib`) already
+// calls into. This brain is that bridge target: the integer arithmetic the
+// ReScript `| None =>` fallback paths spell out.
+//
+// Re-decomposition notes (NOT a transliteration):
+//   * The Promise is incidental -- every kernel is synchronous Int -> Int.
+//   * No module state. Each kernel is a pure function of explicit Int params.
+//   * Float-finished kernels stay host-side: sqrt-floor (Maths.sqrt), Math.pow
+//     fractional growth (the float Math.pow before the clamp), distance*100 (a
+//     sqrt), rand (Math.random). The brain owns only the integer-exact kernels.
+//   * Array-shaped kernels (factor, the Vector and Tensor backends) marshal an
+//     array<int> across the boundary; the host keeps that framing. This brain is
+//     the scalar i32 ABI surface, matching the established Maths.affine pattern.
+//   * `is_prime`'s ReScript bound `d <= floor(sqrt n)` is rephrased as the
+//     integer-exact `d*d <= n`; same primes, no float. `factor`/`shor` array
+//     output stays host-side but share this `d*d <= rem` trial-division spine.
+
+// Safe upper bound for pow results (Coprocessor_Compute.Maths.intMax = 2^30 - 1).
+// pow_clamped saturates here; the host framework treats this as the positive
+// 31-bit ceiling for every scalar kernel result.
+fn int_max() -> Int { 1073741823 }
+
+// |n| without a library call; the gcd/signal/thermal kernels take abs() of their
+// inputs in the ReScript (Array.get ... Some(v) => abs(v)).
+fn iabs(n: Int) -> Int {
+  if n < 0 { 0 - n } else { n }
+}
+
+// --- Maths backend: deterministic integer kernels -------------------------
+
+// gcd -- Euclidean greatest common divisor on absolute values, with the
+// ReScript guard that gcd(0,0)=0. Mirrors `euclidGcd` + the `cmdGcd` 0,0 case.
+// The host has already taken abs of a and b; we re-take it for total safety.
+pub fn gcd(a: Int, b: Int) -> Int {
+  let mut x = iabs(a);
+  let mut y = iabs(b);
+  while y != 0 {
+    let r = x % y;
+    x = y;
+    y = r;
+  }
+  x
+}
+
+// mod -- non-negative modulo (Coprocessor_Compute.Maths.cmdMod `| None` branch:
+// raw = a mod b; if raw < 0 then raw + |b|). The host owns the divisor==0 status
+// 400 guard, so this kernel assumes b != 0; b==0 is never dispatched here.
+pub fn mod_nonneg(dividend: Int, divisor: Int) -> Int {
+  if divisor == 0 { return 0; }
+  let raw = dividend % divisor;
+  if raw < 0 { raw + iabs(divisor) } else { raw }
+}
+
+// prime -- trial-division primality. Returns 1 prime, 0 composite/under-2.
+// Mirrors `Coprocessor_Compute.Maths.isPrime`, with the float sqrt bound replaced
+// by the integer-exact `d*d <= n`.
+pub fn is_prime(n: Int) -> Int {
+  if n < 2 { return 0; }
+  if n == 2 { return 1; }
+  if n % 2 == 0 { return 0; }
+  let mut d = 3;
+  let mut ok = 1;
+  while d * d <= n {
+    if n % d == 0 { ok = 0; }
+    d = d + 2;
+  }
+  ok
+}
+
+// fib -- iterative Fibonacci, clamped to n in 0..46 (fib(46)=1836311903 is the
+// largest that fits a 31-bit signed int; the ReScript cmdFib clamps n>46 to 46
+// and n<0 to 0). Mirrors the `cmdFib` `| None` iteration.
+pub fn fib(n: Int) -> Int {
+  let mut k = n;
+  if k < 0 { k = 0; }
+  if k > 46 { k = 46; }
+  if k == 0 { return 0; }
+  if k == 1 { return 1; }
+  let mut a = 0;
+  let mut b = 1;
+  let mut i = 2;
+  while i <= k {
+    let next = a + b;
+    a = b;
+    b = next;
+    i = i + 1;
+  }
+  b
+}
+
+// pow -- integer base^exp, clamped to [0, int_max]. Mirrors `cmdPow`: a negative
+// exp is treated as 0 (the host guard `| Some(v) if v >= 0 => v | _ => 0`), and
+// the result saturates at int_max on overflow and at 0 below zero. Overflow is
+// detected before it wraps: once the running product exceeds int_max we stop and
+// return the ceiling, matching `if raw > intMax then intMax`.
+pub fn pow_clamped(base: Int, exp: Int) -> Int {
+  let mut e = exp;
+  if e < 0 { e = 0; }
+  if e == 0 { return 1; }
+  let cap = int_max();
+  let mut acc = 1;
+  let mut i = 0;
+  let mut overflow = 0;
+  while i < e {
+    // Saturating multiply: detect overflow against the cap before it happens.
+    if base == 0 {
+      acc = 0;
+    } else {
+      let lim = cap / iabs(base);
+      if iabs(acc) > lim { overflow = 1; }
+      acc = acc * base;
+    }
+    i = i + 1;
+  }
+  if overflow == 1 { return cap; }
+  if acc > cap { return cap; }
+  if acc < 0 { return 0; }
+  acc
+}
+
+// --- Physics backend: integer fixed-point kernels -------------------------
+// Each mirrors the ReScript `| None =>` fallback (the host keeps the status-400
+// length/zero guards and the message strings).
+
+// signal -- free-space attenuation: loss = distance*atten/100; strength is the
+// non-negative remaining power. Mirrors `Physics.cmdSignal` `| None`. The host
+// has taken abs of distance and atten.
+pub fn signal(power: Int, distance: Int, attenuation: Int) -> Int {
+  let loss = iabs(distance) * iabs(attenuation) / 100;
+  if power > loss { power - loss } else { 0 }
+}
+
+// thermal -- temperature rise = watts*duration/heatCap. Mirrors
+// `Physics.cmdThermal` `| None`. The host owns the heatCap<=0 status-400 guard,
+// so heatCap > 0 here; heatCap==0 is never dispatched.
+pub fn thermal(watts: Int, duration: Int, heat_cap: Int) -> Int {
+  if heat_cap == 0 { return 0; }
+  iabs(watts) * iabs(duration) / heat_cap
+}
+
+// cablesag -- catenary sag approximation = weight*length^2/(8*tension). Mirrors
+// `Physics.cmdCablesag` `| None`. The host owns the tension<=0 status-400 guard,
+// so tension > 0 here.
+pub fn cablesag(length: Int, weight: Int, tension: Int) -> Int {
+  if tension == 0 { return 0; }
+  let l = iabs(length);
+  iabs(weight) * l * l / (8 * tension)
+}
+
+// power (watts) -- voltage*current. Mirrors `Physics.cmdPower` `| None` first
+// element.
+pub fn power_watts(voltage: Int, current: Int) -> Int {
+  voltage * current
+}
+
+// power (safety) -- circuit-breaker assessment: 1 SAFE when watts < 1500, else 0
+// OVERLOAD. Mirrors `Physics.cmdPower` `| None` second element.
+pub fn power_safe(watts: Int) -> Int {
+  if watts < 1500 { 1 } else { 0 }
+}

--- a/proposals/idaptik/migrated/Coprocessor_Compute/coprocessor_compute.config.mjs
+++ b/proposals/idaptik/migrated/Coprocessor_Compute/coprocessor_compute.config.mjs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Coprocessor_Compute.affine (idaptik compute
+// co-processor scalar kernels; scalar i32 ABI). Every oracle is an INDEPENDENT
+// JS reimplementation derived from src/shared/Coprocessor_Compute.res semantics
+// (the `| None =>` ReScript fallback arithmetic) -- NOT a copy of the .affine
+// logic -- so the differential sweep is a genuine cross-check. The .res frames
+// these as array<int> -> executionResult; here only the scalar result crosses.
+//
+// Note: `is_prime`'s .res used floor(sqrt n) as the trial bound; this oracle
+// uses an independent `for d=3; d*d<=n` loop, so a codegen regression that broke
+// the .affine `d*d<=n` rephrasing would surface as a mismatch.
+
+// --- independent oracle helpers (re-derived from Coprocessor_Compute.res) ---
+
+const INT_MAX = 1073741823; // Maths.intMax = 2^30 - 1
+const iabs = (n) => (n < 0 ? -n : n);
+
+// gcd: euclidGcd on abs values, gcd(0,0)=0 (cmdGcd).
+const oGcd = (a, b) => {
+  let x = iabs(a);
+  let y = iabs(b);
+  while (y !== 0) {
+    const r = x % y;
+    x = y;
+    y = r;
+  }
+  return x;
+};
+
+// non-negative modulo (cmdMod | None); host guards divisor==0 -> kernel sees 0.
+const oMod = (a, b) => {
+  if (b === 0) return 0;
+  const raw = a % b;
+  return raw < 0 ? raw + iabs(b) : raw;
+};
+
+// primality by independent trial division (isPrime, integer bound).
+const oPrime = (n) => {
+  if (n < 2) return 0;
+  if (n === 2) return 1;
+  if (n % 2 === 0) return 0;
+  for (let d = 3; d * d <= n; d += 2) {
+    if (n % d === 0) return 0;
+  }
+  return 1;
+};
+
+// iterative Fibonacci clamped to 0..46 (cmdFib).
+const oFib = (n) => {
+  let k = n;
+  if (k < 0) k = 0;
+  if (k > 46) k = 46;
+  if (k === 0) return 0;
+  if (k === 1) return 1;
+  let a = 0;
+  let b = 1;
+  for (let i = 2; i <= k; i++) {
+    const next = a + b;
+    a = b;
+    b = next;
+  }
+  return b;
+};
+
+// integer pow, clamped to [0, INT_MAX] (cmdPow | None semantics).
+// Independent route: accumulate in JS double (exact for these small ranges),
+// then clamp -- mirrors `raw = Math.pow(base, exp); if raw > intMax ...`.
+const oPow = (base, exp) => {
+  let e = exp;
+  if (e < 0) e = 0;
+  const raw = Math.pow(base, e);
+  if (raw > INT_MAX) return INT_MAX;
+  if (raw < 0) return 0;
+  return Math.floor(raw);
+};
+
+// Physics integer kernels (| None branches).
+const oSignal = (power, distance, atten) => {
+  const loss = Math.trunc((iabs(distance) * iabs(atten)) / 100);
+  return power > loss ? power - loss : 0;
+};
+const oThermal = (watts, duration, heatCap) => {
+  if (heatCap === 0) return 0;
+  return Math.trunc((iabs(watts) * iabs(duration)) / heatCap);
+};
+const oCablesag = (length, weight, tension) => {
+  if (tension === 0) return 0;
+  const l = iabs(length);
+  return Math.trunc((iabs(weight) * l * l) / (8 * tension));
+};
+const oPowerWatts = (v, i) => v * i;
+const oPowerSafe = (w) => (w < 1500 ? 1 : 0);
+
+export default {
+  affine: "Coprocessor_Compute.affine",
+  cases: [
+    // --- Maths kernels ---
+    {
+      name: "gcd over a,b in [0..30]^2",
+      export: "gcd",
+      args: [[0, 30], [0, 30]],
+      oracle: oGcd,
+    },
+    {
+      name: "gcd over negatives a,b in {-30,-12,-7,0,7,12,30}^2",
+      export: "gcd",
+      args: [{ values: [-30, -12, -7, 0, 7, 12, 30] }, { values: [-30, -12, -7, 0, 7, 12, 30] }],
+      oracle: oGcd,
+    },
+    {
+      name: "mod_nonneg over a in {-17,-5,-1,0,7,13,40}, b in {-5,-3,1,4,7}",
+      export: "mod_nonneg",
+      args: [{ values: [-17, -5, -1, 0, 7, 13, 40] }, { values: [-5, -3, 1, 4, 7] }],
+      oracle: oMod,
+    },
+    {
+      name: "is_prime over [-2..120]",
+      export: "is_prime",
+      args: [[-2, 120]],
+      oracle: oPrime,
+    },
+    {
+      name: "fib over [-3..50]",
+      export: "fib",
+      args: [[-3, 50]],
+      oracle: oFib,
+    },
+    {
+      name: "pow_clamped over base in [-4..12], exp in [-2..10]",
+      export: "pow_clamped",
+      args: [[-4, 12], [-2, 10]],
+      oracle: oPow,
+    },
+    {
+      name: "pow_clamped overflow band: base in {2,3,10,100,1000}, exp in {0..12}",
+      export: "pow_clamped",
+      args: [{ values: [2, 3, 10, 100, 1000] }, [0, 12]],
+      oracle: oPow,
+    },
+    // --- Physics kernels ---
+    {
+      name: "signal over power,distance,atten samples",
+      export: "signal",
+      args: [{ values: [0, 50, 100, 500, 1000] }, { values: [-20, 0, 10, 50, 200] }, { values: [-5, 0, 1, 10, 50] }],
+      oracle: oSignal,
+    },
+    {
+      name: "thermal over watts,duration,heatCap samples",
+      export: "thermal",
+      args: [{ values: [-10, 0, 25, 100, 500] }, { values: [-3, 0, 5, 30, 120] }, { values: [1, 4, 10, 60] }],
+      oracle: oThermal,
+    },
+    {
+      name: "cablesag over length,weight,tension samples",
+      export: "cablesag",
+      args: [{ values: [-8, 0, 10, 40, 100] }, { values: [0, 2, 7, 20] }, { values: [1, 8, 50, 200] }],
+      oracle: oCablesag,
+    },
+    {
+      name: "power_watts over voltage,current in {0,5,12,110,240} x {0,1,4,10,20}",
+      export: "power_watts",
+      args: [{ values: [0, 5, 12, 110, 240] }, { values: [0, 1, 4, 10, 20] }],
+      oracle: oPowerWatts,
+    },
+    {
+      name: "power_safe over watts in [0..3000] step (range)",
+      export: "power_safe",
+      args: [[0, 3000]],
+      oracle: oPowerSafe,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Coprocessor_Security/Coprocessor_Security.affine
+++ b/proposals/idaptik/migrated/Coprocessor_Security/Coprocessor_Security.affine
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Coprocessor_Security -- the pure-integer scalar kernels of the idaptik security
+// co-processor, the brain extracted from src/shared/Coprocessor_Security.res. The
+// ReScript file is a five-backend registry (Crypto / Neural / Quantum / Audio /
+// Graphics) whose `cmd*` wrappers marshal an array<int> and return an
+// executionResult record. The array<int> framing, the status guards, the
+// resourceMetrics, every message string, the session-scoped entangleCounter, and
+// every Math.random / floating-point path (crack, grover, qrng, classify
+// regression, fingerprint ratios, anomaly stddev, evade noise) stay host-side --
+// those are senses, not brain. What crosses the wasm boundary is the
+// DETERMINISTIC scalar integer core: the LCG generator that drives keygen / noise
+// / scramble, and the XOR-fold / checksum bit-arithmetic that drives hash / sign /
+// verify.
+//
+// Re-decomposition notes (NOT a transliteration):
+//   * No module state; the entangleCounter ref is host-owned (it is a counter,
+//     not arithmetic). Every kernel here is a pure function of explicit Int args.
+//   * Array-shaped kernels (keygen's byte buffer, the XOR cipher, Fisher-Yates
+//     scramble, the DSP buffers, the Neural feature vectors) keep their array<int>
+//     framing host-side; the host calls `lcg_next` in its generation loop and
+//     `xor_fold_step` in its fold loop. This brain is the scalar i32 ABI spine,
+//     matching the Random.affine and Maths.affine pattern.
+//   * The LCG and the multiply-heavy steps run at the wasm i32 wraparound exactly
+//     as ReScript's `seed * 1664525 + ... & 0x7FFFFFFF` does after ToInt32; the
+//     parity oracle re-derives the .res mixing with Math.imul + |0, the
+//     established convention (see Random.affine).
+//   * Bitwise: ReScript Int.Bitwise.{lxor,land,lsr,lor,lsl} map to ^ & >> | << .
+
+// --- LCG generator (Crypto.lcgStep / Graphics.lcgStep, identical) ----------
+// Numerical-Recipes constants: a=1664525, c=1013904223, state masked to 31 bits.
+// This is the deterministic spine of keygen (the byte stream), noise (the pixel
+// pattern), and scramble/unscramble (the Fisher-Yates swap sequence -- its
+// reversibility depends on this being bit-exact).
+
+// next LCG state from a seed: (seed*a + c) masked to 31 bits.
+pub fn lcg_next(seed: Int) -> Int {
+  (seed * 1664525 + 1013904223) & 2147483647
+}
+
+// the byte emitted at a step: low 8 bits of the next state (lcgStep's 2nd tuple
+// element). The host seeds its loop with `s := lcg_next(s)` and reads this byte.
+pub fn lcg_byte(seed: Int) -> Int {
+  lcg_next(seed) & 255
+}
+
+// --- XOR-fold hash core (Crypto.xorFold / cmdHash / cmdSign) ---------------
+
+// one fold step: accumulator XOR the next value. `xorFold` is the left fold of
+// this over the array from acc=0; the host drives the loop and this kernel is the
+// step. (Named with the reserved-word guard: the running value is `acc`.)
+pub fn xor_fold_step(acc: Int, x: Int) -> Int {
+  acc ^ x
+}
+
+// big-endian byte `i` (0..3) of a 32-bit int (Crypto.intTo4Bytes element). i<0 or
+// i>3 yields 0. Mirrors land(lsr(n, 8*(3-i)), 0xFF).
+pub fn byte_at(n: Int, i: Int) -> Int {
+  if i < 0 { return 0; }
+  if i > 3 { return 0; }
+  let shift = (3 - i) * 8;
+  (n >> shift) & 255
+}
+
+// --- checksum split / recombine (Crypto.cmdSign / cmdVerify) ---------------
+
+// low byte of the 2-byte checksum sign appends (csLo = cs land 0xFF).
+pub fn checksum_lo(folded: Int) -> Int {
+  folded & 255
+}
+
+// high byte of the 2-byte checksum (csHi = lsr(cs, 8) land 0xFF).
+pub fn checksum_hi(folded: Int) -> Int {
+  (folded >> 8) & 255
+}
+
+// recombine the two stored bytes the way verify does: stored = csLo lor lsl(csHi,
+// 8). The host reads the trailing two bytes off the array and passes them here.
+pub fn checksum_combine(lo: Int, hi: Int) -> Int {
+  lo | (hi << 8)
+}
+
+// verify's gate: 1 PASS when the recomputed fold's low 16 bits equal the stored
+// checksum, 0 FAIL. Mirrors `valid = expected == stored` in cmdVerify, where
+// `stored` only ever holds 16 bits, so we compare the low 16 bits of the fold.
+// (expected is the full xor-fold; stored = combine(lo,hi) is 16-bit; the ReScript
+// sign writes exactly the low 16 bits, so an honest verify compares those.)
+pub fn verify_match(folded: Int, lo: Int, hi: Int) -> Int {
+  let stored = checksum_combine(lo, hi);
+  let expected = folded & 65535;
+  if expected == stored { 1 } else { 0 }
+}
+
+// --- crack key derivation (Crypto.cmdCrack success branch) -----------------
+// The crack ROLL is Math.random (host); but once the host decides success, the
+// derived key is the deterministic `target lxor strength` -- a pure integer
+// kernel worth pinning so the host need not re-implement the bit op.
+pub fn crack_key(target: Int, strength: Int) -> Int {
+  target ^ strength
+}

--- a/proposals/idaptik/migrated/Coprocessor_Security/coprocessor_security.config.mjs
+++ b/proposals/idaptik/migrated/Coprocessor_Security/coprocessor_security.config.mjs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Coprocessor_Security.affine (idaptik security
+// co-processor scalar kernels; scalar i32 ABI). Every oracle is an INDEPENDENT
+// JS reimplementation derived from src/shared/Coprocessor_Security.res semantics
+// -- NOT a copy of the .affine logic. Per the established Random.affine
+// convention, the multiply-bearing LCG oracle re-derives the ORIGINAL .res
+// mixing with Math.imul + |0 to model the wasm i32 wraparound (the .res
+// `seed*1664525 + ... & 0x7FFFFFFF` agrees with this after ToInt32). The pure
+// bit-op oracles use native &, >>, <<, ^, | (no large multiply, no wrap risk).
+
+const i32 = (x) => x | 0;
+
+// LCG: next = (seed*1664525 + 1013904223) & 0x7FFFFFFF  (Crypto.lcgStep).
+// Independent route uses Math.imul for the 32-bit-wrapping product.
+const oLcgNext = (seed) => i32(Math.imul(seed, 1664525) + 1013904223) & 2147483647;
+const oLcgByte = (seed) => oLcgNext(seed) & 255;
+
+// xorFold step: acc lxor x.
+const oXorStep = (acc, x) => i32(acc ^ x);
+
+// intTo4Bytes element i (big-endian byte): land(lsr(n, 8*(3-i)), 0xFF).
+const oByteAt = (n, i) => {
+  if (i < 0 || i > 3) return 0;
+  const shift = (3 - i) * 8;
+  return (n >> shift) & 255;
+};
+
+// sign's 2-byte checksum split + verify's recombination.
+const oCsLo = (f) => f & 255;
+const oCsHi = (f) => (f >> 8) & 255;
+const oCombine = (lo, hi) => i32(lo | (hi << 8));
+// verify gate: low 16 bits of fold vs the 16-bit stored checksum.
+const oVerify = (f, lo, hi) => ((f & 65535) === i32(lo | (hi << 8)) ? 1 : 0);
+
+// crack success key: target lxor strength.
+const oCrackKey = (t, s) => i32(t ^ s);
+
+// sample domains
+const SEEDS = { values: [-2147483648, -1000000, -42, -1, 0, 1, 42, 1000, 65535, 1000000, 2147483647] };
+const BYTES = { values: [0, 1, 7, 16, 42, 64, 127, 128, 200, 255] };
+
+export default {
+  affine: "Coprocessor_Security.affine",
+  cases: [
+    // --- LCG generator (keygen/noise/scramble spine) ---
+    { name: "lcg_next over i32 seed samples", export: "lcg_next", args: [SEEDS], oracle: oLcgNext },
+    { name: "lcg_byte over i32 seed samples", export: "lcg_byte", args: [SEEDS], oracle: oLcgByte },
+    // a contiguous seed sweep too, to catch any off-by-one in the constant fold
+    { name: "lcg_next over [0..512]", export: "lcg_next", args: [[0, 512]], oracle: oLcgNext },
+
+    // --- XOR-fold step (hash/sign spine) ---
+    {
+      name: "xor_fold_step over acc,x i32 samples",
+      export: "xor_fold_step",
+      args: [{ values: [-2147483648, -1, 0, 1, 255, 65535, 1000000, 2147483647] },
+             { values: [-2147483648, -1, 0, 1, 255, 65535, 1000000, 2147483647] }],
+      oracle: oXorStep,
+    },
+
+    // --- byte extraction (intTo4Bytes) ---
+    {
+      name: "byte_at over n samples x i in [-1..5]",
+      export: "byte_at",
+      args: [{ values: [0, 1, 255, 256, 0x12345678, -1, 0x7FFFFFFF, 0xABCDEF] }, [-1, 5]],
+      oracle: oByteAt,
+    },
+
+    // --- checksum split / recombine / verify (sign/verify) ---
+    { name: "checksum_lo over folded samples", export: "checksum_lo",
+      args: [{ values: [0, 1, 255, 256, 0x1234, 0xFFFF, 0x12345678, -1, 2147483647] }], oracle: oCsLo },
+    { name: "checksum_hi over folded samples", export: "checksum_hi",
+      args: [{ values: [0, 1, 255, 256, 0x1234, 0xFFFF, 0x12345678, -1, 2147483647] }], oracle: oCsHi },
+    { name: "checksum_combine over lo,hi bytes", export: "checksum_combine",
+      args: [BYTES, BYTES], oracle: oCombine },
+    {
+      name: "verify_match over folded x lo x hi",
+      export: "verify_match",
+      args: [{ values: [0, 0x1234, 0xFFFF, 0xAB12, 0x12345678, 65536, 131073] }, BYTES, BYTES],
+      oracle: oVerify,
+    },
+
+    // --- crack key derivation ---
+    {
+      name: "crack_key over target x strength",
+      export: "crack_key",
+      args: [{ values: [0, 1, 255, 0x12345678, -1, 2147483647] }, [0, 9]],
+      oracle: oCrackKey,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/DLCLoader/DLCLoader.affine
+++ b/proposals/idaptik/migrated/DLCLoader/DLCLoader.affine
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// DLCLoader -- the DLC puzzle-pack normaliser co-processor, the pure-integer core
+// extracted from idaptik src/shared/DLCLoader.res. Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; they pass primitives across
+// the wasm boundary"), the JS host keeps every PATH and JSON STRING, the
+// SafeJson.parse, every Dict read, and the whole difficulty/tier/id string
+// handling and serialiser. AffineScript owns only the integer decisions the
+// loader makes once the strings have been classified: the tier-ordinal band fold
+// and the two default-fallback selections (parMoves and the hint threshold).
+//
+// The ReScript original interleaves these integer choices with JSON.Classify,
+// Dict.get and String work. We re-decompose by lifting out exactly the numeric
+// decisions -- the tier 0..4 band, "absent vs explicit" selection -- and leaving
+// the string/JSON senses host-side. No strings cross the boundary: the host has
+// already turned "tier4"/"send"/an int field into an integer ordinal and a
+// present/explicit flag pair before it calls the brain. This file IS the
+// contract the existing host bridge (DLCLoaderCoprocessorBridge.js) already
+// links against: it expects the exports tier_clamp / tier_of_number / par_moves
+// / hint_threshold.
+//
+//## Tier-ordinal encoding (the header contract for the JS host)
+//   code  tier            code  tier
+//     0   Tier0             3   Tier3
+//     1   Tier1             4   Tier4
+//     2   Tier2
+// The taxonomy is a contiguous 0..4 band, so the band fold is one range test.
+// A tier ordinal outside 0..4 is not a defined tier: tier_clamp DECLARES the
+// loss by folding it to Tier0 (code 0) -- this mirrors parseTier's wildcard
+// (`| _ => Tier0`), a deliberate controlled collapse over the tier code, not a
+// sentinel. (echo-boundary boundary-tier.json certifies the in-band 0..4
+// round-trip; the out-of-band fold to 0 is the documented loss.)
+//
+//## Float handling (tier_of_number)
+// parseTier's Number arm truncates a JSON number toward zero (Float.toInt) then
+// folds onto 0..4. Per the migration rule "floats stay host-side", the toward-
+// zero truncation is the host's job: the scalar-i32 wasm ABI receives an i32, so
+// by the time tier_of_number runs the number is already the truncated integer
+// ordinal. tier_of_number is therefore the same band fold as tier_clamp over the
+// already-integral ordinal; both are kept as distinct exports because the host
+// bridge names both and the JS host passes a (truncated) number to one and an
+// ordinal to the other.
+
+// The number of canonical tiers in the band.
+pub fn tier_count() -> Int { 5 }
+
+// Fold an arbitrary tier ordinal onto the valid 0..4 band; an unrecognised
+// ordinal becomes Tier0 (0), matching parseTier's `| _ => Tier0` wildcard. This
+// is a DECLARED clamp (controlled loss over the tier code), not a sentinel.
+pub fn tier_clamp(ordinal: Int) -> Int {
+  if ordinal < 0 { return 0; }
+  if ordinal > 4 { return 0; }
+  ordinal
+}
+
+// Map a JSON number (already truncated toward zero by the host / the i32 ABI) to
+// a tier ordinal, folding onto 0..4 with Tier0 as the floor -- exactly what
+// parseTier's Number arm did. Identical band fold to tier_clamp; kept distinct
+// because the host bridge exposes both names.
+pub fn tier_of_number(n: Int) -> Int {
+  if n < 0 { return 0; }
+  if n > 4 { return 0; }
+  n
+}
+
+// Select parMoves: when the explicit optimal/par field is absent (present == 0)
+// fall back to the host-supplied fallback (maxMoves or the parMoves field);
+// otherwise take the explicit value. Mirrors `present == 1 ? explicit : fallback`
+// in parsePuzzleJson -- present is a flag, so any non-zero present means "given".
+pub fn par_moves(present: Int, explicit: Int, fallback: Int) -> Int {
+  if present == 0 { return fallback; }
+  explicit
+}
+
+// Select a hint threshold: the default 3 when none was present (present == 0),
+// otherwise the explicit threshold -- exactly as parseHints did
+// (`present == 1 ? explicit : 3`). present is a flag; any non-zero means "given".
+pub fn hint_threshold(present: Int, explicit: Int) -> Int {
+  if present == 0 { return 3; }
+  explicit
+}

--- a/proposals/idaptik/migrated/DLCLoader/dlcloader.config.mjs
+++ b/proposals/idaptik/migrated/DLCLoader/dlcloader.config.mjs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for DLCLoader.affine (idaptik DLC puzzle-pack normaliser;
+// scalar i32 ABI). The oracles re-derive, in plain independent JS straight from
+// DLCLoader.res, the 0..4 tier band fold (parseTier's `| _ => Tier0` wildcard)
+// and the two "absent vs explicit" selections (parMoves and the hint default 3),
+// so a codegen regression surfaces as a differential mismatch.
+
+// Tier band fold: parseTier maps an ordinal/number onto 0..4, anything else -> 0.
+const tierFold = (c) => (c >= 0 && c <= 4 ? c : 0);
+// parMoves: present flag 0 -> fallback, else explicit (parsePuzzleJson).
+const parMoves = (present, explicit, fallback) => (present === 0 ? fallback : explicit);
+// hintThreshold: present flag 0 -> default 3, else explicit (parseHints).
+const hintThreshold = (present, explicit) => (present === 0 ? 3 : explicit);
+
+export default {
+  affine: "DLCLoader.affine",
+  cases: [
+    { name: "tier_count()", export: "tier_count", args: [], oracle: () => 5 },
+    {
+      name: "tier_clamp over [-3..8]",
+      export: "tier_clamp",
+      args: [[-3, 8]],
+      oracle: (c) => tierFold(c),
+    },
+    {
+      name: "tier_of_number over [-3..8]",
+      export: "tier_of_number",
+      args: [[-3, 8]],
+      oracle: (n) => tierFold(n),
+    },
+    {
+      name: "par_moves over present{0,1,2} x explicit{7,42} x fallback{50,99}",
+      export: "par_moves",
+      args: [{ values: [0, 1, 2] }, { values: [7, 42] }, { values: [50, 99] }],
+      oracle: (present, explicit, fallback) => parMoves(present, explicit, fallback),
+    },
+    {
+      name: "hint_threshold over present{0,1,2} x explicit{0,3,9}",
+      export: "hint_threshold",
+      args: [{ values: [0, 1, 2] }, { values: [0, 3, 9] }],
+      oracle: (present, explicit) => hintThreshold(present, explicit),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/InstructionParser/InstructionParser.affine
+++ b/proposals/idaptik/migrated/InstructionParser/InstructionParser.affine
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// InstructionParser -- the pure opcode-arity VALIDATION kernel re-decomposed
+// from vm/lib/ocaml/InstructionParser.res. The ReScript original entangles
+// three things: the char-by-char TEXT PARSE (String.trim / String.split /
+// String.toUpperCase / Int.fromString -- turning a command line into tokens and
+// an uppercased mnemonic), the per-opcode ARITY CHECK (the pile of
+// `if argCount == N` branches that decide whether a given mnemonic+count is a
+// well-formed instruction), and the CONSTRUCTION of an Instruction.t via the
+// per-op `*.make` smart constructors. Per the DESIGN-VISION ("AffineScript is
+// the brain, JS/Pixi the senses; only primitives cross the wasm boundary") and
+// the explicit migration note (text->opcode parsing is a STRING sense, stays
+// host-side), the tokeniser, the uppercasing, the Int.fromString of operand
+// text, the CALL resolver, and the helpText string are senses. They never
+// become integers and stay host-side.
+//
+//## Why this split, not a port of parse/parseInternal
+// parseInternal's first half is string work: trim, split on " ", drop empties,
+// uppercase tokens[0], count the rest. AffineScript's canonical face has broken
+// string subscripting / string == , so text parsing is precisely what must NOT
+// cross. The host does that parse, maps the uppercased mnemonic to its canonical
+// integer OPCODE (the same 0..22 band VmInstruction.affine owns -- see its
+// header), and counts the operands. What it then asks the kernel is the integer
+// core that survives: "is opcode OP with argCount N a well-formed parse?" -- the
+// truth table the `if argCount == N` / `if argCount >= 3` branches encode. On a
+// 1, the host runs the matching `*.make`; on a 0, it raises the same Error.
+//
+//## Opcode encoding (the header contract for the JS host) -- VmInstruction band
+// The host passes the opcode in the canonical VmInstruction.affine order (the
+// reversible VM's instruction-set band), so the two kernels agree and the host
+// keeps ONE opcode table:
+//   tier 0 (register arithmetic)        tier 2 (stack / memory)
+//     0 NOOP    5 FLIP   10 XOR           16 PUSH   18 LOAD
+//     1 ADD     6 ROL    11 MUL           17 POP    19 STORE
+//     2 SUB     7 ROR    12 DIV          tier 3 (subroutines)
+//     3 NEGATE  8 AND                     20 CALL
+//     4 SWAP    9 OR                     tier 4 (I/O channels)
+//   tier 1 (conditionals)                 21 SEND   22 RECV
+//    13 IFZERO 14 IFPOS 15 LOOP
+// NOTE on LOOP (15): InstructionParser.res has NO text form for LOOP -- the
+// header comment says "LOOP via programmatic API". So although 15 is a valid
+// VM opcode, it is NOT a parseable instruction: accepts_arg_count(15, _) = 0,
+// and min_arg_count(15) = -1 (no text arity exists). An opcode outside 0..22 is
+// likewise not parseable: both report the out-of-band sentinel (0 / -1), never
+// fabricating an in-band arity. (Sentinels declared here; assail stays clean.)
+//
+//## Operand-TYPE checks stay host-side (declared, not migrated)
+// Three ops additionally require an operand to be an INTEGER LITERAL: ROL/ROR's
+// optional <bits> (Int.fromString, .res:79/90), LOAD's <addr> (.res:166) and
+// STORE's <addr> (.res:175); CALL additionally needs a subroutine resolver
+// (.res:187). Those are string/context concerns the host already discharged
+// before it has an integer to pass -- so they are NOT part of the integer
+// arity contract. This kernel validates only the operand COUNT, which is the
+// integer decision the arity branches share.
+
+//## How many text operands a mnemonic needs, at minimum.
+// The canonical minimum operand count for a parseable opcode. For the fixed-
+// arity ops this IS the required count; for the variable ones it is the floor:
+//   ROL/ROR (6,7): 1 minimum, 2 maximum (optional <bits>)
+//   IFZERO/IFPOS (13,14): 3 minimum, unbounded (the body is the rest)
+// LOOP (15) and any out-of-band opcode have no text form -> sentinel -1.
+pub fn min_arg_count(op: Int) -> Int {
+  if op == 0 { return 0; }    // NOOP   takes no arguments
+  if op == 1 { return 2; }    // ADD <a> <b>
+  if op == 2 { return 2; }    // SUB <a> <b>
+  if op == 3 { return 1; }    // NEGATE <a>
+  if op == 4 { return 2; }    // SWAP <a> <b>
+  if op == 5 { return 1; }    // FLIP <a>
+  if op == 6 { return 1; }    // ROL <a> [bits]
+  if op == 7 { return 1; }    // ROR <a> [bits]
+  if op == 8 { return 3; }    // AND <a> <b> <c>
+  if op == 9 { return 3; }    // OR  <a> <b> <c>
+  if op == 10 { return 2; }   // XOR <a> <b>
+  if op == 11 { return 3; }   // MUL <a> <b> <c>
+  if op == 12 { return 4; }   // DIV <a> <b> <q> <r>
+  if op == 13 { return 3; }   // IF_ZERO <test> <exit> <instr...>
+  if op == 14 { return 3; }   // IF_POS  <test> <exit> <instr...>
+  if op == 16 { return 1; }   // PUSH <reg>
+  if op == 17 { return 1; }   // POP  <reg>
+  if op == 18 { return 2; }   // LOAD <reg> <addr>
+  if op == 19 { return 2; }   // STORE <addr> <reg>
+  if op == 20 { return 1; }   // CALL <name>
+  if op == 21 { return 2; }   // SEND <port> <reg>
+  if op == 22 { return 2; }   // RECV <port> <reg>
+  -1                          // LOOP (15) / out of band: no text arity
+}
+
+//## The largest operand count a mnemonic accepts, or -1 if unbounded.
+// Fixed-arity ops: equal to the minimum. ROL/ROR cap at 2 (the optional
+// <bits>). IFZERO/IFPOS have an UNBOUNDED tail (the body instruction is
+// joinWith(" ") of every token from index 3 on, .res:128/141) -> -1 here means
+// "no upper bound" for those two specifically. LOOP / out-of-band: also -1,
+// but min_arg_count is already -1 there, so the host reads "not parseable".
+// Distinguish the two -1 meanings via min_arg_count: min == -1 => not parseable;
+// min >= 0 && max == -1 => parseable with an unbounded tail.
+pub fn max_arg_count(op: Int) -> Int {
+  if op == 6 { return 2; }    // ROL <a> [bits]
+  if op == 7 { return 2; }    // ROR <a> [bits]
+  if op == 13 { return -1; }  // IF_ZERO: unbounded body tail
+  if op == 14 { return -1; }  // IF_POS:  unbounded body tail
+  // For every other parseable op the max equals the min (fixed arity).
+  // LOOP (15) and out-of-band fall through min_arg_count's -1.
+  min_arg_count(op)
+}
+
+//## Does opcode OP accept exactly argCount N operands as a well-formed parse?
+// THE brain: the integer core of parseInternal's per-opcode arity branches
+// (.res:33-212), read as a single truth table over (opcode, argCount).
+//   * fixed-arity op: N == min                        (e.g. ADD: N == 2)
+//   * ROL/ROR (6,7):  N == 1 || N == 2                (optional <bits>)
+//   * IF_ZERO/IF_POS (13,14): N >= 3                  (the `argCount >= 3` guard)
+//   * LOOP (15) / out-of-band opcode: 0               (no text form)
+// Returns 1 = a well-formed arity, 0 = the parse Error branch. A negative
+// argCount (a malformed host count) is never well-formed -> 0.
+pub fn accepts_arg_count(op: Int, arg_count: Int) -> Int {
+  if arg_count < 0 { return 0; }       // malformed count: never valid
+  let lo = min_arg_count(op);
+  if lo < 0 { return 0; }              // LOOP / out-of-band: not parseable
+  let hi = max_arg_count(op);
+  if hi < 0 {
+    // unbounded tail (IFZERO/IFPOS): valid iff at least the minimum
+    if arg_count >= lo { 1 } else { 0 }
+  } else {
+    // bounded: valid iff within [lo, hi] (covers fixed and ROL/ROR ranges)
+    if arg_count < lo { 0 } else { if arg_count > hi { 0 } else { 1 } }
+  }
+}
+
+//## Is opcode OP a text-parseable instruction at all (any arity)?
+// 1 if the parser has a mnemonic branch for OP, 0 otherwise. Exactly the ops
+// with a defined min arity. Lets the host distinguish "Unknown instruction"
+// (.res:214) from "right mnemonic, wrong operand count". LOOP (15) and any
+// opcode outside 0..22 report 0 -- there is no text command that yields them.
+pub fn is_parseable_opcode(op: Int) -> Int {
+  if min_arg_count(op) < 0 { 0 } else { 1 }
+}

--- a/proposals/idaptik/migrated/InstructionParser/instructionparser.config.mjs
+++ b/proposals/idaptik/migrated/InstructionParser/instructionparser.config.mjs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for InstructionParser.affine (idaptik VM opcode-arity
+// validation kernel; scalar i32 ABI). The oracle re-derives the per-opcode
+// operand-count rules straight from InstructionParser.res's `if argCount == N`
+// / `if argCount >= 3` branches in plain JS, against the canonical 0..22
+// VmInstruction opcode band. A codegen regression surfaces as a differential
+// mismatch.
+//
+// Oracle re-derivation, opcode -> (.res arity rule), independent of the .affine:
+//   0 NOOP    == 0      (res:70)        13 IF_ZERO >= 3     (res:125)
+//   1 ADD     == 2      (res:34)        14 IF_POS  >= 3     (res:138)
+//   2 SUB     == 2      (res:40)        15 LOOP    (none -- programmatic only)
+//   3 NEGATE  == 1      (res:58)        16 PUSH    == 1     (res:153)
+//   4 SWAP    == 2      (res:46)        17 POP     == 1     (res:159)
+//   5 FLIP    == 1      (res:64)        18 LOAD    == 2     (res:165)
+//   6 ROL     1 or 2    (res:76,78)     19 STORE   == 2     (res:174)
+//   7 ROR     1 or 2    (res:87,89)     20 CALL    == 1     (res:185)
+//   8 AND     == 3      (res:98)        21 SEND    == 2     (res:202)
+//   9 OR      == 3      (res:104)       22 RECV    == 2     (res:207)
+//  10 XOR     == 2      (res:52)
+//  11 MUL     == 3      (res:110)
+//  12 DIV     == 4      (res:116)
+// LOOP (15) and anything outside 0..22: no text command yields it (res header +
+// res:214 "Unknown instruction").
+
+// Fixed required count per opcode, or null where the op is variable/unparseable.
+// (Keyed by the canonical VmInstruction opcode integer.)
+const FIXED = {
+  0: 0, 1: 2, 2: 2, 3: 1, 4: 2, 5: 1, 8: 3, 9: 3, 10: 2, 11: 3, 12: 4,
+  16: 1, 17: 1, 18: 2, 19: 2, 20: 1, 21: 2, 22: 2,
+};
+const validOp = (op) => Number.isInteger(op) && op >= 0 && op <= 22;
+
+const minArgCount = (op) => {
+  if (!validOp(op)) return -1;
+  if (op === 6 || op === 7) return 1; // ROL/ROR: optional bits
+  if (op === 13 || op === 14) return 3; // IF_ZERO/IF_POS: >= 3
+  if (op === 15) return -1; // LOOP: not text-parseable
+  return op in FIXED ? FIXED[op] : -1;
+};
+const maxArgCount = (op) => {
+  if (op === 6 || op === 7) return 2; // ROL/ROR cap at 2
+  if (op === 13 || op === 14) return -1; // IF_ZERO/IF_POS: unbounded body
+  return minArgCount(op); // fixed (or -1 for LOOP / out-of-band)
+};
+const acceptsArgCount = (op, n) => {
+  if (n < 0) return 0;
+  const lo = minArgCount(op);
+  if (lo < 0) return 0;
+  const hi = maxArgCount(op);
+  if (hi < 0) return n >= lo ? 1 : 0; // unbounded tail
+  return n >= lo && n <= hi ? 1 : 0;
+};
+const isParseableOpcode = (op) => (minArgCount(op) < 0 ? 0 : 1);
+
+// Sweep the full opcode band plus a couple out-of-band, and arg counts -1..6
+// (so the >= 3 / fixed / ROL-ROR-range / negative-count cases all fire).
+const OPCODE = [-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 25];
+
+export default {
+  affine: "InstructionParser.affine",
+  cases: [
+    {
+      name: "min_arg_count over opcode band + out-of-band",
+      export: "min_arg_count",
+      args: [{ values: OPCODE }],
+      oracle: minArgCount,
+    },
+    {
+      name: "max_arg_count over opcode band + out-of-band",
+      export: "max_arg_count",
+      args: [{ values: OPCODE }],
+      oracle: maxArgCount,
+    },
+    {
+      name: "is_parseable_opcode over opcode band + out-of-band",
+      export: "is_parseable_opcode",
+      args: [{ values: OPCODE }],
+      oracle: isParseableOpcode,
+    },
+    {
+      name: "accepts_arg_count over opcode band x argCount [-1..6]",
+      export: "accepts_arg_count",
+      args: [{ values: OPCODE }, [-1, 6]],
+      oracle: acceptsArgCount,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Moletaire/Moletaire.affine
+++ b/proposals/idaptik/migrated/Moletaire/Moletaire.affine
@@ -1,0 +1,594 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Moletaire -- the pure-integer behaviour brain re-decomposed from
+// src/app/companions/Moletaire.res (1317 LOC) together with the level-keyed
+// effect ladders of MoletaireCoprocessors.res and the thresholds / rate /
+// gravity formulae of MoletaireHunger.res. Moletaire is a robotic mole
+// companion: an 11-state machine (Idle -> tunnel/surface -> dig trap /
+// sabotage / carry / distract / glide -> permadeath), a single equipment slot
+// (one of 7 items), a 5-coprocessor "bay" of GURPS-style 0..3 level ladders,
+// and a gravity-based hunger system that periodically wrests control from the
+// player toward edible objects.
+//
+// Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary") the host KEEPS every SENSE: the Pixi
+// Container/Graphics drawing and the hex palette, the item-id / cable-id /
+// sound-name STRINGS, the carried-items array, the Math.random eat-roll and
+// wander-direction, the Math.sqrt edible distances, the float positions /
+// depths / timers / hunger accumulation, the option<float> targets, the
+// pendingEvents queue, the async coprocessor handle and the FeaturePacks flag.
+// The brain owns ONLY the deterministic integer DECISIONS -- no strings, no
+// arrays, no floats, no promises, no module-level mutable state cross.
+//
+//## FLOAT BOUNDARY (rule: floors stay host-side). Every float the brain needs
+// is floored host-side to an Int scaled by 1000 (a "milli-unit"); the JS caller
+// passes round(value * 1000):
+//   * depths (0.0..1.0)        -> milli-depth   (0..1000, where 1000 == 1.0)
+//   * speeds (pixels/second)   -> milli-pixels/s (px x 1000)
+//   * hunger (0.0..1.0)        -> milli-units    (0..1000)
+//   * hunger rate / pull / dt  -> milli-units    (value x 1000)
+//   * distances (pixels)       -> milli-pixels   (px x 1000)
+//   * eat-chance / multipliers -> milli-factors  (1.0 -> 1000, 0.05 -> 50)
+// Speeds and per-coprocessor effect constants are integer-valued in the source
+// (200.0, 25.0, 1.15, 0.6, ...) so the brain returns them directly in milli;
+// only the runtime depth / hunger / distance / dt are floored by the host.
+// Every comparison and the rate / gravity formulae then run in exact integer
+// arithmetic, reproducing the ReScript float compares at the floored resolution
+// (strict `>` stays strict, `>=` stays `>=`).
+//
+//## State ordinal encoding (Moletaire.res stateOrdinal, header contract)
+//   code  state               code  state
+//     0   Idle                  6   Distracted
+//     1   MovingUnderground     7   Gliding
+//     2   MovingAboveGround     8   Crushed
+//     3   DiggingTrap           9   CaughtByDog
+//     4   SabotagingCable      10   Dead
+//     5   CarryingItem        out-of-band -> -1
+//
+//## Facing encoding            ## Equipment encoding (allEquipment order)
+//   0  Left   1  Right            0  Skateboard     4  Rucksack
+//                                 1  Glider         5  FlashCamera
+//## Coprocessor level             2  BatteringRam   6  PlasmaCutter
+//   0 Stock  1 Basic            out-of-band -> -1
+//   2 Enhanced  3 Overclocked
+//                              ## Vibration band    ## Hunger behaviour
+//                                 0  NoData            0  Cooperative
+//                                 1  DirectionOnly     1  Resisting
+//                                 2  DirAndIntent      2  Devouring
+//                                 3  FullProfile       3  Wandering
+
+// ===========================================================================
+// Closed-band taxonomies. Each ordinal set below is contiguous, so the host can
+// never address a phantom state / equipment / level / band.
+// ===========================================================================
+
+pub fn state_count() -> Int { 11 }
+pub fn equipment_count() -> Int { 7 }
+pub fn level_count() -> Int { 4 }
+pub fn vibration_count() -> Int { 4 }
+pub fn behaviour_count() -> Int { 4 }
+
+fn valid_state(s: Int) -> Int {
+  if s < 0 { return 0; }
+  if s > 10 { return 0; }
+  1
+}
+
+fn valid_equipment(e: Int) -> Int {
+  if e < 0 { return 0; }
+  if e > 6 { return 0; }
+  1
+}
+
+fn valid_level(lvl: Int) -> Int {
+  if lvl < 0 { return 0; }
+  if lvl > 3 { return 0; }
+  1
+}
+
+// ===========================================================================
+// Tuning constants (Moletaire.res `module Tuning`). Speeds in milli-pixels/s;
+// depth thresholds in milli-depth (0..1000); action durations in milliseconds.
+// The host reads these so it need not duplicate the magic numbers.
+// ===========================================================================
+
+pub fn underground_speed_mu() -> Int { 200000 }   // 200.0 px/s
+pub fn above_ground_speed_mu() -> Int { 25000 }    // 25.0 px/s
+pub fn skateboard_speed_mu() -> Int { 55000 }      // 55.0 px/s
+pub fn surface_threshold_mu() -> Int { 50 }        // 0.05 depth
+pub fn dog_detection_depth_mu() -> Int { 300 }     // 0.3 depth
+pub fn trap_dig_ms() -> Int { 4000 }               // 4.0 s
+pub fn cable_sabotage_ms() -> Int { 3000 }         // 3.0 s
+pub fn distraction_ms() -> Int { 5000 }            // 5.0 s
+pub fn base_carry_capacity() -> Int { 1 }
+pub fn rucksack_carry_capacity() -> Int { 3 }
+pub fn base_eat_chance_milli() -> Int { 50 }       // 0.05 base item-eat chance
+
+// ===========================================================================
+// Carry capacity: 3 with Rucksack (equipment 4) equipped, else 1.
+// (Moletaire.res getCarryCapacity.) equipped is the equipment ordinal, or -1
+// for an empty slot.
+// ===========================================================================
+pub fn carry_capacity(equipped: Int) -> Int {
+  if equipped == 4 { return 3; }
+  1
+}
+
+// can_give_item: the mole may accept an item iff alive and currently carrying
+// fewer than its capacity (Moletaire.res giveItem). alive / carried are the
+// host-side bool / array-length passed as ints; equipped sets the capacity.
+pub fn can_give_item(alive: Int, carried: Int, equipped: Int) -> Int {
+  if alive == 0 { return 0; }
+  let cap = carry_capacity(equipped);
+  if carried < cap { return 1; }
+  0
+}
+
+// ===========================================================================
+// Movement speed selection (Moletaire.res updateMovement `speed`). Returns the
+// milli-pixels/s speed for the current state, applying the PathOptimiser
+// efficiency multiplier (passed as a milli-factor, e.g. 1150 == 1.15) where the
+// source applies it. CarryingItem underground runs at 0.7x the underground
+// speed; above ground (CarryingItem or MovingAboveGround) the skateboard
+// (equipment 0) lifts the surface speed. underground is the host's
+// depth > surfaceThreshold test (1/0). Non-moving states return 0.
+//
+//   state        current state ordinal (0..10)
+//   equipped     equipment ordinal, or -1 for empty
+//   underground  1/0: depth > surfaceThreshold
+//   path_mult_milli  PathOptimiser efficiency, milli-factor (1000 == 1.0)
+// ===========================================================================
+pub fn movement_speed_mu(state: Int, equipped: Int, underground: Int, path_mult_milli: Int) -> Int {
+  // MovingUnderground (1): underground speed x path efficiency.
+  if state == 1 {
+    return (underground_speed_mu() * path_mult_milli) / 1000;
+  }
+  // MovingAboveGround (2): skateboard lifts surface speed.
+  if state == 2 {
+    if equipped == 0 { return skateboard_speed_mu(); }
+    return above_ground_speed_mu();
+  }
+  // CarryingItem (5): underground -> 0.7x underground x path; surface -> walk.
+  if state == 5 {
+    if underground != 0 {
+      let base = (underground_speed_mu() * 7) / 10;
+      return (base * path_mult_milli) / 1000;
+    }
+    return above_ground_speed_mu();
+  }
+  0
+}
+
+// ===========================================================================
+// Facing / direction signs (the `if dx > 0 { Right } else { Left }` and
+// `if dx > 0 { 1.0 } else { -1.0 }` idioms threaded throughout the source). The
+// host passes the floored horizontal delta (milli-pixels); only the sign
+// matters. facing: dx > 0 -> Right(1) else Left(0). direction: dx > 0 -> +1,
+// dx < 0 -> -1, dx == 0 -> 0 (matches MoletaireHunger.calculatePull's tri-state
+// direction; the simpler two-way Moletaire.res sites pass dx != 0).
+// ===========================================================================
+pub fn facing_for_delta(dx_mu: Int) -> Int {
+  if dx_mu > 0 { 1 } else { 0 }
+}
+
+pub fn direction_for_delta(dx_mu: Int) -> Int {
+  if dx_mu > 0 { return 1; }
+  if dx_mu < 0 { return -1; }
+  0
+}
+
+// ===========================================================================
+// Order gates (Moletaire.res orderMoveTo / orderDigTrap / orderSabotageCable /
+// launchGlider / useFlash). Each returns 1 (accepted) / 0 (refused), mirroring
+// the guard the command checks before mutating state. alive / depth / equipped
+// come from the host. depth_mu is milli-depth (0..1000).
+// ===========================================================================
+
+// orderDigTrap / orderSabotageCable: alive, not Dead(10), and underground past
+// depth 0.1 (100 mu). Both share this gate.
+pub fn can_dig(alive: Int, state: Int, depth_mu: Int) -> Int {
+  if alive == 0 { return 0; }
+  if state == 10 { return 0; }
+  if depth_mu > 100 { return 1; }
+  0
+}
+
+// orderMoveTo: alive and not Dead(10). Returns the state to enter:
+// MovingUnderground(1) when underground requested, else MovingAboveGround(2);
+// -1 when the order is refused (so the host leaves the state unchanged).
+pub fn order_move_state(alive: Int, state: Int, underground_requested: Int) -> Int {
+  if alive == 0 { return -1; }
+  if state == 10 { return -1; }
+  if underground_requested != 0 { return 1; }
+  2
+}
+
+// launchGlider: alive, Glider(1) equipped, and on the surface (depth <
+// surfaceThreshold). 1 = the glider launches (host sets Gliding + glide vars).
+pub fn can_launch_glider(alive: Int, equipped: Int, depth_mu: Int) -> Int {
+  if alive == 0 { return 0; }
+  if equipped != 1 { return 0; }
+  if depth_mu < surface_threshold_mu() { return 1; }
+  0
+}
+
+// useFlash: alive and FlashCamera(5) equipped.
+pub fn can_use_flash(alive: Int, equipped: Int) -> Int {
+  if alive == 0 { return 0; }
+  if equipped == 5 { return 1; }
+  0
+}
+
+// distractByWire: alive, not Dead(10)/DiggingTrap(3)/SabotagingCable(4), and the
+// loose wire within 200px (200000 mu) (Moletaire.res distractByWire). 1 = the
+// mole is pulled to Distracted.
+pub fn can_distract_by_wire(alive: Int, state: Int, wire_dist_mu: Int) -> Int {
+  if alive == 0 { return 0; }
+  if state == 10 { return 0; }
+  if state == 3 { return 0; }
+  if state == 4 { return 0; }
+  if wire_dist_mu < 200000 { return 1; }
+  0
+}
+
+// ===========================================================================
+// State machine (Moletaire.res updateState). Given the current state and the
+// floored timers, returns the next state ordinal. The host owns the float
+// movement integration; the brain owns the discrete transitions.
+//
+//   state              current state ordinal (0..10)
+//   action_timer_ms    DiggingTrap/SabotagingCable countdown (ms remaining)
+//   glide_progress_mu  Gliding progress in milli (0..1000, 1000 == 1.0)
+//   distract_timer_ms  Distracted countdown (ms remaining)
+//
+// Transition provenance (updateState):
+//   Idle(0): holds (movement handled by the movement kernel above).
+//   DiggingTrap(3): actionTimer <= 0 -> Idle(0), emit TrapTriggered; else hold.
+//   SabotagingCable(4): actionTimer <= 0 -> Idle(0), emit CableSabotaged; hold.
+//   Distracted(6): distractionTimer <= 0 -> Idle(0); else hold.
+//   Gliding(7): glideProgress >= 1.0 (1000) -> Idle(0); else hold.
+//   Crushed(8)/CaughtByDog(9): -> Dead(10) (permadeath finalised).
+//   Dead(10): absorbing.
+// Moving/Carrying states (1,2,5) are driven by movement_speed_mu / the host;
+// the brain holds them here (no timer-driven transition of their own).
+// ===========================================================================
+pub fn next_state(state: Int, action_timer_ms: Int, glide_progress_mu: Int, distract_timer_ms: Int) -> Int {
+  if valid_state(state) == 0 { return -1; }
+
+  // DiggingTrap (3) / SabotagingCable (4): action timer drains to Idle.
+  if state == 3 {
+    if action_timer_ms <= 0 { return 0; }
+    return 3;
+  }
+  if state == 4 {
+    if action_timer_ms <= 0 { return 0; }
+    return 4;
+  }
+
+  // Distracted (6): distraction timer drains to Idle.
+  if state == 6 {
+    if distract_timer_ms <= 0 { return 0; }
+    return 6;
+  }
+
+  // Gliding (7): progress reaches 1.0 -> Idle.
+  if state == 7 {
+    if glide_progress_mu >= 1000 { return 0; }
+    return 7;
+  }
+
+  // Crushed (8) / CaughtByDog (9): permadeath -> Dead (10).
+  if state == 8 { return 10; }
+  if state == 9 { return 10; }
+
+  // Idle(0), moving/carrying(1,2,5), Dead(10): hold.
+  state
+}
+
+// Item-delivery eat roll (Moletaire.res updateMovement arrival branch). On
+// arrival while CarryingItem, the mole eats the carried item with probability
+// base * StabilisationCore multiplier. The host supplies the floored
+// Math.random() roll in milli (0..999) and the StabilisationCore multiplier in
+// milli-factor; the brain returns 1 = item eaten (emit ItemEaten), 0 =
+// delivered (emit ItemDelivered). eatChance = 50 * mult / 1000 (milli).
+pub fn item_eaten(roll_milli: Int, stabilisation_mult_milli: Int) -> Int {
+  let eat_chance = (base_eat_chance_milli() * stabilisation_mult_milli) / 1000;
+  if roll_milli < eat_chance { return 1; }
+  0
+}
+
+// ===========================================================================
+// Coprocessor effect ladders (MoletaireCoprocessors.res). Each is a pure
+// level(0..3) -> effect switch; the verified brain replaces the ReScript
+// ladder. An out-of-band level yields the out-of-band sentinel -1 for the
+// integer-valued ladders, 0 for the boolean gates.
+// ===========================================================================
+
+// AudioSynthesiser: distinct sound count. Stock 0 / MK-I 3 / MK-II 6 / MK-III 10.
+pub fn audio_sound_count(level: Int) -> Int {
+  if valid_level(level) == 0 { return -1; }
+  if level == 0 { return 0; }
+  if level == 1 { return 3; }
+  if level == 2 { return 6; }
+  10
+}
+
+// AudioSynthesiser: voice mimicry available only at Overclocked (3).
+pub fn can_mimic_voice(level: Int) -> Int {
+  if level == 3 { return 1; }
+  0
+}
+
+// PathOptimiser: efficiency multiplier in milli-factor. Stock 1000 (1.0) /
+// MK-I 1150 (1.15) / MK-II 1300 (1.30) / MK-III 1500 (1.50).
+pub fn path_efficiency_milli(level: Int) -> Int {
+  if valid_level(level) == 0 { return -1; }
+  if level == 0 { return 1000; }
+  if level == 1 { return 1150; }
+  if level == 2 { return 1300; }
+  1500
+}
+
+// SignalProcessor: underground sensor range in grid cells. Stock 1 / MK-I 3 /
+// MK-II 5 / MK-III 8.
+pub fn sensor_range(level: Int) -> Int {
+  if valid_level(level) == 0 { return -1; }
+  if level == 0 { return 1; }
+  if level == 1 { return 3; }
+  if level == 2 { return 5; }
+  8
+}
+
+// SignalProcessor: vault weak-point detection only at Overclocked (3).
+pub fn can_detect_vault_weak_points(level: Int) -> Int {
+  if level == 3 { return 1; }
+  0
+}
+
+// VibrationAnalyser: information band. The level maps directly onto the
+// vibration ordinal (Stock 0 NoData ... MK-III 3 FullProfile).
+pub fn vibration_band(level: Int) -> Int {
+  if valid_level(level) == 0 { return -1; }
+  level
+}
+
+// StabilisationCore: item-eat-chance multiplier in milli-factor. Stock 1000
+// (1.0) / MK-I 600 (0.6) / MK-II 200 (0.2) / MK-III 50 (0.05).
+pub fn eat_chance_multiplier_milli(level: Int) -> Int {
+  if valid_level(level) == 0 { return -1; }
+  if level == 0 { return 1000; }
+  if level == 1 { return 600; }
+  if level == 2 { return 200; }
+  50
+}
+
+// StabilisationCore: fragile-item carry available at Enhanced (2) or higher.
+pub fn can_carry_fragile(level: Int) -> Int {
+  if level >= 2 { return 1; }
+  0
+}
+
+// scanAhead gate (Moletaire.res scanAhead): only underground and alive does the
+// SignalProcessor return its range; otherwise 0. underground is the host's
+// depth > surfaceThreshold test (1/0); level is the SignalProcessor level.
+pub fn scan_ahead(alive: Int, underground: Int, level: Int) -> Int {
+  if alive == 0 { return 0; }
+  if underground == 0 { return 0; }
+  sensor_range(level)
+}
+
+// playSynthSound validity (Moletaire.res playSynthSound): the requested sound
+// index is playable iff alive, the AudioSynthesiser supports at least one sound,
+// and 0 <= index < maxSounds. 1 = play that index (host looks the name up in its
+// string array), 0 = refused. max_sounds comes from audio_sound_count.
+pub fn can_play_sound(alive: Int, max_sounds: Int, sound_index: Int) -> Int {
+  if alive == 0 { return 0; }
+  if max_sounds <= 0 { return 0; }
+  if sound_index < 0 { return 0; }
+  if sound_index >= max_sounds { return 0; }
+  1
+}
+
+// ===========================================================================
+// Hunger system (MoletaireHunger.res). Thresholds in milli-units (0..1000).
+// ===========================================================================
+
+pub fn peckish_threshold_milli() -> Int { 400 }     // 0.4
+pub fn hungry_threshold_milli() -> Int { 400 }      // 0.4
+pub fn starving_threshold_milli() -> Int { 800 }    // 0.8
+pub fn objective_eat_threshold_milli() -> Int { 900 } // 0.9
+
+// getBehaviour (MoletaireHunger.getBehaviour): classify the hunger behaviour.
+// hunger > starving(800): Devouring(2) if an edible is nearby else Wandering(3).
+// hunger > hungry(400): Resisting(1). Otherwise Cooperative(0). has_nearby is
+// the host's "an edible is in range" flag (1/0).
+pub fn hunger_behaviour(hunger_milli: Int, has_nearby: Int) -> Int {
+  if hunger_milli > starving_threshold_milli() {
+    if has_nearby != 0 { return 2; }
+    return 3;
+  }
+  if hunger_milli > hungry_threshold_milli() { return 1; }
+  0
+}
+
+// willEatObjective: hunger above objectiveEat(900) -> the mole eats a carried
+// objective (mission fail). 1/0.
+pub fn will_eat_objective(hunger_milli: Int) -> Int {
+  if hunger_milli > objective_eat_threshold_milli() { return 1; }
+  0
+}
+
+// objectiveAtRisk: hunger above starving(800) -> warn (objective at risk). 1/0.
+pub fn objective_at_risk(hunger_milli: Int) -> Int {
+  if hunger_milli > starving_threshold_milli() { return 1; }
+  0
+}
+
+// isResistingControl band (Moletaire.res update hunger loop): the mole resists
+// player control only once hunger crosses the hungry threshold (400). 1/0.
+pub fn hunger_resists(hunger_milli: Int) -> Int {
+  if hunger_milli > hungry_threshold_milli() { return 1; }
+  0
+}
+
+// hungerColor band ordinal (MoletaireHunger.hungerColor). The host owns the hex
+// palette; the brain returns the band index:
+//   0  green  (< peckish 400)        2  orange (< starving 800)
+//   1  yellow-green (< 600)          3  red    (>= starving 800)
+pub fn hunger_color_band(hunger_milli: Int) -> Int {
+  if hunger_milli < peckish_threshold_milli() { return 0; }
+  if hunger_milli < 600 { return 1; }
+  if hunger_milli < starving_threshold_milli() { return 2; }
+  3
+}
+
+// hungerDisplayString band ordinal (MoletaireHunger.hungerDisplayString). The
+// host maps the band to its label string:
+//   0 FULL (<100)        2 PECKISH (<600)       4 STARVING (<objEat 900)
+//   1 CONTENT (<peckish) 3 HUNGRY (<starving)   5 RAVENOUS (>=900)
+pub fn hunger_display_band(hunger_milli: Int) -> Int {
+  if hunger_milli < 100 { return 0; }
+  if hunger_milli < peckish_threshold_milli() { return 1; }
+  if hunger_milli < 600 { return 2; }
+  if hunger_milli < starving_threshold_milli() { return 3; }
+  if hunger_milli < objective_eat_threshold_milli() { return 4; }
+  5
+}
+
+// ===========================================================================
+// Hunger rate (MoletaireHunger.calculateHungerRate). Returns the per-second
+// hunger increase in micro-units (rate-milli x 1000, see below), exact in
+// integer arithmetic. The ReScript form is
+//   baseRate * movementMult * accelerationMult * coprocMult * levelMult
+// with movementMult = 1.5 (moving) / 0.5 (still), accelerationMult =
+//   1.0 + currentHunger*0.5. To stay integer-exact the host passes every float
+// operand as a milli-factor (x1000):
+//   base_rate_milli   baseRate    x 1000  (e.g. 0.015 -> 15)
+//   is_moving         1/0
+//   hunger_milli      currentHunger x 1000 (0..1000)
+//   coproc_mult_milli coprocMult  x 1000
+//   level_mult_milli  levelMult   x 1000
+// movementMult is 1500/500; accelerationMult = 1000 + hunger_milli/2 (milli).
+// The result is returned in MICRO-units (rate x 1_000_000), which keeps three
+// extra fractional digits for the tiny per-second rates (~0.0225/s) the host
+// then multiplies by dt.
+//
+// ABI NOTE: AffineScript `Int` is i32 in the wasm ABI, so the naive five-factor
+// product (up to ~7e17) would overflow. We instead fold a `/1000` after each
+// milli-factor past the second, keeping every intermediate <= ~7.1e8 < 2^31:
+//   a = base * movement                 (<= 35*1500          = 52500)
+//   a = a * accel  / 1000               (<= 52500*1500/1000  = 78750)
+//   a = a * coproc / 1000               (<= 78750*3000/1000  = 236250)
+//   a = a * level  / 1000               (<= 236250*3000/1000 = 708750)
+// `a` then carries exactly the micro-unit rate (each `/1000` peels one milli
+// scale; base+movement leave a x1000^2 product, and the three later `/1000`
+// land it at x1000^2 == micro). The per-step truncation is the canonical
+// contract the oracle reproduces step for step.
+// ===========================================================================
+pub fn hunger_rate_micro(base_rate_milli: Int, is_moving: Int, hunger_milli: Int, coproc_mult_milli: Int, level_mult_milli: Int) -> Int {
+  let movement_milli = if is_moving != 0 { 1500 } else { 500 };
+  let accel_milli = 1000 + hunger_milli / 2;
+  let a1 = base_rate_milli * movement_milli;
+  let a2 = (a1 * accel_milli) / 1000;
+  let a3 = (a2 * coproc_mult_milli) / 1000;
+  (a3 * level_mult_milli) / 1000
+}
+
+// ===========================================================================
+// Gravity pull magnitude (MoletaireHunger.calculatePull). The signed pull is
+//   direction * cappedMagnitude
+// where magnitude = G * hungerMult / clampedDistSq, G = 5000, distSq clamped to
+// >= 100, magnitude capped at 200, and the piecewise hungerMult is
+//   hunger < peckish(0.4):   hunger/0.4 * 0.2
+//   hunger < starving(0.8):  0.2 + (hunger-0.4)/0.4 * 0.8
+//   else:                    1.0 + (hunger-0.8)/0.2 * 2.0
+// The host computes dx/dy/distSq (float) and floors distSq to milli-pixels^2;
+// the brain returns the SIGNED pull in milli-pixels/s (host applies * dt).
+//
+// hunger_mult_milli: the hungerMult as a milli-factor (0..3000), returned by
+//   hunger_mult_milli() below so the piecewise split is itself verified.
+// dist_sq_px: clampedDistSq floored to PLAIN px^2 by the host (the host applies
+//   the >= 100 px^2 clamp before calling). px^2 is the i32-safe unit here:
+//   milli-pixels^2 would overflow i32 for any realistic distance (5000px ->
+//   2.5e13), so unlike the linear distances elsewhere the SQUARED distance
+//   crosses unscaled. Distances up to ~46000px keep px^2 < 2^31.
+// direction: -1 / 0 / +1 from direction_for_delta(dx).
+//
+// magnitude(milli, x1000) = G(5000) * hungerMult_milli / dist_sq_px, capped at
+// 200000 milli (200 px/s). 5000*hungerMult_milli (<= 5000*3000 = 1.5e7) stays
+// i32-safe, and dist_sq_px >= 100 from the clamp. Verified bit-identical to a
+// BigInt G*mult/distSq reference across the swept distSq/mult grid.
+// ===========================================================================
+pub fn hunger_mult_milli(hunger_milli: Int) -> Int {
+  // hunger < peckish (400): hunger/0.4 * 0.2 = hunger * 0.5  (milli: hunger/2).
+  if hunger_milli < peckish_threshold_milli() {
+    return hunger_milli / 2;
+  }
+  // hunger < starving (800): 0.2 + (hunger-0.4)/0.4 * 0.8.
+  //   milli: 200 + (hunger-400) * 800 / 400 = 200 + (hunger-400)*2.
+  if hunger_milli < starving_threshold_milli() {
+    return 200 + (hunger_milli - 400) * 2;
+  }
+  // else: 1.0 + (hunger-0.8)/0.2 * 2.0.
+  //   milli: 1000 + (hunger-800) * 2000 / 200 = 1000 + (hunger-800)*10.
+  1000 + (hunger_milli - 800) * 10
+}
+
+pub fn hunger_pull_mu(direction: Int, hunger_mult_milli_in: Int, dist_sq_px: Int) -> Int {
+  if dist_sq_px <= 0 { return 0; }
+  // magnitude in milli-pixels/s; numerator 5000*mult <= 1.5e7 stays i32-safe.
+  let magnitude = (5000 * hunger_mult_milli_in) / dist_sq_px;
+  let capped = if magnitude > 200000 { 200000 } else { magnitude };
+  if direction > 0 { return capped; }
+  if direction < 0 { return -capped; }
+  0
+}
+
+// ===========================================================================
+// Underground-scan trigger band (Moletaire.res update scan loop). The
+// SignalProcessor underground scan only runs while MovingUnderground(1) or
+// DiggingTrap(3). 1 = run the scan this tick, 0 = skip. (The host owns the
+// scanTimer accumulation; this is the state gate it consults at expiry.)
+// ===========================================================================
+pub fn scan_runs(state: Int) -> Int {
+  if state == 1 { return 1; }
+  if state == 3 { return 1; }
+  0
+}
+
+// ===========================================================================
+// Query predicates (Moletaire.res isAlive / isUnderground / isIdle / isDigging
+// / isDistracted / isGliding / state classification). Pure integer
+// classification over the state ordinal and the floored depth.
+// ===========================================================================
+
+// isUnderground: depth > surfaceThreshold (50 mu).
+pub fn is_underground(depth_mu: Int) -> Int {
+  if depth_mu > surface_threshold_mu() { return 1; }
+  0
+}
+
+pub fn is_idle(state: Int) -> Int { if state == 0 { 1 } else { 0 } }
+
+// isDigging: DiggingTrap(3) or SabotagingCable(4).
+pub fn is_digging(state: Int) -> Int {
+  if state == 3 { return 1; }
+  if state == 4 { return 1; }
+  0
+}
+
+pub fn is_distracted(state: Int) -> Int { if state == 6 { 1 } else { 0 } }
+pub fn is_gliding(state: Int) -> Int { if state == 7 { 1 } else { 0 } }
+
+// isDead: Crushed(8), CaughtByDog(9), or Dead(10) -- the terminal band.
+pub fn is_dead(state: Int) -> Int {
+  if valid_state(state) == 0 { return 0; }
+  if state >= 8 { return 1; }
+  0
+}
+
+// Stomp / death-cause -> state (Moletaire.res crushMole / catchByDog). The host
+// writes one value back: crush -> Crushed(8), dog catch -> CaughtByDog(9).
+pub fn crush_state() -> Int { 8 }
+pub fn caught_by_dog_state() -> Int { 9 }

--- a/proposals/idaptik/migrated/Moletaire/moletaire.config.mjs
+++ b/proposals/idaptik/migrated/Moletaire/moletaire.config.mjs
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Moletaire.affine (the robotic-mole behaviour brain
+// re-decomposed from src/app/companions/Moletaire.res + MoletaireCoprocessors.res
+// + MoletaireHunger.res). The brain is Int-only, so parity runs directly against
+// the deliverable.
+//
+// Every oracle is an INDEPENDENT re-derivation of the ReScript semantics in
+// plain JS -- the taxonomies, the Tuning constants, the per-coprocessor effect
+// ladders, the hunger thresholds / behaviour classifier / rate formula / gravity
+// pull, the order gates and the 11-state machine -- NOT a copy of the .affine. A
+// codegen regression surfaces as a differential mismatch. Units mirror the
+// brain: depths/hunger/factors in milli (1000 == 1.0), speeds/distances in
+// milli-pixels, timers in milliseconds, hunger rate in micro-units.
+
+const trunc = Math.trunc;
+
+// --- taxonomies -------------------------------------------------------------
+function validState(s) { return s >= 0 && s <= 10; }
+function validLevel(l) { return l >= 0 && l <= 3; }
+
+// --- carry capacity (Moletaire.res getCarryCapacity) ------------------------
+function carryCapacity(equipped) {
+  return equipped === 4 ? 3 : 1; // Rucksack == 4
+}
+function canGiveItem(alive, carried, equipped) {
+  if (alive === 0) return 0;
+  return carried < carryCapacity(equipped) ? 1 : 0;
+}
+
+// --- movement speed selection (Moletaire.res updateMovement) ----------------
+const UNDERGROUND = 200000, ABOVEGROUND = 25000, SKATEBOARD = 55000;
+function movementSpeed(state, equipped, underground, pathMult) {
+  if (state === 1) return trunc((UNDERGROUND * pathMult) / 1000);
+  if (state === 2) return equipped === 0 ? SKATEBOARD : ABOVEGROUND;
+  if (state === 5) {
+    if (underground !== 0) {
+      const base = trunc((UNDERGROUND * 7) / 10);
+      return trunc((base * pathMult) / 1000);
+    }
+    return ABOVEGROUND;
+  }
+  return 0;
+}
+
+// --- facing / direction signs ----------------------------------------------
+function facingForDelta(dx) { return dx > 0 ? 1 : 0; }
+function directionForDelta(dx) {
+  if (dx > 0) return 1;
+  if (dx < 0) return -1;
+  return 0;
+}
+
+// --- order gates (Moletaire.res command guards) -----------------------------
+function canDig(alive, state, depth) {
+  if (alive === 0) return 0;
+  if (state === 10) return 0;
+  return depth > 100 ? 1 : 0;
+}
+function orderMoveState(alive, state, undergroundReq) {
+  if (alive === 0) return -1;
+  if (state === 10) return -1;
+  return undergroundReq !== 0 ? 1 : 2;
+}
+function canLaunchGlider(alive, equipped, depth) {
+  if (alive === 0) return 0;
+  if (equipped !== 1) return 0; // Glider == 1
+  return depth < 50 ? 1 : 0; // surfaceThreshold == 50
+}
+function canUseFlash(alive, equipped) {
+  if (alive === 0) return 0;
+  return equipped === 5 ? 1 : 0; // FlashCamera == 5
+}
+function canDistractByWire(alive, state, wireDist) {
+  if (alive === 0) return 0;
+  if (state === 10 || state === 3 || state === 4) return 0;
+  return wireDist < 200000 ? 1 : 0;
+}
+
+// --- 11-state machine (Moletaire.res updateState) ---------------------------
+function nextState(state, actionTimer, glideProgress, distractTimer) {
+  if (!validState(state)) return -1;
+  if (state === 3) return actionTimer <= 0 ? 0 : 3;
+  if (state === 4) return actionTimer <= 0 ? 0 : 4;
+  if (state === 6) return distractTimer <= 0 ? 0 : 6;
+  if (state === 7) return glideProgress >= 1000 ? 0 : 7;
+  if (state === 8) return 10;
+  if (state === 9) return 10;
+  return state; // Idle / moving / carrying / Dead hold
+}
+function itemEaten(roll, stabMult) {
+  const eatChance = trunc((50 * stabMult) / 1000);
+  return roll < eatChance ? 1 : 0;
+}
+
+// --- coprocessor effect ladders (MoletaireCoprocessors.res) ------------------
+function audioSoundCount(l) {
+  if (!validLevel(l)) return -1;
+  return [0, 3, 6, 10][l];
+}
+function canMimicVoice(l) { return l === 3 ? 1 : 0; }
+function pathEfficiency(l) {
+  if (!validLevel(l)) return -1;
+  return [1000, 1150, 1300, 1500][l];
+}
+function sensorRange(l) {
+  if (!validLevel(l)) return -1;
+  return [1, 3, 5, 8][l];
+}
+function canDetectVault(l) { return l === 3 ? 1 : 0; }
+function vibrationBand(l) {
+  if (!validLevel(l)) return -1;
+  return l;
+}
+function eatChanceMult(l) {
+  if (!validLevel(l)) return -1;
+  return [1000, 600, 200, 50][l];
+}
+function canCarryFragile(l) { return l >= 2 ? 1 : 0; }
+function scanAhead(alive, underground, level) {
+  if (alive === 0) return 0;
+  if (underground === 0) return 0;
+  return sensorRange(level);
+}
+function canPlaySound(alive, maxSounds, idx) {
+  if (alive === 0) return 0;
+  if (maxSounds <= 0) return 0;
+  if (idx < 0) return 0;
+  if (idx >= maxSounds) return 0;
+  return 1;
+}
+
+// --- hunger thresholds / behaviour (MoletaireHunger.res) ---------------------
+const PECKISH = 400, HUNGRY = 400, STARVING = 800, OBJ_EAT = 900;
+function hungerBehaviour(hunger, hasNearby) {
+  if (hunger > STARVING) return hasNearby !== 0 ? 2 : 3;
+  if (hunger > HUNGRY) return 1;
+  return 0;
+}
+function willEatObjective(h) { return h > OBJ_EAT ? 1 : 0; }
+function objectiveAtRisk(h) { return h > STARVING ? 1 : 0; }
+function hungerResists(h) { return h > HUNGRY ? 1 : 0; }
+function hungerColorBand(h) {
+  if (h < PECKISH) return 0;
+  if (h < 600) return 1;
+  if (h < STARVING) return 2;
+  return 3;
+}
+function hungerDisplayBand(h) {
+  if (h < 100) return 0;
+  if (h < PECKISH) return 1;
+  if (h < 600) return 2;
+  if (h < STARVING) return 3;
+  if (h < OBJ_EAT) return 4;
+  return 5;
+}
+
+// --- hunger rate (MoletaireHunger.calculateHungerRate), micro-units ---------
+// rate = base * movement * accel * coproc * level, every float operand passed
+// as a milli-factor; result returned scaled by 1_000_000 (micro). movementMult
+// = 1500/500; accel = 1000 + hunger/2. Because the brain's Int is i32, the
+// product is folded with a /1000 after each milli-factor past the second; the
+// per-step truncation IS the contract, so the oracle reproduces the same chain
+// step for step (a single big division would round differently).
+function hungerRateMicro(baseRate, isMoving, hunger, coprocMult, levelMult) {
+  const movement = isMoving !== 0 ? 1500 : 500;
+  const accel = 1000 + trunc(hunger / 2);
+  const a1 = baseRate * movement;
+  const a2 = trunc((a1 * accel) / 1000);
+  const a3 = trunc((a2 * coprocMult) / 1000);
+  return trunc((a3 * levelMult) / 1000);
+}
+
+// --- gravity pull (MoletaireHunger.calculatePull) ---------------------------
+// piecewise hungerMult in milli (0..3000).
+function hungerMultMilli(h) {
+  if (h < PECKISH) return trunc(h / 2);
+  if (h < STARVING) return 200 + (h - 400) * 2;
+  return 1000 + (h - 800) * 10;
+}
+// signed pull in milli-pixels/s; magnitude_milli = G(5000)*mult/distSq_px capped
+// at 200000. distSq crosses as PLAIN px^2 (milli-px^2 would overflow i32 for any
+// realistic distance); the host clamps distSq >= 100 px^2 before calling.
+function hungerPull(direction, multMilli, distSqPx) {
+  if (distSqPx <= 0) return 0;
+  const magnitude = trunc((5000 * multMilli) / distSqPx);
+  const capped = magnitude > 200000 ? 200000 : magnitude;
+  if (direction > 0) return capped;
+  if (direction < 0) return -capped;
+  return 0;
+}
+
+// --- scan / query predicates ------------------------------------------------
+function scanRuns(state) { return state === 1 || state === 3 ? 1 : 0; }
+function isUnderground(depth) { return depth > 50 ? 1 : 0; }
+function isDigging(state) { return state === 3 || state === 4 ? 1 : 0; }
+function isDead(state) {
+  if (!validState(state)) return 0;
+  return state >= 8 ? 1 : 0;
+}
+
+export default {
+  affine: "Moletaire.affine",
+  cases: [
+    // --- taxonomy counts ---
+    { name: "state_count()", export: "state_count", args: [], oracle: () => 11 },
+    { name: "equipment_count()", export: "equipment_count", args: [], oracle: () => 7 },
+    { name: "level_count()", export: "level_count", args: [], oracle: () => 4 },
+    { name: "vibration_count()", export: "vibration_count", args: [], oracle: () => 4 },
+    { name: "behaviour_count()", export: "behaviour_count", args: [], oracle: () => 4 },
+
+    // --- Tuning constants (nullary) ---
+    { name: "underground_speed_mu()", export: "underground_speed_mu", args: [], oracle: () => 200000 },
+    { name: "above_ground_speed_mu()", export: "above_ground_speed_mu", args: [], oracle: () => 25000 },
+    { name: "skateboard_speed_mu()", export: "skateboard_speed_mu", args: [], oracle: () => 55000 },
+    { name: "surface_threshold_mu()", export: "surface_threshold_mu", args: [], oracle: () => 50 },
+    { name: "dog_detection_depth_mu()", export: "dog_detection_depth_mu", args: [], oracle: () => 300 },
+    { name: "trap_dig_ms()", export: "trap_dig_ms", args: [], oracle: () => 4000 },
+    { name: "cable_sabotage_ms()", export: "cable_sabotage_ms", args: [], oracle: () => 3000 },
+    { name: "distraction_ms()", export: "distraction_ms", args: [], oracle: () => 5000 },
+    { name: "base_carry_capacity()", export: "base_carry_capacity", args: [], oracle: () => 1 },
+    { name: "rucksack_carry_capacity()", export: "rucksack_carry_capacity", args: [], oracle: () => 3 },
+    { name: "base_eat_chance_milli()", export: "base_eat_chance_milli", args: [], oracle: () => 50 },
+
+    // --- carry capacity / give ---
+    { name: "carry_capacity over equipped [-1..7]", export: "carry_capacity", args: [[-1, 7]], oracle: (e) => carryCapacity(e) },
+    {
+      name: "can_give_item: alive x carried x equipped",
+      export: "can_give_item",
+      args: [[0, 1], { values: [0, 1, 2, 3, 4] }, { values: [-1, 0, 4] }],
+      oracle: (a, c, e) => canGiveItem(a, c, e),
+    },
+
+    // --- movement speed selection ---
+    {
+      name: "movement_speed_mu: state x equipped x underground x pathMult",
+      export: "movement_speed_mu",
+      args: [
+        [-1, 11],                              // state incl. out-of-band shoulders
+        { values: [-1, 0, 1, 4] },             // empty / skateboard / glider / rucksack
+        [0, 1],                                // underground flag
+        { values: [1000, 1150, 1300, 1500] },  // path efficiency milli
+      ],
+      oracle: (s, e, u, p) => movementSpeed(s, e, u, p),
+    },
+
+    // --- facing / direction ---
+    { name: "facing_for_delta over [-5..5]", export: "facing_for_delta", args: [[-5, 5]], oracle: (d) => facingForDelta(d) },
+    { name: "direction_for_delta over [-5..5]", export: "direction_for_delta", args: [[-5, 5]], oracle: (d) => directionForDelta(d) },
+
+    // --- order gates ---
+    {
+      name: "can_dig: alive x state x depth",
+      export: "can_dig",
+      args: [[0, 1], { values: [0, 3, 10] }, { values: [0, 99, 100, 101, 500, 1000] }],
+      oracle: (a, s, d) => canDig(a, s, d),
+    },
+    {
+      name: "order_move_state: alive x state x undergroundReq",
+      export: "order_move_state",
+      args: [[0, 1], { values: [0, 5, 10] }, [0, 1]],
+      oracle: (a, s, u) => orderMoveState(a, s, u),
+    },
+    {
+      name: "can_launch_glider: alive x equipped x depth",
+      export: "can_launch_glider",
+      args: [[0, 1], { values: [0, 1, 5] }, { values: [0, 49, 50, 51, 300] }],
+      oracle: (a, e, d) => canLaunchGlider(a, e, d),
+    },
+    {
+      name: "can_use_flash: alive x equipped",
+      export: "can_use_flash",
+      args: [[0, 1], [-1, 6]],
+      oracle: (a, e) => canUseFlash(a, e),
+    },
+    {
+      name: "can_distract_by_wire: alive x state x wireDist",
+      export: "can_distract_by_wire",
+      args: [[0, 1], { values: [0, 1, 3, 4, 6, 10] }, { values: [0, 199999, 200000, 200001, 250000] }],
+      oracle: (a, s, w) => canDistractByWire(a, s, w),
+    },
+
+    // --- state machine ---
+    {
+      name: "next_state: full table x timers x glideProgress",
+      export: "next_state",
+      args: [
+        [-1, 11],                              // state incl. out-of-band shoulders
+        { values: [-100, 0, 1, 4000] },        // action timer ms
+        { values: [0, 999, 1000, 1001] },      // glide progress milli
+        { values: [-100, 0, 1, 5000] },        // distraction timer ms
+      ],
+      oracle: (s, at, gp, dt) => nextState(s, at, gp, dt),
+    },
+    {
+      name: "item_eaten: roll x stabilisationMult",
+      export: "item_eaten",
+      args: [
+        { values: [0, 24, 25, 29, 30, 49, 50, 51, 999] },
+        { values: [50, 200, 600, 1000] },      // MK-III .. Stock multipliers
+      ],
+      oracle: (r, m) => itemEaten(r, m),
+    },
+
+    // --- coprocessor ladders ---
+    { name: "audio_sound_count over level [-1..4]", export: "audio_sound_count", args: [[-1, 4]], oracle: (l) => audioSoundCount(l) },
+    { name: "can_mimic_voice over level [-1..4]", export: "can_mimic_voice", args: [[-1, 4]], oracle: (l) => canMimicVoice(l) },
+    { name: "path_efficiency_milli over level [-1..4]", export: "path_efficiency_milli", args: [[-1, 4]], oracle: (l) => pathEfficiency(l) },
+    { name: "sensor_range over level [-1..4]", export: "sensor_range", args: [[-1, 4]], oracle: (l) => sensorRange(l) },
+    { name: "can_detect_vault_weak_points over level [-1..4]", export: "can_detect_vault_weak_points", args: [[-1, 4]], oracle: (l) => canDetectVault(l) },
+    { name: "vibration_band over level [-1..4]", export: "vibration_band", args: [[-1, 4]], oracle: (l) => vibrationBand(l) },
+    { name: "eat_chance_multiplier_milli over level [-1..4]", export: "eat_chance_multiplier_milli", args: [[-1, 4]], oracle: (l) => eatChanceMult(l) },
+    { name: "can_carry_fragile over level [-1..4]", export: "can_carry_fragile", args: [[-1, 4]], oracle: (l) => canCarryFragile(l) },
+    {
+      name: "scan_ahead: alive x underground x level",
+      export: "scan_ahead",
+      args: [[0, 1], [0, 1], [-1, 4]],
+      oracle: (a, u, l) => scanAhead(a, u, l),
+    },
+    {
+      name: "can_play_sound: alive x maxSounds x index",
+      export: "can_play_sound",
+      args: [[0, 1], { values: [0, 1, 3, 6, 10] }, { values: [-1, 0, 2, 5, 9, 10] }],
+      oracle: (a, m, i) => canPlaySound(a, m, i),
+    },
+
+    // --- hunger thresholds (nullary) ---
+    { name: "peckish_threshold_milli()", export: "peckish_threshold_milli", args: [], oracle: () => 400 },
+    { name: "hungry_threshold_milli()", export: "hungry_threshold_milli", args: [], oracle: () => 400 },
+    { name: "starving_threshold_milli()", export: "starving_threshold_milli", args: [], oracle: () => 800 },
+    { name: "objective_eat_threshold_milli()", export: "objective_eat_threshold_milli", args: [], oracle: () => 900 },
+
+    // --- hunger behaviour / risk ---
+    {
+      name: "hunger_behaviour: hunger x hasNearby",
+      export: "hunger_behaviour",
+      args: [{ values: [0, 400, 401, 800, 801, 1000] }, [0, 1]],
+      oracle: (h, n) => hungerBehaviour(h, n),
+    },
+    { name: "will_eat_objective over hunger sweep", export: "will_eat_objective", args: [{ values: [0, 800, 899, 900, 901, 1000] }], oracle: (h) => willEatObjective(h) },
+    { name: "objective_at_risk over hunger sweep", export: "objective_at_risk", args: [{ values: [0, 799, 800, 801, 1000] }], oracle: (h) => objectiveAtRisk(h) },
+    { name: "hunger_resists over hunger sweep", export: "hunger_resists", args: [{ values: [0, 399, 400, 401, 1000] }], oracle: (h) => hungerResists(h) },
+    { name: "hunger_color_band over [0..1000 step]", export: "hunger_color_band", args: [{ values: [0, 399, 400, 599, 600, 799, 800, 1000] }], oracle: (h) => hungerColorBand(h) },
+    { name: "hunger_display_band over [0..1000 step]", export: "hunger_display_band", args: [{ values: [0, 99, 100, 399, 400, 599, 600, 799, 800, 899, 900, 1000] }], oracle: (h) => hungerDisplayBand(h) },
+
+    // --- hunger rate (micro-units) ---
+    {
+      name: "hunger_rate_micro: base x moving x hunger x coproc x level",
+      export: "hunger_rate_micro",
+      args: [
+        { values: [15, 35] },                  // base hunger rate (0.015), training (0.035)
+        [0, 1],
+        { values: [0, 400, 800, 1000] },
+        { values: [1000, 600, 50] },
+        { values: [1000, 1500, 3000] },
+      ],
+      oracle: (b, m, h, c, l) => hungerRateMicro(b, m, h, c, l),
+    },
+
+    // --- gravity pull ---
+    { name: "hunger_mult_milli over hunger sweep", export: "hunger_mult_milli", args: [{ values: [0, 200, 399, 400, 600, 799, 800, 900, 1000] }], oracle: (h) => hungerMultMilli(h) },
+    {
+      name: "hunger_pull_mu: direction x multMilli x distSqPx",
+      export: "hunger_pull_mu",
+      args: [
+        { values: [-1, 0, 1] },
+        { values: [0, 100, 500, 1000, 3000] },
+        { values: [0, 100, 2500, 250000, 10000000, 2000000000] }, // px^2: clamp..near-i32-max
+      ],
+      oracle: (d, m, q) => hungerPull(d, m, q),
+    },
+
+    // --- scan / query predicates ---
+    { name: "scan_runs over state [-1..11]", export: "scan_runs", args: [[-1, 11]], oracle: (s) => scanRuns(s) },
+    { name: "is_underground over depth sweep", export: "is_underground", args: [{ values: [0, 49, 50, 51, 1000] }], oracle: (d) => isUnderground(d) },
+    { name: "is_idle over state [-1..11]", export: "is_idle", args: [[-1, 11]], oracle: (s) => (s === 0 ? 1 : 0) },
+    { name: "is_digging over state [-1..11]", export: "is_digging", args: [[-1, 11]], oracle: (s) => isDigging(s) },
+    { name: "is_distracted over state [-1..11]", export: "is_distracted", args: [[-1, 11]], oracle: (s) => (s === 6 ? 1 : 0) },
+    { name: "is_gliding over state [-1..11]", export: "is_gliding", args: [[-1, 11]], oracle: (s) => (s === 7 ? 1 : 0) },
+    { name: "is_dead over state [-1..11]", export: "is_dead", args: [[-1, 11]], oracle: (s) => isDead(s) },
+    { name: "crush_state()", export: "crush_state", args: [], oracle: () => 8 },
+    { name: "caught_by_dog_state()", export: "caught_by_dog_state", args: [], oracle: () => 9 },
+  ],
+};

--- a/proposals/idaptik/migrated/StateDiff/StateDiff.affine
+++ b/proposals/idaptik/migrated/StateDiff/StateDiff.affine
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// StateDiff -- the pure per-variable change-classification kernel re-decomposed
+// from vm/lib/ocaml/StateDiff.res. The ReScript original entangles four things:
+// the dict<int> key-union over two states (Dict.keysToArray + Set dedup), the
+// per-variable change DECISION over a pair of option<int> values, the aggregate
+// COUNT of changed variables, and a pile of STRING presentation (printDiff,
+// printSideBySide, padLeft/padRight, printMismatches). Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; only primitives cross the
+// wasm boundary"), the variable NAMES, the dict, the key-union, and every
+// Console.log are senses -- they never become integers and stay host-side.
+// What crosses is the deterministic arithmetic at the heart of every one of
+// those functions: GIVEN one variable's before/after values, is it a change,
+// and does it match its target. The kernel is stateless and total.
+//
+//## Why this split, not a port of computeDiff/printDiff
+// computeDiff walks string keys, builds `diff` records, and the print/side-by-
+// side/mismatch functions format them into strings. The string keys and the
+// records and the formatting are senses. The integer core is the per-pair
+// truth table the `changed` switch (StateDiff.res:25-30) and the getMismatches
+// per-key switch (StateDiff.res:146-149) each encode. The host owns the key
+// loop; it folds this kernel over each key and tallies the host-side count.
+//
+//## option<int> encoding (the header contract for the JS host)
+// An option<int> cannot cross the scalar-i32 boundary, so the host splits it
+// into a PRESENCE FLAG and a VALUE. present = 1 means Some(value); present = 0
+// means None (and value is then ignored -- the host may pass any int, the
+// kernel never reads it). This is the standard option-lowering for the i32 ABI.
+// No string and no option crosses; only the four i32s of a (before, after) pair.
+
+//## changed? -- the integer core of the `changed` switch (StateDiff.res:25-30).
+// Mirrors the truth table exactly: both present -> values differ; exactly one
+// present (appeared or disappeared) -> 1; neither present -> 0. Returns the
+// .res bool as 1/0. This is what computeDiff stamps into each diff.changed and
+// what countChanges / printDiff each filter on.
+//   (Some v1, Some v2) -> v1 != v2     (None, Some _) -> 1
+//   (Some _,  None)    -> 1            (None, None)   -> 0
+pub fn change_flag(
+  before_present: Int,
+  before_val: Int,
+  after_present: Int,
+  after_val: Int,
+) -> Int {
+  if before_present == 1 {
+    if after_present == 1 {
+      // both Some: changed iff the values differ
+      if before_val != after_val { 1 } else { 0 }
+    } else {
+      // Some before, None after: disappeared -> changed
+      1
+    }
+  } else {
+    if after_present == 1 {
+      // None before, Some after: appeared -> changed
+      1
+    } else {
+      // None, None: nothing to change
+      0
+    }
+  }
+}
+
+//## matches-target? -- the integer core of the getMismatches per-key switch
+// (StateDiff.res:146-149), read as its complement. A key MATCHES its target iff
+// both current and target are present and equal; any absence, or a value
+// difference, is a mismatch. Returns 1 = matches, 0 = mismatch. The host folds
+// this over the target keys: matchesTarget is "every key matches" (all 1s);
+// getMismatches collects the keys where this is 0; printMismatches counts them.
+//   (Some v1, Some v2) -> v1 == v2      _ -> 0 (a mismatch)
+pub fn matches_target(
+  current_present: Int,
+  current_val: Int,
+  target_present: Int,
+  target_val: Int,
+) -> Int {
+  if current_present == 1 {
+    if target_present == 1 {
+      // both Some: matches iff equal
+      if current_val == target_val { 1 } else { 0 }
+    } else {
+      // target absent -> the getMismatches `_` arm -> mismatch
+      0
+    }
+  } else {
+    // current absent -> the getMismatches `_` arm -> mismatch
+    0
+  }
+}
+
+//## is-mismatch? -- the direct getMismatches predicate (StateDiff.res:142-150),
+// the boolean Array.filter keeps. Exactly the negation of matches_target, given
+// as its own export so the host can call whichever polarity its loop wants
+// without a host-side flip. 1 = this key is a mismatch (filtered in), 0 = not.
+pub fn is_mismatch(
+  current_present: Int,
+  current_val: Int,
+  target_present: Int,
+  target_val: Int,
+) -> Int {
+  if matches_target(current_present, current_val, target_present, target_val) == 1 {
+    0
+  } else {
+    1
+  }
+}

--- a/proposals/idaptik/migrated/StateDiff/statediff.config.mjs
+++ b/proposals/idaptik/migrated/StateDiff/statediff.config.mjs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for StateDiff.affine (idaptik VM state-diff kernel;
+// scalar i32 ABI). The oracle re-derives the per-variable change/mismatch truth
+// tables straight from StateDiff.res in plain JS, so a codegen regression
+// surfaces as a differential mismatch. option<int> is lowered to a (present,
+// value) pair: present in {0,1}; value swept over a small signed band so the
+// equal / not-equal split is exercised on both sides.
+//
+// Oracle re-derivations (independent of the .affine):
+//   change_flag   <- StateDiff.res:25-30  (the `changed` switch)
+//   matches_target<- StateDiff.res:146-149 (getMismatches per-key switch, negated)
+//   is_mismatch   <- StateDiff.res:142-150 (the filter predicate itself)
+const changeFlag = (bp, bv, ap, av) => {
+  if (bp === 1 && ap === 1) return bv !== av ? 1 : 0; // (Some,Some) -> v1!=v2
+  if (bp === 0 && ap === 1) return 1; // (None,Some) -> true
+  if (bp === 1 && ap === 0) return 1; // (Some,None) -> true
+  return 0; // (None,None) -> false
+};
+const matchesTarget = (cp, cv, tp, tv) => {
+  if (cp === 1 && tp === 1) return cv === tv ? 1 : 0; // both Some -> equal?
+  return 0; // any absence -> getMismatches `_` arm -> not a match
+};
+const isMismatch = (cp, cv, tp, tv) => (matchesTarget(cp, cv, tp, tv) === 1 ? 0 : 1);
+
+// Presence in {0,1}; values swept over a 3-wide band {-1,0,1} so equal and
+// not-equal cases both fire under the Cartesian product.
+const PRESENT = { values: [0, 1] };
+const VAL = { values: [-1, 0, 1] };
+
+export default {
+  affine: "StateDiff.affine",
+  cases: [
+    {
+      name: "change_flag over present^2 x value^2",
+      export: "change_flag",
+      args: [PRESENT, VAL, PRESENT, VAL],
+      oracle: changeFlag,
+    },
+    {
+      name: "matches_target over present^2 x value^2",
+      export: "matches_target",
+      args: [PRESENT, VAL, PRESENT, VAL],
+      oracle: matchesTarget,
+    },
+    {
+      name: "is_mismatch over present^2 x value^2",
+      export: "is_mismatch",
+      args: [PRESENT, VAL, PRESENT, VAL],
+      oracle: isMismatch,
+    },
+  ],
+};


### PR DESCRIPTION
## Migration wave 2 — 6 integer-brain kernels from string-gated idaptik modules

Continues the integer-brain extraction (the C1–C12 pattern: pure-integer decision logic crosses to `.affine`/wasm; strings/floats/async stay host-side as "senses"). Each kernel is a four-gate deliverable — G1 compile, G2 **independent-oracle** differential parity, G4 assail-clean — and **every one was re-verified by me**, not just self-reported by the agent that wrote it:

| Kernel | Exports | Parity |
|---|---|---|
| DLCLoader | tier_count/clamp/of_number, par_moves, hint_threshold | 46/46 |
| CharacterSelectScreen | csel_trunc_* / grid placement | 161/161 |
| StateDiff | change_flag, matches_target, is_mismatch | 108/108 |
| InstructionParser | min/max/accepts_arg_count, is_parseable_opcode | 297/297 |
| Coprocessor_Compute | gcd, mod_nonneg, is_prime, fib, pow_clamped, signal, thermal, cablesag, power_* | 4839/4839 |
| Coprocessor_Security | LCG spine + XOR-fold/checksum bit-arithmetic | 1533/1533 |

All assail-clean (0 findings). Re-decompositions, not transliterations — e.g. CharacterSelectScreen sees only the *length Int* (the string stays host-side), InstructionParser reuses the canonical `VmInstruction` 0..22 opcode band (text parse host-side), Coprocessor_Security's LCG models i32 wraparound with `Math.imul`/`|0` in its independent oracle.

**`NO_NEW_BRAINS` this wave (honest non-results):** GossamerFs (`%raw` IPC senses), KernelMonitor (already covered by the `uirenderlogic` cross-cutting coprocessor), SafeJson (pure JSON-text parsing — no integer core).

A 7th kernel (Moletaire) is still extracting and will be added to this branch when verified.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_