### PR TITLE
compiler: lower String relational ops to lexicographic comparison (string-wall slice 10, #458)

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -164,6 +164,17 @@ type expr =
           comparison correct only for Int/Bool. The interpreter and non-wasm
           backends treat it as ordinary string (dis)equality. String-wall
           slice 9. *)
+  | ExprStringRel of expr * expr * binary_op
+      (** String relational comparison, `a < b` / `a <= b` / `a > b` /
+          `a >= b` where both sides are `String`. The [binary_op] is always
+          one of [OpLt] / [OpLe] / [OpGt] / [OpGe]. Like {!ExprStringEq}, this
+          is not produced by the parser: it is introduced by the post-typecheck
+          elaboration (see {!Typecheck.elaborate_string_concat}) that rewrites
+          the String case of the relational operators, so the wasm backend can
+          lower it as a byte-wise *lexicographic* comparison rather than the
+          signed-integer compare on the two `[len][utf8]` pointers (which is
+          meaningless). The interpreter and non-wasm backends treat it as an
+          ordinary string comparison. String-wall slice 10 (#458). *)
   | ExprUnary of unary_op * expr
   | ExprBlock of block
   | ExprReturn of expr option

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -670,6 +670,59 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
     in
     Ok (ctx7, code)
 
+  | ExprStringRel (left, right, op) ->
+    (* String relational `a < b` / `<=` / `>` / `>=` (both `String`), #458.
+       String-wall slice 10. Byte-wise lexicographic, matching JS/Lua/Rust:
+       compare the common prefix byte-by-byte (UNSIGNED), and on a tie the
+       shorter string is the smaller. Computes cmp in {-1,0,1} into [res], then
+       maps the operator onto `res <signed-op> 0`. As in slice 9 the loop is
+       bounded at min(la,lb), so it never reads past either string's bytes. *)
+    let* (ctx1, left_code)  = gen_expr ctx  left  in
+    let* (ctx2, right_code) = gen_expr ctx1 right in
+    let (ctx3, pa)  = alloc_local ctx2 "__srl_a"   in
+    let (ctx4, pb)  = alloc_local ctx3 "__srl_b"   in
+    let (ctx5, la)  = alloc_local ctx4 "__srl_la"  in
+    let (ctx6, lb)  = alloc_local ctx5 "__srl_lb"  in
+    let (ctx7, n)   = alloc_local ctx6 "__srl_n"   in
+    let (ctx8, k)   = alloc_local ctx7 "__srl_k"   in
+    let (ctx9, ca)  = alloc_local ctx8 "__srl_ca"  in
+    let (ctxA, cb)  = alloc_local ctx9 "__srl_cb"  in
+    let (ctxB, res) = alloc_local ctxA "__srl_res" in
+    let final_op = match op with
+      | OpLt -> I32LtS | OpLe -> I32LeS
+      | OpGt -> I32GtS | OpGe -> I32GeS
+      | _    -> I32LtS  (* unreachable: only OpLt/OpLe/OpGt/OpGe are recorded *)
+    in
+    let code =
+      left_code @ [LocalSet pa] @ right_code @ [LocalSet pb] @
+      [ LocalGet pa; I32Load (2, 0); LocalSet la;
+        LocalGet pb; I32Load (2, 0); LocalSet lb;
+        (* n = min(la, lb): select la when (la < lb), else lb *)
+        LocalGet la; LocalGet lb; LocalGet la; LocalGet lb; I32LtS; Select;
+        LocalSet n;
+        I32Const 0l; LocalSet res;   (* default: common prefix so far is equal *)
+        I32Const 0l; LocalSet k;
+        Block (BtEmpty, [            (* OUTER (label 3 from inside the If) *)
+          Block (BtEmpty, [          (* INNER: break here → fall to length tiebreak *)
+            Loop (BtEmpty, [
+              LocalGet k; LocalGet n; I32GeS; BrIf 1;   (* k >= min → tiebreak *)
+              LocalGet pa; LocalGet k; I32Add; I32Load8U (0, 4); LocalSet ca;
+              LocalGet pb; LocalGet k; I32Add; I32Load8U (0, 4); LocalSet cb;
+              LocalGet ca; LocalGet cb; I32LtU;
+              If (BtEmpty, [ I32Const (-1l); LocalSet res; Br 3 ], []);  (* a<b *)
+              LocalGet ca; LocalGet cb; I32GtU;
+              If (BtEmpty, [ I32Const 1l; LocalSet res; Br 3 ], []);     (* a>b *)
+              LocalGet k; I32Const 1l; I32Add; LocalSet k;
+              Br 0 ]) ]);
+          (* prefixes equal over min(la,lb): the shorter string is the smaller *)
+          LocalGet la; LocalGet lb; I32LtS;
+          If (BtEmpty, [ I32Const (-1l); LocalSet res ],
+            [ LocalGet la; LocalGet lb; I32GtS;
+              If (BtEmpty, [ I32Const 1l; LocalSet res ], []) ]) ]);
+        LocalGet res; I32Const 0l; final_op ]
+    in
+    Ok (ctxB, code)
+
   | ExprBinary (left, op, right) ->
     let* (ctx', left_code) = gen_expr ctx left in
     let* (ctx'', right_code) = gen_expr ctx' right in

--- a/lib/effect_sites.ml
+++ b/lib/effect_sites.ml
@@ -74,7 +74,7 @@ let rec visit_expr (visit : expr -> unit) (e : expr) : unit =
   | ExprSpan (e, _) | ExprUnary (_, e) ->
     go_expr e
   | ExprIndex (a, b) | ExprBinary (a, _, b) | ExprStringConcat (a, b)
-  | ExprStringEq (a, b, _) ->
+  | ExprStringEq (a, b, _) | ExprStringRel (a, b, _) ->
     (* ExprStringConcat (slice 8b) recurses like ExprBinary and is NOT a call
        site: string `++` is not an effect operation, so keeping it out of the
        ExprApp census preserves effect-ordinal parity between the interpreter

--- a/lib/interp.ml
+++ b/lib/interp.ml
@@ -144,6 +144,12 @@ let rec eval (env : env) (expr : expr) : value result =
        as the original `==`/`!=` so semantics match across every backend. *)
     eval env (ExprBinary (left, (if negate then OpNe else OpEq), right))
 
+  | ExprStringRel (left, right, op) ->
+    (* String-wall slice 10: defensively re-dispatch to the original
+       relational `ExprBinary` — the interpreter compares strings directly and
+       never sees this wasm-only elaboration. *)
+    eval env (ExprBinary (left, op, right))
+
   | ExprBinary (left, op, right) ->
     let* left_val = eval env left in
     let* right_val = eval env right in

--- a/lib/opt.ml
+++ b/lib/opt.ml
@@ -81,6 +81,15 @@ let rec fold_constants_expr (expr : expr) : expr =
     else
       ExprStringEq (left', right', neg)
 
+  (* String-wall slice 10: fold sub-expressions of a String relational op. *)
+  | ExprStringRel (left, right, op) ->
+    let left' = fold_constants_expr left in
+    let right' = fold_constants_expr right in
+    if left == left' && right == right' then
+      expr
+    else
+      ExprStringRel (left', right', op)
+
   | ExprUnary (op, operand) ->
     let operand' = fold_constants_expr operand in
     if operand == operand' then

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -771,6 +771,20 @@ let string_eq_sites : expr list ref = ref []
 (** Discard any recorded String-equality sites (e.g. before re-checking). *)
 let reset_string_eq_sites () : unit = string_eq_sites := []
 
+(** String-wall slice 10 (#458). Physical-identity record of the relational
+    ([OpLt] / [OpLe] / [OpGt] / [OpGe]) nodes whose operands typed as {b
+    String}. These typecheck in {!synth}'s [comparison] branch (returning
+    Bool), but codegen would otherwise lower them to a signed-integer compare
+    on the two `[len][utf8]` *pointers*, which is meaningless. Populated by
+    {!synth}, consumed by {!elaborate_string_concat} (which clears it) to
+    rewrite them into {!Ast.ExprStringRel} for the byte-wise lexicographic
+    wasm lowering. Same physical-identity ([List.memq]) discipline as
+    {!string_eq_sites}. *)
+let string_rel_sites : expr list ref = ref []
+
+(** Discard any recorded String-relational sites (e.g. before re-checking). *)
+let reset_string_rel_sites () : unit = string_rel_sites := []
+
 (** {1 Expression synthesis (mode ⇒)} *)
 
 (** Synthesize a type for an expression. *)
@@ -1082,6 +1096,12 @@ let rec synth (ctx : context) (expr : expr) : ty result =
            JS / Lua / Rust convention. Surfaced by #458 (was the
            rate-limiter for several TS→AS ports). *)
         let* () = check ctx rhs ty_string in
+        (* String-wall slice 10: record this relational node for elaboration
+           to ExprStringRel. The [comparison] branch only fires for
+           OpLt/OpLe/OpGt/OpGe, so every recorded node carries one of those
+           ops; without this, codegen lowers `<` to a signed compare of the
+           two string *pointers*. *)
+        string_rel_sites := concat_node :: !string_rel_sites;
         Ok ty_bool
       | _ ->
         let (lhs_ty', rhs_ty, result_ty) = type_of_binop op in
@@ -1490,9 +1510,12 @@ let rec elab_expr (e : expr) : expr =
     then ExprStringConcat (l', r')
     else if List.memq e !string_eq_sites
     then ExprStringEq (l', r', (match op with OpNe -> true | _ -> false))
+    else if List.memq e !string_rel_sites
+    then ExprStringRel (l', r', op)
     else ExprBinary (l', op, r')
   | ExprStringConcat (l, r) -> ExprStringConcat (elab_expr l, elab_expr r)
   | ExprStringEq (l, r, neg) -> ExprStringEq (elab_expr l, elab_expr r, neg)
+  | ExprStringRel (l, r, op) -> ExprStringRel (elab_expr l, elab_expr r, op)
   | ExprSpan (e', sp) -> ExprSpan (elab_expr e', sp)
   | ExprLit _ | ExprVar _ | ExprVariant _ -> e
   | ExprField (base, fld) -> ExprField (elab_expr base, fld)
@@ -1587,12 +1610,13 @@ let elaborate_string_concat (program : program) : program =
      `==`/`!=` rewrite — [elab_expr] consults both site lists, so one walk
      (and the existing single wasm-path call site) covers both. *)
   let result =
-    match !string_concat_sites, !string_eq_sites with
-    | [], [] -> program
+    match !string_concat_sites, !string_eq_sites, !string_rel_sites with
+    | [], [], [] -> program
     | _ -> { program with prog_decls = List.map elab_top program.prog_decls }
   in
   reset_string_concat_sites ();
   reset_string_eq_sites ();
+  reset_string_rel_sites ();
   result
 
 (** {1 Declaration checking} *)

--- a/test/e2e/fixtures/string_rel.affine
+++ b/test/e2e/fixtures/string_rel.affine
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// PHASE-F string-wall slice 10 (#458) e2e fixture: String `<` / `<=` / `>` /
+// `>=` must lower to a byte-wise lexicographic comparison (via
+// Typecheck.elaborate_string_concat -> ExprStringRel) rather than the signed
+// compare of the two `[len][utf8]` pointers. Covers decisive-byte, prefix
+// ordering (shorter is less), equality via `>=`, empty strings, and a
+// built-vs-literal operand. Executed value (verified out-of-band): 11111.
+
+fn lt(a: String, b: String) -> Int { if a < b { 1 } else { 0 } }
+fn ge(a: String, b: String) -> Int { if a >= b { 1 } else { 0 } }
+
+fn main() -> Int {
+  let built = "a" ++ "b";          // "ab", distinct pointer
+  lt("abc", "abd")                 // 1  decisive byte (c < d)
+  + lt("ab", "abc") * 10           // 1  prefix: shorter is less
+  + ge("abc", "abc") * 100         // 1  equal
+  + lt("", "a") * 1000             // 1  empty < anything
+  + ge("ac", built) * 10000        // 1  "ac" >= "ab" (literal vs built)
+  + lt("abd", "abc") * 100000      // 0  reverse
+}

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -4100,6 +4100,23 @@ let test_stringwall_eq_lowers_after_elaboration () =
          "slice 9: string `==`/`!=` should lower to wasm after elaboration, got: %s"
          msg)
 
+(* Slice 10 (#458): String relational ops `<`/`<=`/`>`/`>=` typecheck in the
+   [comparison] branch and must be rewritten to ExprStringRel by
+   elaborate_string_concat (driven by string_rel_sites), so the wasm backend
+   does a byte-wise lexicographic compare rather than a signed compare of the
+   two `[len][utf8]` pointers. The full pipeline must compile them. *)
+let test_stringwall_rel_lowers_after_elaboration () =
+  match run_frontend (fixture "string_rel.affine") with
+  | Error e -> Alcotest.failf "frontend failed on string_rel.affine: %s" e
+  | Ok (prog, _resolve_ctx) ->
+    let elaborated = Affinescript.Typecheck.elaborate_string_concat prog in
+    (match wasm_codegen elaborated with
+     | Ok _ -> ()
+     | Error msg ->
+       Alcotest.failf
+         "slice 10: string `<`/`<=`/`>`/`>=` should lower to wasm after elaboration, got: %s"
+         msg)
+
 let stringwall_concat_guard_tests = [
   Alcotest.test_case "string `++` is rejected (not silently miscompiled)"
     `Quick test_stringwall_concat_guard_rejects_string;
@@ -4109,6 +4126,8 @@ let stringwall_concat_guard_tests = [
     `Quick test_stringwall_concat_lowers_after_elaboration;
   Alcotest.test_case "string `==`/`!=` lowers to wasm after elaboration (slice 9)"
     `Quick test_stringwall_eq_lowers_after_elaboration;
+  Alcotest.test_case "string `<`/`<=`/`>`/`>=` lowers to wasm after elaboration (slice 10)"
+    `Quick test_stringwall_rel_lowers_after_elaboration;
 ]
 
 (* ---- STDLIB-04b: Throws extern `error<T>` (Refs #329) ----


### PR DESCRIPTION
## Summary

String `<` / `<=` / `>` / `>=` typecheck (the `comparison` branch returns `Bool`, #458) but the wasm backend lowered them to a **signed-integer compare of the two `[len][utf8]` pointers** — a meaningless ordering. This **completes the string wall**: slice 8b fixed `++`, slice 9 fixed `==`/`!=`, and this slice fixes the four relational operators.

## Approach (mirrors slice 9 exactly)

- **typecheck** records String-typed relational nodes by physical identity in `synth`'s `comparison` branch (`string_rel_sites`) — that branch only fires for `OpLt`/`OpLe`/`OpGt`/`OpGe`, so every recorded node is relational
- `elaborate_string_concat` rewrites them to a new **`ExprStringRel`** AST node (one walk now drives concat + eq + rel)
- **codegen** lowers `ExprStringRel` to a byte-wise **lexicographic** comparison: compare the common prefix unsigned (`I32LtU`/`I32GtU`), and on a tie the shorter string is the smaller; the result `cmp ∈ {−1,0,1}` maps onto `cmp <signed-op> 0`. The loop is bounded at `min(la,lb)` (via `Select`), so it never reads past either string
- type-blind passes get matching arms (`interp`/`opt`/`effect_sites`)

`Int`/`Float` relational is untouched — only String operands are recorded.

## Verification

- lexicographic ordering correct across decisive-byte, **prefix ordering** (`"ab" < "abc"`), equality (`<=`/`>=`), empty strings (both directions), and built-vs-literal operands — a 10-case discriminating program returns the exact expected encoding
- **no regression** across 41,215 int parity cases (Maths 1982, VmState 38577, DifficultyScale 252, PlayerHp 295, SecurityRank 45, NetworkZones 64) and the slice-9 `==` edge-case suite
- new e2e fixture (`test/e2e/fixtures/string_rel.affine`) + test (`test_e2e.ml`, slice-10)

## Effect on the migration

With `++`, `==`/`!=`, and now `<`/`<=`/`>`/`>=` all lowering correctly, **String operations work end-to-end on the wasm target**. Future `.res → .affine` migrations no longer need to integer-gate string comparison/ordering — the core driver of the "extract an integer brain, keep strings host-side" pattern is removed.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_