### PR TITLE
migration: wave 3 — 5 integer brains (NetworkZones, Terminal, VmState, VMNetwork, VMMessageBus)

### DIFF
--- a/proposals/idaptik/migrated/NetworkZones/NetworkZones.affine
+++ b/proposals/idaptik/migrated/NetworkZones/NetworkZones.affine
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// NetworkZones -- the zone-category taxonomy + ISP-routing-class co-processor,
+// the pure-integer core extracted from src/app/devices/NetworkZones.res. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only primitives
+// cross the wasm boundary"), the JS host keeps EVERY string: the subnet prefixes
+// and the String.startsWith IP-to-zone matching, the zone-id strings, the
+// per-zone canAccessZones string arrays and their membership tests, the display
+// names and security-level strings. AffineScript owns only the canonical integer
+// encoding of the eight zone categories and the routing-class decision that the
+// ReScript canRouteViaISP makes purely over those categories.
+//
+// The ReScript original is an 8-constructor variant `zoneCategory`; routing
+// (canRouteViaISP) branches first on the DESTINATION category -- a Service
+// destination is reachable through the ISP tier hierarchy, an ISP destination is
+// reachable as part of that hierarchy, and any other category is NOT ISP-routed
+// at all (returns false before any access-list check). We re-decompose the
+// variant as the canonical 0..7 integer the constructor order already implies,
+// so category validity is one range test and the routing-class is a closed band
+// switch over the destination category. The string access-list checks stay
+// host-side; the brain only decides WHICH class of routing applies, so the host
+// knows which checks to run. The variant IS the integer; no strings cross.
+//
+//## Zone-category encoding (the header contract for the JS host)
+//   code  category     code  category
+//     0   LAN            4   Management
+//     1   DMZ            5   SCADA
+//     2   Internal       6   ISP
+//     3   IoT            7   Service
+// Order is NetworkZones.res `zoneCategory`. The encoding is LOSSLESS: eight
+// distinct categories map to eight distinct codes, so the host round-trips
+// category <-> code with no collision. A code outside 0..7 is not a category:
+// is_valid_category reports 0 and clamp_category returns the out-of-band
+// sentinel -1 -- never an in-band code, so no in-band collision is introduced
+// (this is a sentinel, not a clamp; assail stays clean).
+//
+//## Routing-class encoding (the second header contract)
+// routing_class(dest_category) classifies the destination category by HOW the
+// host must test reachability via the ISP-tier mechanism (NetworkZones.res
+// canRouteViaISP):
+//     2  TIER_ENDPOINT   destination is a public Service (code 7): reachable if
+//                        the source can reach ANY ISP tier or "public". Host runs
+//                        the four isp-tier* + public access-list checks.
+//     1  TIER_MEMBER     destination is ISP infrastructure (code 6): reachable if
+//                        the source can reach this ISP id, a lower tier, or
+//                        "public". Host runs the dest-id + lower-tier + public
+//                        access-list checks.
+//     0  NOT_ROUTED      any other valid category (0..5): canRouteViaISP returns
+//                        false immediately; the host runs NO ISP-tier check.
+//    -1  NOT_A_CATEGORY  the destination code is out of band (not 0..7).
+// The class is exactly the branch canRouteViaISP takes; the brain replaces the
+// `destZone.category == Service` / `== ISP` / else cascade with one integer
+// switch so the host needs no category enum of its own.
+
+// The number of canonical zone categories in the taxonomy.
+pub fn category_count() -> Int { 8 }
+
+// The integer code of the LAN category (band floor, for host symmetry).
+pub fn lan_category() -> Int { 0 }
+
+// The integer code of the ISP category -- the category whose destinations are
+// ISP-tier MEMBERS (canRouteViaISP `destZone.category == ISP` arm).
+pub fn isp_category() -> Int { 6 }
+
+// The integer code of the Service category -- the category whose destinations
+// are ISP-tier ENDPOINTS (canRouteViaISP `destZone.category == Service` arm).
+pub fn service_category() -> Int { 7 }
+
+// Whether a host integer names a defined zone category. 1 = valid, 0 = out of
+// band. The eight categories form the contiguous closed band 0..7.
+pub fn is_valid_category(code: Int) -> Int {
+  if code < 0 { 0 } else { if code > 7 { 0 } else { 1 } }
+}
+
+// Canonicalise a host integer: identity on a valid 0..7 code, the out-of-band
+// sentinel -1 otherwise. -1 is not an in-band code, so out-of-band input can
+// never be confused with a real category (this is a sentinel, not a clamp).
+pub fn clamp_category(code: Int) -> Int {
+  if is_valid_category(code) == 1 { code } else { -1 }
+}
+
+// Classify a DESTINATION zone category by its ISP-tier routing class -- the pure
+// integer core of NetworkZones.res canRouteViaISP. Returns the routing-class
+// band 2 / 1 / 0 / -1 (see header). The host parses IPs to zones (strings) and
+// runs the per-class access-list string checks; the brain only says which class
+// applies, replacing the `category == Service` / `== ISP` / else cascade.
+pub fn routing_class(dest_category: Int) -> Int {
+  if is_valid_category(dest_category) == 0 { return -1; }
+  if dest_category == 7 { return 2; }
+  if dest_category == 6 { return 1; }
+  0
+}
+
+// Whether a destination category is reachable through the ISP-tier mechanism at
+// all (canRouteViaISP can return true only for these). 1 for Service or ISP
+// destinations, 0 for any other valid category, 0 for out-of-band. This is the
+// host's fast pre-check: if 0, skip every ISP-tier access-list test outright.
+pub fn is_isp_routable(dest_category: Int) -> Int {
+  let cls = routing_class(dest_category);
+  if cls > 0 { 1 } else { 0 }
+}

--- a/proposals/idaptik/migrated/NetworkZones/networkzones.config.mjs
+++ b/proposals/idaptik/migrated/NetworkZones/networkzones.config.mjs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for NetworkZones.affine (idaptik zone-category taxonomy +
+// ISP-routing-class kernel; scalar i32 ABI). The oracle re-derives, from the
+// original NetworkZones.res semantics, the 0..7 category band and the routing
+// class that canRouteViaISP branches on, so a codegen regression surfaces as a
+// differential mismatch.
+//
+// Original logic (ReScript, NetworkZones.res):
+//   zoneCategory order: LAN=0 DMZ=1 Internal=2 IoT=3 Management=4 SCADA=5
+//                       ISP=6 Service=7
+//   canRouteViaISP(source, dest):
+//     if dest.category == Service  -> reachable via any ISP tier or "public"
+//     else if dest.category == ISP -> reachable via the tier hierarchy / public
+//     else                         -> false   (not ISP routing)
+//   => the routing CLASS is a pure function of dest.category:
+//        Service -> endpoint-class (2), ISP -> member-class (1), else -> 0.
+
+// Independent oracle: category validity over the closed 0..7 band.
+const validCategory = (c) => c >= 0 && c <= 7;
+
+// Independent oracle: the routing class canRouteViaISP selects on dest.category.
+// Service (7) is the tier endpoint; ISP (6) is a tier member; every other valid
+// category routes through neither branch (canRouteViaISP returns false); an
+// out-of-band code is not a category at all.
+function oracleRoutingClass(destCategory) {
+  if (!validCategory(destCategory)) return -1;
+  if (destCategory === 7) return 2; // Service
+  if (destCategory === 6) return 1; // ISP
+  return 0; // LAN/DMZ/Internal/IoT/Management/SCADA -> not ISP-routed
+}
+
+export default {
+  affine: "NetworkZones.affine",
+  cases: [
+    { name: "category_count()", export: "category_count", args: [], oracle: () => 8 },
+    { name: "lan_category()", export: "lan_category", args: [], oracle: () => 0 },
+    { name: "isp_category()", export: "isp_category", args: [], oracle: () => 6 },
+    { name: "service_category()", export: "service_category", args: [], oracle: () => 7 },
+    {
+      name: "is_valid_category over [-3..11]",
+      export: "is_valid_category",
+      args: [[-3, 11]],
+      oracle: (c) => (validCategory(c) ? 1 : 0),
+    },
+    {
+      name: "clamp_category over [-3..11]",
+      export: "clamp_category",
+      args: [[-3, 11]],
+      oracle: (c) => (validCategory(c) ? c : -1),
+    },
+    {
+      name: "routing_class over [-3..11]",
+      export: "routing_class",
+      args: [[-3, 11]],
+      oracle: (c) => oracleRoutingClass(c),
+    },
+    {
+      name: "is_isp_routable over [-3..11]",
+      export: "is_isp_routable",
+      args: [[-3, 11]],
+      oracle: (c) => (oracleRoutingClass(c) > 0 ? 1 : 0),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Terminal/Terminal.affine
+++ b/proposals/idaptik/migrated/Terminal/Terminal.affine
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Terminal -- the terminal command-processor co-processor, the pure-integer
+// core extracted from idaptik src/app/devices/Terminal.res. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; they pass
+// primitives across the wasm boundary"), the JS host keeps EVERY string: the
+// command-line tokeniser (String.split / trim / startsWith / slice), the SSH
+// host parser, path concatenation, the per-line Pixi Text objects, the output
+// formatting, and the %raw keydown handler. ALL string parsing is a host sense
+// and stays in ReScript. AffineScript owns only the integer logic that the
+// original module computes around those strings:
+//
+//   * the command taxonomy as a closed integer band (after the host tokenises a
+//     command string to a command CODE) -- validity, feature-gating, count;
+//   * the SSH-session-stack bounds (top index, empty test, push/pop depth) --
+//     the host holds the actual sshSession records, keyed by the depth this
+//     core computes;
+//   * the output ring-buffer eviction count (Terminal.res:55 while-loop);
+//   * the maxLines geometry from the pixel height (Terminal.res:1064), in
+//     milli-units because the floats are ratios of pixels;
+//   * the cursor-blink accumulator state machine (Terminal.res:1108), the
+//     accumulator carried in milli-seconds;
+//   * the backspace length clamp (Terminal.res:967), len-1 floored at 0.
+//
+// Re-decomposition (NOT transliteration): the ReScript `handleBuiltInCommand`
+// is one 700-line string `switch`. That switch IS a host sense -- the host
+// tokenises and dispatches on the string. What the brain contributes is the
+// *shape* of the command space: a contiguous 0..N-1 band whose upper segment is
+// feature-gated. The string switch becomes a range test plus a gate test. No
+// strings cross the boundary; no module state survives (the sshStack length,
+// the line count, the blink accumulator and the input length are all explicit
+// Int parameters -- the host owns the arrays and passes their measured sizes).
+//
+//## Command-code encoding (the header contract for the JS host)
+// The host tokenises `cmd` (Terminal.res:932) to one of these canonical codes.
+// The order mirrors the `switch cmd` arms in handleBuiltInCommand; codes 0..16
+// are the always-available builtins, codes 17..23 are the invertible-
+// programming pack (gated by FeaturePacks.isInvertibleProgrammingEnabled at
+// Terminal.res:592/599/609/619/627/698/902). Any token the host cannot map is
+// passed as -1 ("command not found", Terminal.res:916).
+//
+//   code  command     code  command       code  command
+//     0   help          8   reboot         16   pbx
+//     1   clear         9   scan          ----  -- gated pack below --
+//     2   pwd          10   crack          17   vm
+//     3   ls           11   ssh            18   puzzle
+//     4   cd           12   ping           19   send
+//     5   cat          13   exit           20   recv
+//     6   mkdir        14   shutdown       21   coproc
+//     7   rm           15   covert         22   vmnet
+//                                          23   undo
+//   (cp folds onto the same ungated band as its siblings; the host maps it to a
+//    free always-available code -- it is not separately gated. The taxonomy
+//    boundary the brain certifies is "ungated 0..16 vs gated 17..23", which is
+//    the only integer distinction the dispatcher makes.)
+//
+// The encoding is LOSSLESS over the dispatch decision: distinct command codes
+// stay distinct, and is_command_available is the exact predicate the ReScript
+// `if FeaturePacks.isInvertibleProgrammingEnabled()` guard computes. A code
+// outside 0..23 is not a command: is_valid_command reports 0 and
+// canonicalise_command returns the out-of-band sentinel -1 -- never an in-band
+// code, so out-of-band input can never collide with a real command (this is a
+// sentinel, not a clamp; assail stays clean).
+
+// ---------------------------------------------------------------------------
+// Command taxonomy
+// ---------------------------------------------------------------------------
+
+// The number of always-available (ungated) builtin commands: codes 0..16.
+pub fn ungated_command_count() -> Int { 17 }
+
+// The total number of canonical command codes, ungated plus the gated
+// invertible-programming pack (codes 17..23): 24 codes, 0..23.
+pub fn command_count() -> Int { 24 }
+
+// Whether a host integer names a defined command code. 1 = valid, 0 = out of
+// band. Mirrors "did the tokeniser produce a known command" (Terminal.res:932,
+// where an unknown token falls to the `_` arm at 907).
+pub fn is_valid_command(code: Int) -> Int {
+  if code < 0 { 0 } else { if code > 23 { 0 } else { 1 } }
+}
+
+// Whether a command code belongs to the feature-gated invertible-programming
+// pack (codes 17..23: vm, puzzle, send, recv, coproc, vmnet, undo). 1 = gated,
+// 0 = ungated-or-invalid.
+pub fn is_gated_command(code: Int) -> Int {
+  if is_valid_command(code) == 0 { 0 } else { if code < 17 { 0 } else { 1 } }
+}
+
+// Whether a command code may run, given the invertible-programming feature
+// flag. This is the exact predicate the ReScript `if
+// FeaturePacks.isInvertibleProgrammingEnabled()` guard computes at
+// Terminal.res:592/599/609/619/627/698/902: an ungated command always runs; a
+// gated command runs only when the flag is on; an invalid code never runs.
+// `feature_on` is the host-passed boolean (1 = enabled, else 0).
+// 1 = available (host dispatches the command), 0 = "command not found".
+pub fn is_command_available(code: Int, feature_on: Int) -> Int {
+  if is_valid_command(code) == 0 {
+    0
+  } else {
+    if is_gated_command(code) == 0 {
+      1
+    } else {
+      if feature_on == 1 { 1 } else { 0 }
+    }
+  }
+}
+
+// Canonicalise a host command integer: identity on a valid 0..23 code, the
+// out-of-band sentinel -1 otherwise. -1 is not an in-band code, so an
+// unrecognised token can never be confused with a real command (sentinel, not
+// a clamp).
+pub fn canonicalise_command(code: Int) -> Int {
+  if is_valid_command(code) == 1 { code } else { -1 }
+}
+
+// ---------------------------------------------------------------------------
+// SSH session-stack bounds (Terminal.res:199-209, 478-510)
+// ---------------------------------------------------------------------------
+
+// The index of the active SSH session given a stack of `depth` sessions: the
+// top index `depth - 1` when SSH'd, or the out-of-band sentinel -1 when the
+// stack is empty (local terminal -- getActiveState falls through to the local
+// deviceState, Terminal.res:206). The host indexes its sshStack array with this.
+pub fn ssh_active_index(depth: Int) -> Int {
+  if depth > 0 { depth - 1 } else { -1 }
+}
+
+// Whether the terminal is inside an SSH session (Terminal.res:200/478): the
+// `Array.length(terminal.sshStack) > 0` test. 1 = remote (SSH'd), 0 = local.
+pub fn ssh_is_remote(depth: Int) -> Int {
+  if depth > 0 { 1 } else { 0 }
+}
+
+// The stack depth after pushing one SSH session (Terminal.res:418): depth + 1.
+// Bounded below at 0 so a negative host measurement cannot produce depth 0.
+pub fn ssh_push_depth(depth: Int) -> Int {
+  if depth < 0 { 1 } else { depth + 1 }
+}
+
+// The stack depth after popping one SSH session on `exit` (Terminal.res:487):
+// depth - 1, floored at 0 (you cannot pop below empty; the ReScript guards the
+// pop behind `length > 0` at 478, so the floor is the same invariant made
+// total).
+pub fn ssh_pop_depth(depth: Int) -> Int {
+  if depth > 0 { depth - 1 } else { 0 }
+}
+
+// After an `exit` pop, whether the terminal is still in a (nested) SSH session
+// and must restore the previous host's prompt rather than the local prompt
+// (Terminal.res:494). Given the depth BEFORE the pop, the post-pop depth is
+// ssh_pop_depth(depth); this returns 1 iff that residual depth is still > 0.
+pub fn ssh_prompt_is_remote_after_exit(depth: Int) -> Int {
+  if ssh_pop_depth(depth) > 0 { 1 } else { 0 }
+}
+
+// ---------------------------------------------------------------------------
+// Output ring buffer (Terminal.res:55-62)
+// ---------------------------------------------------------------------------
+
+// How many of the oldest output lines to evict so the buffer fits maxLines.
+// Mirrors the `while Array.length(terminal.outputLines) > terminal.maxLines`
+// drop-front loop (Terminal.res:55): the excess is line_count - max_lines when
+// positive, else 0. The host destroys exactly this many head Text objects and
+// slices them off (Terminal.res:58-59). max_lines is treated as >= 0.
+pub fn output_evict_count(line_count: Int, max_lines: Int) -> Int {
+  let cap = if max_lines < 0 { 0 } else { max_lines };
+  if line_count > cap { line_count - cap } else { 0 }
+}
+
+// ---------------------------------------------------------------------------
+// maxLines geometry (Terminal.res:1063-1064), milli-units
+// ---------------------------------------------------------------------------
+
+// The number of visible output lines a terminal of `height_mpx` (pixel height
+// in milli-pixels, i.e. host height *1000) can show, leaving 30px for the input
+// line and padding, at the fixed 16px lineHeight (Terminal.res:1063). The
+// ReScript computes `Float.toInt((height -. 30.0) /. lineHeight)`; we mirror it
+// in milli-units: usable = height_mpx - 30000, divided by the lineHeight 16000,
+// truncated toward zero. Floored at 0 so a sub-30px terminal yields no lines
+// rather than a negative count.
+//
+// lineHeight is the constant 16.0 (Terminal.res:1063); we inline it as 16000
+// milli-px rather than take it as a parameter because it is not host-tunable in
+// the source (it is a `let` literal, never a field set by the caller).
+pub fn max_lines(height_mpx: Int) -> Int {
+  let usable = height_mpx - 30000;
+  if usable <= 0 { 0 } else { usable / 16000 }
+}
+
+// ---------------------------------------------------------------------------
+// Cursor-blink state machine (Terminal.res:1108-1114), milli-seconds
+// ---------------------------------------------------------------------------
+
+// The cursor-blink accumulator advanced by one frame. `blink_ms` is the carried
+// accumulator and `delta_ms` the frame delta, both in milli-seconds (the
+// ReScript floats *1000). When the accumulator crosses the 0.5s threshold
+// (500 ms, Terminal.res:1110) it resets to 0; otherwise it accumulates.
+// Returns the next accumulator value -- the host keeps no other timer state.
+pub fn cursor_blink_next(blink_ms: Int, delta_ms: Int) -> Int {
+  let advanced = blink_ms + delta_ms;
+  if advanced > 500 { 0 } else { advanced }
+}
+
+// Whether this frame's accumulation toggles the cursor visibility
+// (Terminal.res:1110-1112): 1 iff blink_ms + delta_ms crosses 500 ms. The host
+// flips its showCursor boolean and redraws the input line exactly when this is
+// 1. Same threshold as cursor_blink_next so the two stay in lock-step.
+pub fn cursor_should_toggle(blink_ms: Int, delta_ms: Int) -> Int {
+  if blink_ms + delta_ms > 500 { 1 } else { 0 }
+}
+
+// ---------------------------------------------------------------------------
+// Backspace length clamp (Terminal.res:964-969)
+// ---------------------------------------------------------------------------
+
+// The new input length after a Backspace: len - 1, floored at 0. The ReScript
+// slices `~start=0, ~end=String.length(currentInput) - 1` (Terminal.res:965);
+// on an already-empty input that end is -1, which the host slice treats as
+// empty -- we make the invariant explicit so the length the host trims to is
+// never negative. (The string content is the host's; the brain only computes
+// the resulting length so the host can slice without an underflow.)
+pub fn backspace_len(len: Int) -> Int {
+  if len > 0 { len - 1 } else { 0 }
+}

--- a/proposals/idaptik/migrated/Terminal/terminal.config.mjs
+++ b/proposals/idaptik/migrated/Terminal/terminal.config.mjs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Terminal.affine (idaptik terminal command-processor
+// integer brain; scalar i32 ABI). Each oracle is an INDEPENDENT JS
+// reimplementation of the corresponding integer logic in
+// idaptik/src/app/devices/Terminal.res, so a codegen regression surfaces as a
+// differential mismatch.
+//
+// Source-of-truth cross-references (Terminal.res line numbers):
+//   command taxonomy ...... handleBuiltInCommand switch (213-918) + the
+//                           FeaturePacks.isInvertibleProgrammingEnabled guards
+//                           at 592/599/609/619/627/698/902; codes 0..16 ungated,
+//                           17..23 the invertible-programming pack.
+//   ssh_* ................. getActiveState (199-209), ssh push (418), exit
+//                           pop (478-510).
+//   output_evict_count .... addOutput trim loop (55-62).
+//   max_lines ............. make (1063-1064): Float.toInt((h-30)/16).
+//   cursor_* .............. update (1108-1114): blink+delta > 0.5 toggles+resets.
+//   backspace_len ......... handleKeyInput (964-969): len-1 on Backspace.
+
+// --- independent oracle helpers (re-derived, not imported from the brain) ---
+
+const validCmd = (c) => c >= 0 && c <= 23;
+const gatedCmd = (c) => validCmd(c) && c >= 17;
+
+export default {
+  affine: "Terminal.affine",
+  cases: [
+    // --- command taxonomy ---
+    {
+      name: "ungated_command_count()",
+      export: "ungated_command_count",
+      args: [],
+      oracle: () => 17,
+    },
+    {
+      name: "command_count()",
+      export: "command_count",
+      args: [],
+      oracle: () => 24,
+    },
+    {
+      name: "is_valid_command over [-3..27]",
+      export: "is_valid_command",
+      args: [[-3, 27]],
+      oracle: (c) => (validCmd(c) ? 1 : 0),
+    },
+    {
+      name: "is_gated_command over [-3..27]",
+      export: "is_gated_command",
+      args: [[-3, 27]],
+      oracle: (c) => (gatedCmd(c) ? 1 : 0),
+    },
+    {
+      name: "is_command_available over [-3..27] x {off,on}",
+      export: "is_command_available",
+      args: [[-3, 27], { values: [0, 1] }],
+      oracle: (c, on) => {
+        if (!validCmd(c)) return 0;
+        if (!gatedCmd(c)) return 1; // ungated: always runs
+        return on === 1 ? 1 : 0; // gated: only when feature flag is on
+      },
+    },
+    {
+      name: "canonicalise_command over [-3..27]",
+      export: "canonicalise_command",
+      args: [[-3, 27]],
+      oracle: (c) => (validCmd(c) ? c : -1),
+    },
+
+    // --- SSH session-stack bounds ---
+    {
+      name: "ssh_active_index over depth [-2..8]",
+      export: "ssh_active_index",
+      args: [[-2, 8]],
+      oracle: (d) => (d > 0 ? d - 1 : -1),
+    },
+    {
+      name: "ssh_is_remote over depth [-2..8]",
+      export: "ssh_is_remote",
+      args: [[-2, 8]],
+      oracle: (d) => (d > 0 ? 1 : 0),
+    },
+    {
+      name: "ssh_push_depth over depth [-2..8]",
+      export: "ssh_push_depth",
+      args: [[-2, 8]],
+      oracle: (d) => (d < 0 ? 1 : d + 1),
+    },
+    {
+      name: "ssh_pop_depth over depth [-2..8]",
+      export: "ssh_pop_depth",
+      args: [[-2, 8]],
+      oracle: (d) => (d > 0 ? d - 1 : 0),
+    },
+    {
+      name: "ssh_prompt_is_remote_after_exit over depth [-2..8]",
+      export: "ssh_prompt_is_remote_after_exit",
+      args: [[-2, 8]],
+      oracle: (d) => {
+        const post = d > 0 ? d - 1 : 0; // ssh_pop_depth
+        return post > 0 ? 1 : 0;
+      },
+    },
+
+    // --- output ring buffer ---
+    {
+      name: "output_evict_count over count [0..40] x max {-1,0,10,30}",
+      export: "output_evict_count",
+      args: [[0, 40], { values: [-1, 0, 10, 30] }],
+      oracle: (n, max) => {
+        const cap = max < 0 ? 0 : max;
+        return n > cap ? n - cap : 0;
+      },
+    },
+
+    // --- maxLines geometry (milli-pixels) ---
+    {
+      name: "max_lines over height_mpx {0,29999,30000,46000,400000,720000}",
+      export: "max_lines",
+      args: [{ values: [0, 29999, 30000, 46000, 400000, 720000] }],
+      oracle: (h) => {
+        const usable = h - 30000;
+        if (usable <= 0) return 0;
+        return Math.trunc(usable / 16000);
+      },
+    },
+
+    // --- cursor-blink state machine (milli-seconds) ---
+    {
+      name: "cursor_blink_next over blink {0,100,400,500} x delta {16,33,200}",
+      export: "cursor_blink_next",
+      args: [{ values: [0, 100, 400, 500] }, { values: [16, 33, 200] }],
+      oracle: (b, d) => {
+        const adv = b + d;
+        return adv > 500 ? 0 : adv;
+      },
+    },
+    {
+      name: "cursor_should_toggle over blink {0,100,400,500} x delta {16,33,200}",
+      export: "cursor_should_toggle",
+      args: [{ values: [0, 100, 400, 500] }, { values: [16, 33, 200] }],
+      oracle: (b, d) => (b + d > 500 ? 1 : 0),
+    },
+
+    // --- backspace length clamp ---
+    {
+      name: "backspace_len over len [-2..12]",
+      export: "backspace_len",
+      args: [[-2, 12]],
+      oracle: (n) => (n > 0 ? n - 1 : 0),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/VMMessageBus/VMMessageBus.affine
+++ b/proposals/idaptik/migrated/VMMessageBus/VMMessageBus.affine
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// VMMessageBus -- the message-routing co-processor, the pure-integer core
+// extracted from idaptik src/app/multiplayer/VMMessageBus.res (the bridge between
+// VM I/O ports and game/co-op events). Per the DESIGN-VISION ("AffineScript is
+// the brain, JS/Pixi the senses; only primitives cross the wasm boundary"), the
+// host keeps every STRING and every mutable buffer: the Dict<portName,[Int]>
+// output buffer (writePortOutput/readPortOutput, res:53-82), the coopOutbox
+// array, the inbound handler refs, and -- decisively -- ALL the string work in
+// classifyPort (res:96-114: the `port == "console"` literal compares and the
+// `String.startsWith(port, "covert:")` prefix test). String.startsWith on the
+// topic prefix is a host SENSE. The host parses the port string into an integer
+// message-kind code and the kernel does the integer dispatch over that code.
+// Every export is i32 -> i32 (scalar ABI).
+//
+//## Why this split, not a port of classifyPort / flushCoopOutbox
+// classifyPort is end-to-end string work (literal `==` and prefix `startsWith`)
+// -- exactly what AffineScript's canonical face cannot do soundly (broken string
+// subscript / string ==). So the host runs that parse and emits the matched
+// message-target ORDINAL. What survives as the integer brain are the routing
+// DECISIONS the message-target consumers and flushCoopOutbox make over the
+// closed enum bands: "is this target relayed to the co-op partner over the
+// WebSocket?", "is it a co-op channel / a covert channel?", and the per-coop-
+// event-kind "does this event call the multiplayer client?" dispatch
+// (flushCoopOutbox res:136-161, whose only non-sending arm is PortData). Those
+// are integer truth tables over the two enums; the string parse that produces
+// the ordinal is the host sense feeding them.
+//
+//## messageTarget encoding (the header contract for the JS host)
+// The host parses a port string to exactly one of these ordinals, in the
+// declaration order of the `messageTarget` variant (res:86-94), and hands the
+// kernel the ordinal -- never the string:
+//   code  target              port form (classifyPort branch)
+//     0   Console             "console"
+//     1   Display             "display"
+//     2   Firewall            "firewall"
+//     3   CoopSync            "coop:sync"
+//     4   CoopChat            "coop:chat"
+//     5   CoopItem            "coop:item"
+//     6   CovertLinkChannel   "covert:<id>"   (String.startsWith host sense)
+//     7   DevicePort          any other port  (the else arm)
+// The encoding is LOSSLESS over its closed 0..7 band. A target ordinal outside
+// 0..7 is not a message target: is_valid_target reports 0 and clamp_target
+// returns the OUT-OF-BAND SENTINEL -1 -- never an in-band code, so out-of-band
+// input cannot be confused with a real target (sentinel, not a clamp; assail
+// PA-AFF-001 stays clean).
+//
+//## coopEvent encoding (the header contract for the JS host)
+// The host tags each outgoing co-op event with one of these ordinals, in the
+// declaration order of the `coopEvent` variant (res:120-127):
+//   code  event                payload kind
+//     0   VMExecuted           {deviceId, instruction, args}
+//     1   VMUndone             {deviceId}
+//     2   StateSync            {deviceId, registers}
+//     3   PortData             {port, values}    -- routed via VM state sync, NOT sent
+//     4   CovertLinkFound      {connectionId}
+//     5   CovertLinkActivated  {connectionId}
+//     6   ChatSent             {message}
+// flushCoopOutbox sends every kind to MultiplayerClient EXCEPT PortData (res:148:
+// `| PortData(_) => ()` -- "Port data goes through VM state sync"). That single
+// exception is the only non-trivial integer decision in the drain loop.
+
+// The number of message-target classes in the routing taxonomy.
+pub fn message_target_count() -> Int { 8 }
+
+//## Whether a host integer names a defined message target. 1 = valid, 0 = out of band.
+pub fn is_valid_target(code: Int) -> Int {
+  if code < 0 { return 0; }
+  if code > 7 { return 0; }
+  1
+}
+
+//## Canonicalise a host target ordinal: identity on a valid 0..7 code, the
+// out-of-band SENTINEL -1 otherwise. -1 is not an in-band code, so an
+// unrecognised target can never be confused with a real one (sentinel, not a
+// clamp). Mirrors the closed `messageTarget` band of classifyPort.
+pub fn clamp_target(code: Int) -> Int {
+  if is_valid_target(code) == 1 { code } else { -1 }
+}
+
+//## Is this message target relayed to the co-op partner over the WebSocket?
+// The routing decision the co-op relay makes: only the three co-op channels --
+// CoopSync(3), CoopChat(4), CoopItem(5) -- cross to the partner via the
+// multiplayer client; Console/Display/Firewall (local game systems) and
+// CovertLinkChannel/DevicePort (handled by the in-VM covert link / device port
+// plumbing) stay local. Returns 1 = relay, 0 = local. Out-of-band target -> 0.
+pub fn relays_to_partner(target: Int) -> Int {
+  if target == 3 { return 1; }   // CoopSync
+  if target == 4 { return 1; }   // CoopChat
+  if target == 5 { return 1; }   // CoopItem
+  0
+}
+
+//## Is this target one of the co-op channels (coop:sync / coop:chat / coop:item)?
+// The closed CoopSync..CoopItem sub-band (3..5) of messageTarget. Lets the host
+// distinguish a co-op channel from the covert/device/local targets without a
+// second string parse. Returns 1 = co-op channel, 0 = not. Out-of-band -> 0.
+pub fn is_coop_channel(target: Int) -> Int {
+  if target < 3 { return 0; }
+  if target > 5 { return 0; }
+  1
+}
+
+//## Is this target the covert-link data channel ("covert:<id>")?
+// CovertLinkChannel(6) alone. The `String.startsWith(port, "covert:")` branch of
+// classifyPort, read as its ordinal. Returns 1 = covert channel, 0 = not.
+pub fn is_covert_channel(target: Int) -> Int {
+  if target == 6 { 1 } else { 0 }
+}
+
+// The number of co-op event kinds in the outbox taxonomy.
+pub fn coop_event_count() -> Int { 7 }
+
+//## Whether a host integer names a defined co-op event kind. 1 = valid, 0 = out of band.
+pub fn is_valid_event(kind: Int) -> Int {
+  if kind < 0 { return 0; }
+  if kind > 6 { return 0; }
+  1
+}
+
+//## Does this co-op event kind get sent to the multiplayer client on outbox drain?
+// THE flushCoopOutbox decision (res:136-161): the drain loop forwards every
+// event kind to MultiplayerClient EXCEPT PortData(3), whose data is routed via
+// VM state sync instead (res:148). So the predicate is "valid kind AND not
+// PortData". Returns 1 = send to client, 0 = do not. An out-of-band kind is not
+// a defined event and returns 0 (fails safe to "do not send").
+pub fn event_sends_to_client(kind: Int) -> Int {
+  if is_valid_event(kind) == 0 { return 0; }   // not a defined event kind
+  if kind == 3 { return 0; }                   // PortData: routed via VM state sync, not sent
+  1
+}

--- a/proposals/idaptik/migrated/VMMessageBus/vmmessagebus.config.mjs
+++ b/proposals/idaptik/migrated/VMMessageBus/vmmessagebus.config.mjs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for VMMessageBus.affine (idaptik VM message-routing
+// kernel; scalar i32 ABI). Each oracle re-derives the rule straight from
+// VMMessageBus.res in plain JS, INDEPENDENTLY of the .affine, so a codegen
+// regression surfaces as a differential mismatch.
+//
+// Oracle re-derivation (rule <- source site), independent of the .affine:
+//   messageTarget band: Console..DevicePort = 0..7   (res:86-94 declaration order)
+//   coopEvent band:     VMExecuted..ChatSent = 0..6   (res:120-127 declaration order)
+//   is_valid_target     = 0 <= t <= 7
+//   clamp_target        = valid ? t : -1
+//   relays_to_partner   = t in {CoopSync 3, CoopChat 4, CoopItem 5} ? 1 : 0
+//                         (the co-op channels are the partner-relayed ones; the
+//                          local/covert/device targets are not)
+//   is_coop_channel     = 3 <= t <= 5 ? 1 : 0
+//   is_covert_channel   = t == CovertLinkChannel(6) ? 1 : 0   (the startsWith "covert:" arm)
+//   event_sends_to_client = (validEvent && kind != PortData(3)) ? 1 : 0
+//                         (flushCoopOutbox res:136-161 sends every kind but PortData, res:148)
+
+const validTarget = (t) => Number.isInteger(t) && t >= 0 && t <= 7;
+const isValidTarget = (t) => (validTarget(t) ? 1 : 0);
+const clampTarget = (t) => (validTarget(t) ? t : -1);
+// Co-op channels (3,4,5) are the only targets relayed to the partner.
+const relaysToPartner = (t) => (t === 3 || t === 4 || t === 5 ? 1 : 0);
+const isCoopChannel = (t) => (t >= 3 && t <= 5 ? 1 : 0);
+const isCovertChannel = (t) => (t === 6 ? 1 : 0);
+
+const validEvent = (k) => Number.isInteger(k) && k >= 0 && k <= 6;
+const isValidEvent = (k) => (validEvent(k) ? 1 : 0);
+// flushCoopOutbox forwards every event kind to the client EXCEPT PortData(3).
+const eventSendsToClient = (k) => (validEvent(k) && k !== 3 ? 1 : 0);
+
+// Sweep the full messageTarget band plus out-of-band, and the full coopEvent
+// band plus out-of-band, so every in-band arm and both boundary guards fire.
+const TARGET = [-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+const EVENT = [-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 9];
+
+export default {
+  affine: "VMMessageBus.affine",
+  cases: [
+    {
+      name: "message_target_count()",
+      export: "message_target_count",
+      args: [],
+      oracle: () => 8,
+    },
+    {
+      name: "is_valid_target over target band + out-of-band",
+      export: "is_valid_target",
+      args: [{ values: TARGET }],
+      oracle: isValidTarget,
+    },
+    {
+      name: "clamp_target over target band + out-of-band",
+      export: "clamp_target",
+      args: [{ values: TARGET }],
+      oracle: clampTarget,
+    },
+    {
+      name: "relays_to_partner over target band + out-of-band",
+      export: "relays_to_partner",
+      args: [{ values: TARGET }],
+      oracle: relaysToPartner,
+    },
+    {
+      name: "is_coop_channel over target band + out-of-band",
+      export: "is_coop_channel",
+      args: [{ values: TARGET }],
+      oracle: isCoopChannel,
+    },
+    {
+      name: "is_covert_channel over target band + out-of-band",
+      export: "is_covert_channel",
+      args: [{ values: TARGET }],
+      oracle: isCovertChannel,
+    },
+    {
+      name: "coop_event_count()",
+      export: "coop_event_count",
+      args: [],
+      oracle: () => 7,
+    },
+    {
+      name: "is_valid_event over event band + out-of-band",
+      export: "is_valid_event",
+      args: [{ values: EVENT }],
+      oracle: isValidEvent,
+    },
+    {
+      name: "event_sends_to_client over event band + out-of-band",
+      export: "event_sends_to_client",
+      args: [{ values: EVENT }],
+      oracle: eventSendsToClient,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/VMNetwork/VMNetwork.affine
+++ b/proposals/idaptik/migrated/VMNetwork/VMNetwork.affine
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// VMNetwork -- the causal-ordering co-processor, the pure-integer core extracted
+// from idaptik src/app/multiplayer/VMNetwork.res (Tier 5 multi-VM networking).
+// Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary") and the SHAPE-A note on the host binding
+// (VMNetworkCoprocessor.res / VMNetworkCoprocessorBridge.js), the model never
+// lives in wasm: the host keeps the deviceVMs dict, the instructionLog, the
+// per-device register files and the WebSocket transport, and -- critically --
+// does ALL string work itself. The host alone parses the wire port string
+// ("net:<ip>:<sub>", "covert:<id>", everything else), the device IPs, the
+// instruction text. The kernel sees only scalars: a Lamport clock value, a
+// register cell with its write timestamp, the consumed/undone flags, and a
+// pre-decoded port-channel ordinal. Every export is i32 -> i32 (scalar ABI).
+//
+//## Why this split, not a port of VMNetwork.res
+// VMNetwork.res entangles (a) the Lamport arithmetic (tick = time+1, sync =
+// max(local,remote)+1 -- res:61-89), (b) the causal-undo gate (refuse undo when
+// the last instruction's output was consumed by another VM -- res:240-256),
+// (c) the cross-VM register reconciliation the header advertises as "last-
+// writer-wins register reconciliation", and (d) a great deal of string-keyed
+// routing (routePortMessage's String.startsWith("net:")/("covert:") branch,
+// res:150-188, plus the Dict-by-deviceId/IP plumbing). Only (a)(b)(c) are
+// integer decisions; (d) is a STRING sense and stays host-side. The host
+// decodes the port prefix to a channel ordinal BEFORE calling the kernel, so no
+// string ever crosses. This file is the verified core of the six kernels the
+// host binding (VMNetworkCoprocessor.res:41-56) already contracts for, with the
+// canonical names the bridge JS requires (VMNetworkCoprocessorBridge.js:99-107:
+// tick / sync / merge_timestamp / merge_register / can_undo / route_kind).
+//
+//## Channel-ordinal encoding (the header contract for the JS host)
+// The host decodes the routed-port prefix to exactly one of these ordinals
+// (mirror of VMNetworkCoprocessorBridge.js CHANNEL, and of routePortMessage's
+// prefix branch) and hands route_kind the ordinal, never the string:
+//   ordinal  channel   meaning (routePortMessage branch)
+//     0      NET       "net:<ip>:<sub>"  -> deliver to target device by IP
+//     1      COVERT    "covert:<id>"     -> deliver through the covert link
+//     2      LOCAL     (any other port)  -> no cross-VM routing
+// The encoding is LOSSLESS over its closed 0..2 band: three channels map to
+// three routing classes with no collision. A prefix ordinal outside 0..2 is
+// not a routed channel: route_kind returns the OUT-OF-BAND SENTINEL -1 (declared
+// here, never an in-band class, so no in-band collision is introduced -- this is
+// a sentinel, not a clamp; assail PA-AFF-001 stays clean).
+
+//## tick -- advance the Lamport clock by one on a local VM event.
+// The integer core of VMNetwork.tick (res:61-74): the host owns the clock cell;
+// the kernel only computes the advanced stamp `time + 1`. Causal ordering needs
+// every local event to strictly increase the clock, so this is unconditional.
+pub fn tick(time: Int) -> Int {
+  time + 1
+}
+
+//## sync -- merge a remote clock on receive: max(local, remote) + 1.
+// The integer core of VMNetwork.sync (res:76-89): on receiving a remote stamp,
+// the merged clock is one past the later of the two, so the local clock never
+// runs backwards and always dominates anything it has seen (Lamport receive
+// rule). The host owns the clock cell; the kernel computes the merged stamp.
+pub fn sync(local: Int, remote: Int) -> Int {
+  if local > remote { local + 1 } else { remote + 1 }
+}
+
+//## merge_timestamp -- the surviving Lamport stamp of a reconciled register cell.
+// The header's "last-writer-wins register reconciliation": when two VMs hold the
+// same register, the cell that survives is the LATER write, so its stamp is the
+// max of the two write stamps. Ties keep the local stamp (they are equal, so the
+// choice is immaterial to the value -- see merge_register's strict-greater gate).
+pub fn merge_timestamp(local_ts: Int, remote_ts: Int) -> Int {
+  if remote_ts > local_ts { remote_ts } else { local_ts }
+}
+
+//## merge_register -- last-writer-wins register value.
+// Companion to merge_timestamp (host binding VMNetworkCoprocessor.res:49-50):
+// the reconciled register takes the REMOTE value only when the remote write is
+// strictly later (remote_ts > local_ts); on a tie or an older remote write the
+// local value stands. Strict-greater (not >=) makes the tie deterministic and
+// keeps the local writer authoritative for its own concurrent writes.
+pub fn merge_register(local_val: Int, local_ts: Int, remote_val: Int, remote_ts: Int) -> Int {
+  if remote_ts > local_ts { remote_val } else { local_val }
+}
+
+//## can_undo -- the causal-undo gate.
+// The integer core of undoOnDevice's refusal predicate (res:240-256): undo of
+// the last instruction is permitted iff its output was NEITHER consumed by
+// another VM's RECV NOR already undone. The host passes the two record flags as
+// 0/1 (instr.consumed ? 1 : 0, instr.undone ? 1 : 0) and refuses undo when this
+// returns 0 (res:252: `canUndo(...) != 1`). Returns 1 = may undo, 0 = refuse.
+// Any flag value other than 0 is treated as "set" (truthy), so a stray non-0/1
+// host encoding fails safe to refusal rather than fabricating permission.
+pub fn can_undo(consumed: Int, undone: Int) -> Int {
+  if consumed != 0 { return 0; }
+  if undone != 0 { return 0; }
+  1
+}
+
+//## route_kind -- classify a routed port by its decoded channel ordinal.
+// The integer core of routePortMessage (res:150-188) AFTER the host has parsed
+// the port string into a channel ordinal. It canonicalises the routing class for
+// a defined channel (identity on the closed 0..2 band: NET->0, COVERT->1,
+// LOCAL->2) and reports the out-of-band SENTINEL -1 for any prefix that is not a
+// routed channel. -1 is not an in-band class, so an unrecognised prefix can
+// never be confused with a real routing target (sentinel, not clamp).
+pub fn route_kind(prefix: Int) -> Int {
+  if prefix < 0 { return -1; }   // out of band: not a routed channel
+  if prefix > 2 { return -1; }   // out of band: not a routed channel
+  prefix                         // NET=0 / COVERT=1 / LOCAL=2: identity routing class
+}

--- a/proposals/idaptik/migrated/VMNetwork/vmnetwork.config.mjs
+++ b/proposals/idaptik/migrated/VMNetwork/vmnetwork.config.mjs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for VMNetwork.affine (idaptik Tier-5 causal-ordering
+// kernel; scalar i32 ABI). Each oracle re-derives the rule straight from the
+// ReScript source / the host binding contract in plain JS, INDEPENDENTLY of the
+// .affine, so a codegen regression surfaces as a differential mismatch.
+//
+// Oracle re-derivation (rule <- source site), independent of the .affine:
+//   tick(t)            = t + 1                          (VMNetwork.res:70)
+//   sync(l, r)         = max(l, r) + 1                  (VMNetwork.res:85)
+//   merge_timestamp    = max(localTs, remoteTs)         (VMNetworkCoprocessor.res:46-47,
+//                                                         "the later write")
+//   merge_register     = remoteTs > localTs ? remote : local  (VMNetworkCoprocessor.res:49-50,
+//                                                         last-writer-wins, strict-greater)
+//   can_undo(c, u)     = (c == 0 && u == 0) ? 1 : 0     (VMNetwork.res:240-256;
+//                                                         VMNetworkCoprocessor.res:52-53)
+//   route_kind(p)      = (0<=p<=2) ? p : -1             (routePortMessage prefix branch,
+//                                                         VMNetwork.res:150-188; CHANNEL
+//                                                         {NET:0,COVERT:1,LOCAL:2})
+
+// Lamport advance: strictly increment.
+const tick = (t) => t + 1;
+// Lamport receive merge: one past the later of the two clocks.
+const sync = (l, r) => Math.max(l, r) + 1;
+// Surviving write stamp of a reconciled register: the later write.
+const mergeTimestamp = (localTs, remoteTs) => Math.max(localTs, remoteTs);
+// Last-writer-wins value: take remote only on a STRICTLY greater stamp.
+const mergeRegister = (localVal, localTs, remoteVal, remoteTs) =>
+  remoteTs > localTs ? remoteVal : localVal;
+// Causal-undo gate: may undo iff neither consumed nor undone. Any non-zero flag
+// counts as set (truthy), mirroring the kernel's `!= 0` test.
+const canUndo = (consumed, undone) => (consumed === 0 && undone === 0 ? 1 : 0);
+// Routed-channel classifier: identity on the 0..2 band, out-of-band sentinel -1.
+const routeKind = (p) => (p >= 0 && p <= 2 ? p : -1);
+
+// Sweep ranges chosen so every branch fires:
+//  - clock values incl. 0 and a tie (l == r) for sync's > branch;
+//  - flags over {-1,0,1,2} so the `!= 0` truthiness + the 0 case both fire;
+//  - channel ordinals over [-2..5] so both out-of-band guards and all three
+//    in-band channels are exercised.
+const FLAG = [-1, 0, 1, 2];
+const CLOCK = [-1, 0, 1, 2, 7, 42];
+const CHANNEL = [-2, -1, 0, 1, 2, 3, 5];
+
+export default {
+  affine: "VMNetwork.affine",
+  cases: [
+    {
+      name: "tick over [-1..10]",
+      export: "tick",
+      args: [[-1, 10]],
+      oracle: tick,
+    },
+    {
+      name: "sync over clock x clock (incl. ties)",
+      export: "sync",
+      args: [{ values: CLOCK }, { values: CLOCK }],
+      oracle: sync,
+    },
+    {
+      name: "merge_timestamp over clock x clock",
+      export: "merge_timestamp",
+      args: [{ values: CLOCK }, { values: CLOCK }],
+      oracle: mergeTimestamp,
+    },
+    {
+      name: "merge_register: lww value over {val,ts} x {val,ts}",
+      export: "merge_register",
+      args: [{ values: [10, 20] }, { values: CLOCK }, { values: [30, 40] }, { values: CLOCK }],
+      oracle: mergeRegister,
+    },
+    {
+      name: "can_undo over flag x flag",
+      export: "can_undo",
+      args: [{ values: FLAG }, { values: FLAG }],
+      oracle: canUndo,
+    },
+    {
+      name: "route_kind over channel band + out-of-band",
+      export: "route_kind",
+      args: [{ values: CHANNEL }],
+      oracle: routeKind,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/VmState/VmState.affine
+++ b/proposals/idaptik/migrated/VmState/VmState.affine
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// VmState -- the flat-memory ADDRESSING core of the idaptik reversible VM, the
+// pure-integer slice extracted from vm/lib/ocaml/VmState.res. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; they pass
+// primitives across the wasm boundary"), VmState.res is almost entirely senses:
+// it is a flat `dict<int>` keyed by underscore-prefixed STRINGS (`_sp`, `_s:N`,
+// `_mem:N`, `_csp`, `_cs:N`, `_pin:PORT`, `_pout:PORT`, `_pi:PORT:N`,
+// `_po:PORT:N`), accessed through `Dict.get`/`Dict.set`, `Option.getOr`,
+// `Array.fromInitializer`, and `String.startsWith`. Every key string, the
+// mutable dict, the array materialisation, and the `isInternalKey` "_" test
+// stay host-side. The OPCODE pointer/value arithmetic (sp+/-1, additive
+// mem/port) is already its own cluster -- VmStack.affine, VmMemory.affine,
+// VmPort.affine. What is left for a brain, and not covered there, is the
+// INTROSPECTION addressing the dict layout implies:
+//
+//   * the size of the flat memory region (256 cells, addresses 0..255);
+//   * which integer addresses are in bounds;
+//   * the absolute address the i-th cell of a [start, length) range maps to
+//     (`getMemoryRange`: start + i);
+//   * how many port-input items remain unread (`getPortInputRemaining`:
+//     totalItems - readPointer), and how deep the stack-contents materialisation
+//     runs (`getStackContents` walks 0..sp-1, i.e. `sp` cells).
+//
+// We re-decompose these as scalar-int functions over explicit Int params (no
+// module state, no dict, no strings cross): the host parses the dict, hands the
+// brain the integers (sp, start, length, addr, ptr, totalItems), and renders the
+// result. "The address IS the integer."
+//
+//## Memory addressing contract (the header contract for the JS host)
+//   The flat memory region is `memory_size()` == 256 cells, addresses 0..255.
+//   is_valid_address(addr)        -> 1 iff 0 <= addr <= 255, else 0.
+//   clamp_address(addr)           -> addr if in band, else the out-of-band
+//                                    sentinel -1 (NOT a real address, so no
+//                                    in-band collision is introduced; assail
+//                                    stays clean -- same sentinel discipline as
+//                                    DeviceType.clamp_device_type).
+//   range_addr(start, i)          -> start + i  (absolute address of the i-th
+//                                    cell of a range beginning at `start`).
+//   range_addr_in_bounds(start, length, i) -> 1 iff 0 <= i < length AND the
+//                                    resulting absolute address start+i is a
+//                                    valid 0..255 cell, else 0. (Lets the host
+//                                    skip out-of-region reads up front.)
+//   stack_depth(sp)               -> max(sp, 0): how many slots getStackContents
+//                                    materialises (a negative sp reads nothing).
+//   port_input_remaining(total, ptr) -> max(total - ptr, 0): unread input items
+//                                    (clamped at 0 so an over-read pointer yields
+//                                    no items rather than a negative count).
+
+// The number of cells in the VM's flat memory region (VmState.res `memorySize`).
+pub fn memory_size() -> Int { 256 }
+
+// The highest valid memory address (memory_size - 1). The band is 0..255.
+pub fn max_address() -> Int { 255 }
+
+// Whether a host integer names a real memory cell. 1 = in band, 0 = out of band.
+pub fn is_valid_address(addr: Int) -> Int {
+  if addr < 0 { 0 } else { if addr > 255 { 0 } else { 1 } }
+}
+
+// Canonicalise a host integer address: identity on a valid 0..255 cell, the
+// out-of-band sentinel -1 otherwise. -1 is not a real address, so out-of-band
+// input can never be confused with an in-band cell (sentinel, not a clamp).
+pub fn clamp_address(addr: Int) -> Int {
+  if is_valid_address(addr) == 1 { addr } else { -1 }
+}
+
+// The absolute address of the i-th cell of a memory range that begins at
+// `start` (VmState.res getMemoryRange: `getMemory(state, start + i)`).
+pub fn range_addr(start: Int, i: Int) -> Int { start + i }
+
+// Whether the i-th cell of a [start, length) range is both inside the range
+// (0 <= i < length) AND a valid 0..255 memory cell. 1 = read it, 0 = skip.
+pub fn range_addr_in_bounds(start: Int, length: Int, i: Int) -> Int {
+  if i < 0 { return 0; }
+  if i >= length { return 0; }
+  is_valid_address(range_addr(start, i))
+}
+
+// How many stack slots getStackContents materialises for a given stack pointer:
+// it walks indices 0..sp-1, i.e. `sp` cells, clamped at 0 so a negative pointer
+// reads nothing rather than a negative length.
+pub fn stack_depth(sp: Int) -> Int {
+  if sp < 0 { return 0; }
+  sp
+}
+
+// How many port-input items remain unread (VmState.res getPortInputRemaining:
+// `totalItems - readPointer`), clamped at 0 so an over-advanced read pointer
+// yields no items rather than a negative count. Equivalent to max(count-ptr, 0):
+// when ptr >= count the buffer is fully read, so 0 items remain. (`count` is the
+// total item count; the bare name `total` is reserved, so we spell it `count`.)
+pub fn port_input_remaining(count: Int, ptr: Int) -> Int {
+  if ptr >= count { return 0; }
+  count - ptr
+}

--- a/proposals/idaptik/migrated/VmState/vmstate.config.mjs
+++ b/proposals/idaptik/migrated/VmState/vmstate.config.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for VmState.affine (idaptik flat-memory addressing core;
+// scalar i32 ABI). The oracle re-derives the 256-cell band, range addressing,
+// stack depth, and unread-port count in plain JS straight from the
+// VmState.res introspection semantics, so a codegen regression surfaces as a
+// differential mismatch.
+
+// In-bounds memory cell: 0..255.
+const validAddr = (a) => a >= 0 && a <= 255;
+
+export default {
+  affine: "VmState.affine",
+  cases: [
+    { name: "memory_size()", export: "memory_size", args: [], oracle: () => 256 },
+    { name: "max_address()", export: "max_address", args: [], oracle: () => 255 },
+    {
+      name: "is_valid_address over [-3..260]",
+      export: "is_valid_address",
+      args: [[-3, 260]],
+      oracle: (a) => (validAddr(a) ? 1 : 0),
+    },
+    {
+      name: "clamp_address over [-3..260]",
+      export: "clamp_address",
+      args: [[-3, 260]],
+      oracle: (a) => (validAddr(a) ? a : -1),
+    },
+    {
+      name: "range_addr(start, i) = start + i",
+      export: "range_addr",
+      args: [[-2, 260], [-2, 18]],
+      oracle: (start, i) => (start + i) | 0,
+    },
+    {
+      name: "range_addr_in_bounds(start, length, i)",
+      export: "range_addr_in_bounds",
+      args: [[-2, 258], [0, 8], [-2, 10]],
+      oracle: (start, length, i) => {
+        if (i < 0) return 0;
+        if (i > length - 1) return 0;
+        return validAddr((start + i) | 0) ? 1 : 0;
+      },
+    },
+    {
+      name: "stack_depth(sp) = max(sp, 0)",
+      export: "stack_depth",
+      args: [[-5, 300]],
+      oracle: (sp) => (sp < 0 ? 0 : sp),
+    },
+    {
+      name: "port_input_remaining(count, ptr) = max(count - ptr, 0)",
+      export: "port_input_remaining",
+      args: [[0, 40], [0, 40]],
+      oracle: (count, ptr) => (count - ptr < 0 ? 0 : count - ptr),
+    },
+  ],
+};


### PR DESCRIPTION
## Migration wave 3 — integer brains from string-gated + de-quarantined idaptik modules

Third extraction wave. Continues the C1–C12 + waves 1/2 pattern: pure-integer "brains" extracted to `.affine` (compiled to wasm, verified by independent-oracle parity + assail), all string/float/async/state kept host-side. Notably includes files previously quarantined on `String.startsWith` — confirmed a host-side sense the brains don't touch.

### Migrated — 5 kernels (verified: I re-ran every gate myself)
| Kernel | What | Parity | Assail |
|---|---|---|---|
| **NetworkZones** | zone taxonomy (0..7) + ISP routing-class | 64/64 | clean |
| **Terminal** | command taxonomy (0..23) + SSH-stack bounds + output ring-buffer + cursor-blink FSM + backspace clamp (16 exports) | 421/421 | clean |
| **VmState** | flat-memory addressing/introspection (256-cell bound, validity, range guard, stack depth, port-input remaining; 8 exports) | 38577/38577 | clean |
| **VMNetwork** | Tier-5 causal-ordering core: tick/sync/merge_timestamp/merge_register/can_undo/route_kind | 251/251 | clean |
| **VMMessageBus** | message-routing dispatch over two enum bands (messageTarget 0..7 + coopEvent 0..6; 9 exports) | 84/84 | clean |

`VMNetwork`/`VMMessageBus` match existing host coprocessor contracts (`VMNetworkCoprocessor.res`). `Terminal` is the standout — a 1115-LOC, ~90%-string module still yielded a clean separable integer brain (the 700-line command switch, tokenising, SSH parsing, Pixi rendering all stay ReScript).

### Already-migrated / no brain
- **PortNames** → already migrated in a prior session (re-verified 52/52; left untouched).
- **CoprocessorBridge**, **VMBridge** → `NO_NEW_BRAINS` (pure host-side bridges; every integer transform they route to is already a migrated brain — `Coprocessor_Compute`/`Security`, `VmArith`/`VmBitwise`/`VmStack`/`VmMemory`/`VmState`).

### Playbook by-product
VmState hit two real parse traps worth recording: a nested `else { if <cond-with-subtraction> }` parse-errors (flatten to early-return guards), and `total` is a **reserved keyword** (rename accumulators).

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s