### PR TITLE
migration: 17 integer-brain kernels from idaptik logic-directory sweep (cluster C13)

### DIFF
--- a/proposals/idaptik/migrated/AccessClamp/AccessClamp.affine
+++ b/proposals/idaptik/migrated/AccessClamp/AccessClamp.affine
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// AccessClamp -- the accessibility-preference range-clamp co-processor, the
+// pure-integer core extracted from src/app/utils/AccessibilitySettings.res
+// `setFontScale` and `setGameSpeed` (the font-scale clamp is the same bound the
+// FontScaleCoprocessor.res bridge documents as `clampScale`, 0.75..2.0). Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only primitives
+// cross the wasm boundary") the JS host keeps the cached refs, the localStorage
+// persistence and the live PixiJS multiply (px * scale); AffineScript owns only
+// the integer range-clamp arithmetic.
+//
+// The ReScript clamps a Float preference with `Math.max(lo, Math.min(hi, v))`.
+// Float cannot cross the scalar-i32 boundary, so the preference crosses in
+// MILLI-UNITS: the JS caller passes round(scale * 1000) and reads back an integer
+// milli-value it divides by 1000. The bounds become integer milli-bounds and the
+// clamp is exact (the ReScript bounds 0.75 / 2.0 / 0.25 / 1.0 are all multiples of
+// 0.001, so the milli-domain loses nothing).
+//
+//## Font-scale bound (setFontScale: Math.max(0.75, Math.min(2.0, scale)))
+//   milli range [750 .. 2000]   (0.75x .. 2.0x text size)
+//## Game-speed bound (setGameSpeed: Math.max(0.25, Math.min(1.0, speed)))
+//   milli range [250 .. 1000]   (0.25x very-slow .. 1.0x normal)
+//
+// This is a genuine CLAMP (saturating to the nearest in-band bound), not a
+// sentinel: an out-of-range preference is pinned to the lo or hi bound exactly as
+// the ReScript Math.max/Math.min does, never to a sentinel. The clamp is total
+// and idempotent over the integer milli-domain.
+
+// The font-scale lower / upper milli-bounds (0.75 / 2.0 * 1000).
+pub fn font_scale_min_milli() -> Int { 750 }
+pub fn font_scale_max_milli() -> Int { 2000 }
+
+// The game-speed lower / upper milli-bounds (0.25 / 1.0 * 1000).
+pub fn game_speed_min_milli() -> Int { 250 }
+pub fn game_speed_max_milli() -> Int { 1000 }
+
+// A generic saturating clamp of v into [lo, hi]. Mirrors Math.max(lo,
+// Math.min(hi, v)): clamp UP to lo first conceptually, but the ReScript applies
+// min(hi, v) then max(lo, ...) -- when lo <= hi the two orders agree, and the
+// preference bounds always satisfy lo <= hi, so the single form below is exact.
+fn clamp_range(v: Int, lo: Int, hi: Int) -> Int {
+  if v < lo { lo } else { if v > hi { hi } else { v } }
+}
+
+// Clamp a font-scale milli-value into [750, 2000] (AccessibilitySettings
+// setFontScale's range bound; the FontScaleCoprocessor `clampScale`).
+pub fn clamp_font_scale_milli(scale_milli: Int) -> Int {
+  clamp_range(scale_milli, 750, 2000)
+}
+
+// Clamp a game-speed milli-value into [250, 1000] (AccessibilitySettings
+// setGameSpeed's range bound).
+pub fn clamp_game_speed_milli(speed_milli: Int) -> Int {
+  clamp_range(speed_milli, 250, 1000)
+}
+
+// Whether a font-scale milli-value is already in-band (no clamp would change it).
+// 1 = in [750,2000], 0 = would be saturated. Lets the host skip a redundant
+// write when the preference is already valid.
+pub fn font_scale_in_band(scale_milli: Int) -> Int {
+  if scale_milli < 750 { 0 } else { if scale_milli > 2000 { 0 } else { 1 } }
+}
+
+// Whether a game-speed milli-value is already in-band (no clamp would change it).
+pub fn game_speed_in_band(speed_milli: Int) -> Int {
+  if speed_milli < 250 { 0 } else { if speed_milli > 1000 { 0 } else { 1 } }
+}

--- a/proposals/idaptik/migrated/AccessClamp/accessclamp.config.mjs
+++ b/proposals/idaptik/migrated/AccessClamp/accessclamp.config.mjs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for AccessClamp.affine (idaptik accessibility-preference
+// range clamps in milli-units; scalar i32 ABI). The oracle re-derives the
+// Math.max(lo, Math.min(hi, v)) clamps from AccessibilitySettings.res
+// INDEPENDENTLY in plain JS (milli-scaled bounds), so a codegen regression
+// surfaces as a differential mismatch.
+
+// Independent re-derivation of the ReScript Math.max(lo, Math.min(hi, v)).
+const clampRange = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+const FS_LO = 750, FS_HI = 2000, GS_LO = 250, GS_HI = 1000;
+
+export default {
+  affine: "AccessClamp.affine",
+  cases: [
+    { name: "font_scale_min_milli()", export: "font_scale_min_milli", args: [], oracle: () => 750 },
+    { name: "font_scale_max_milli()", export: "font_scale_max_milli", args: [], oracle: () => 2000 },
+    { name: "game_speed_min_milli()", export: "game_speed_min_milli", args: [], oracle: () => 250 },
+    { name: "game_speed_max_milli()", export: "game_speed_max_milli", args: [], oracle: () => 1000 },
+    {
+      // Sweep across and well past both bounds, stepping by 1 over the full
+      // [0..2500] milli-range would be 2501 cases; a coarser representative sweep
+      // over the boundary neighbourhoods plus interior is sufficient and fast.
+      name: "clamp_font_scale_milli over boundary + interior",
+      export: "clamp_font_scale_milli",
+      args: [{ values: [0, 500, 749, 750, 751, 1000, 1375, 1999, 2000, 2001, 2500, -100] }],
+      oracle: (v) => clampRange(v, FS_LO, FS_HI),
+    },
+    {
+      name: "clamp_game_speed_milli over boundary + interior",
+      export: "clamp_game_speed_milli",
+      args: [{ values: [0, 100, 249, 250, 251, 500, 750, 999, 1000, 1001, 1500, -50] }],
+      oracle: (v) => clampRange(v, GS_LO, GS_HI),
+    },
+    {
+      name: "font_scale_in_band over boundary neighbourhood",
+      export: "font_scale_in_band",
+      args: [{ values: [749, 750, 751, 1999, 2000, 2001, 0, 2500] }],
+      oracle: (v) => (v >= FS_LO && v <= FS_HI ? 1 : 0),
+    },
+    {
+      name: "game_speed_in_band over boundary neighbourhood",
+      export: "game_speed_in_band",
+      args: [{ values: [249, 250, 251, 999, 1000, 1001, 0, 1500] }],
+      oracle: (v) => (v >= GS_LO && v <= GS_HI ? 1 : 0),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/AlertPalette/AlertPalette.affine
+++ b/proposals/idaptik/migrated/AlertPalette/AlertPalette.affine
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// AlertPalette -- the accessibility alert-colour lookup co-processor, the
+// pure-integer core extracted from src/app/utils/ColorPalette.res `alertColor`.
+// The existing ColorPalette co-processor (colorpalette.wasm, bound by
+// ColorPaletteCoprocessor.res) deliberately captured only the RGB-channel and
+// WCAG luminance/contrast KERNELS and left the accessibility palette LOOKUP
+// TABLES on the ReScript side (FeaturePacks documents this: "the live HUD
+// call-sites alertColor/deviceColor are accessibility palette lookup tables with
+// no corresponding kernel"). This brain captures exactly that residual: the
+// alert-level colour table, which is wholly pure-integer (enum bands in, a 24-bit
+// RGB integer out) with no host delegation -- unlike deviceColor/securityColor
+// whose Normal arm delegates to DeviceTypes host getters.
+//
+// Per the DESIGN-VISION the JS host keeps the AccessibilitySettings refs (the
+// high-contrast flag and colour-blind mode); AffineScript owns only the integer
+// table: given the high-contrast flag, the colour-blind mode and the alert level
+// it returns the packed colour.
+//
+//## Alert level encoding (levelInt, the header contract for the JS host)
+//   0 = Clear   1 = Noticed   2 = Caution   3 = Alert   4 = Danger
+// The ReScript switch has explicit arms for 0..4 and a `_` catch-all that takes
+// the Danger-row's "max" colour; we reproduce that fold (level >= 4 OR level < 0
+// uses the catch-all row), so the table is total over all Int and matches the
+// ReScript exactly.
+//
+//## Colour-blind mode encoding (mode, mirrors AccessibilitySettings.colorBlindMode)
+//   0 = Normal       3 = Tritanopia
+//   1 = Protanopia   4 = Achromatopsia
+//   2 = Deuteranopia
+// Protanopia and Deuteranopia share one table (the ReScript `Protanopia |
+// Deuteranopia =>` combined arm). An out-of-band mode folds onto Normal (0),
+// matching AccessibilitySettings.colorBlindModeFromString's `_ => Normal`.
+//
+// high_contrast is a host boolean crossed as 0 (off) or 1 (on); any non-zero is
+// treated as on. When on, the mode is ignored (the ReScript tests high contrast
+// first), so the high-contrast table is returned regardless of mode.
+//
+// All outputs are 24-bit RGB integers (0..0xFFFFFF = 16777215), well inside i32;
+// no value collides with another row at the same level, and -1 is never emitted,
+// so this is a pure total lookup (assail stays clean: no sentinel collapse).
+
+// Fold an arbitrary colour-blind mode index onto the valid 0..4 band; unknown ->
+// Normal (0). Mirrors colorBlindModeFromString's `_ => Normal`.
+pub fn clamp_mode(mode: Int) -> Int {
+  if mode < 0 { 0 } else { if mode > 4 { 0 } else { mode } }
+}
+
+// The catch-all alert row index used for level < 0 or level > 4: the ReScript
+// `_` arm coincides with the Danger row visually but uses a DISTINCT "max"
+// colour, so it is modelled as its own row index 5.
+fn alert_row(level: Int) -> Int {
+  if level < 0 { 5 } else { if level > 4 { 5 } else { level } }
+}
+
+//## High-contrast alert table (isHighContrastEnabled() == true)
+//   row 0 0x00ff00  1 0xffff00  2 0xffaa00  3 0xff4400  4 0xff0000  _ 0xff0000
+fn high_contrast_colour(level: Int) -> Int {
+  let r = alert_row(level);
+  if r == 0 { 65280 } else {
+  if r == 1 { 16776960 } else {
+  if r == 2 { 16755200 } else {
+  if r == 3 { 16729088 } else {
+  16711680 } } } }
+}
+
+//## Normal-mode alert table
+//   0 0x00ff00  1 0x88ff00  2 0xffff00  3 0xff8800  4 0xff4400  _ 0xff0000
+fn normal_colour(level: Int) -> Int {
+  let r = alert_row(level);
+  if r == 0 { 65280 } else {
+  if r == 1 { 8978176 } else {
+  if r == 2 { 16776960 } else {
+  if r == 3 { 16746496 } else {
+  if r == 4 { 16729088 } else {
+  16711680 } } } } }
+}
+
+//## Protanopia/Deuteranopia alert table (shared arm)
+//   0 0x0088ff  1 0x44aaff  2 0xffdd44  3 0xffaa00  4 0xff8800  _ 0xff6600
+fn protan_deuter_colour(level: Int) -> Int {
+  let r = alert_row(level);
+  if r == 0 { 35071 } else {
+  if r == 1 { 4500223 } else {
+  if r == 2 { 16768324 } else {
+  if r == 3 { 16755200 } else {
+  if r == 4 { 16746496 } else {
+  16737792 } } } } }
+}
+
+//## Tritanopia alert table
+//   0 0x00ee88  1 0x66dd66  2 0xdddd00  3 0xee6688  4 0xdd2266  _ 0xcc0044
+fn tritan_colour(level: Int) -> Int {
+  let r = alert_row(level);
+  if r == 0 { 61064 } else {
+  if r == 1 { 6741350 } else {
+  if r == 2 { 14540032 } else {
+  if r == 3 { 15623816 } else {
+  if r == 4 { 14492262 } else {
+  13369412 } } } } }
+}
+
+//## Achromatopsia alert table (brightness-only)
+//   0 0xffffff  1 0xcccccc  2 0x999999  3 0x777777  4 0x444444  _ 0x222222
+fn achroma_colour(level: Int) -> Int {
+  let r = alert_row(level);
+  if r == 0 { 16777215 } else {
+  if r == 1 { 13421772 } else {
+  if r == 2 { 10066329 } else {
+  if r == 3 { 7829367 } else {
+  if r == 4 { 4473924 } else {
+  2236962 } } } } }
+}
+
+// The packed RGB alert colour for a high-contrast flag, a colour-blind mode and
+// an alert level. High contrast wins first (mode ignored); otherwise the mode
+// selects the table. This is the full ColorPalette.res `alertColor` decision.
+pub fn alert_colour(high_contrast: Int, mode: Int, level: Int) -> Int {
+  if high_contrast != 0 { high_contrast_colour(level) } else {
+    let m = clamp_mode(mode);
+    if m == 0 { normal_colour(level) } else {
+    if m == 1 { protan_deuter_colour(level) } else {
+    if m == 2 { protan_deuter_colour(level) } else {
+    if m == 3 { tritan_colour(level) } else {
+    achroma_colour(level) } } } }
+  }
+}

--- a/proposals/idaptik/migrated/AlertPalette/alertpalette.config.mjs
+++ b/proposals/idaptik/migrated/AlertPalette/alertpalette.config.mjs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for AlertPalette.affine (idaptik accessibility alert
+// colour lookup; scalar i32 ABI). The oracle re-derives the alertColor decision
+// tables from ColorPalette.res INDEPENDENTLY in plain JS (hex literals, mirroring
+// the ReScript source rather than the .affine's decimal encoding), so a codegen
+// regression or a transcription error in the .affine surfaces as a differential
+// mismatch.
+
+// The catch-all row for level < 0 or > 4 (the ReScript `_` arm), modelled as row 5.
+const row = (lvl) => (lvl < 0 || lvl > 4 ? 5 : lvl);
+
+const HC = [0x00ff00, 0xffff00, 0xffaa00, 0xff4400, 0xff0000, 0xff0000];
+const NORMAL = [0x00ff00, 0x88ff00, 0xffff00, 0xff8800, 0xff4400, 0xff0000];
+const PROTDEUT = [0x0088ff, 0x44aaff, 0xffdd44, 0xffaa00, 0xff8800, 0xff6600];
+const TRITAN = [0x00ee88, 0x66dd66, 0xdddd00, 0xee6688, 0xdd2266, 0xcc0044];
+const ACHROMA = [0xffffff, 0xcccccc, 0x999999, 0x777777, 0x444444, 0x222222];
+
+const clampMode = (m) => (m < 0 || m > 4 ? 0 : m);
+
+const alertColour = (hc, mode, level) => {
+  const r = row(level);
+  if (hc !== 0) return HC[r];
+  const m = clampMode(mode);
+  if (m === 0) return NORMAL[r];
+  if (m === 1 || m === 2) return PROTDEUT[r];
+  if (m === 3) return TRITAN[r];
+  return ACHROMA[r];
+};
+
+export default {
+  affine: "AlertPalette.affine",
+  cases: [
+    {
+      name: "clamp_mode over [-3..8]",
+      export: "clamp_mode",
+      args: [[-3, 8]],
+      oracle: (m) => clampMode(m),
+    },
+    {
+      // Full cartesian over the high-contrast path: hc=1, every mode, every level
+      // (incl. out-of-band level to exercise the `_` row).
+      name: "alert_colour high-contrast path (hc=1) over modes x levels",
+      export: "alert_colour",
+      args: [{ values: [1, 2, 7] }, [0, 4], [-2, 6]],
+      oracle: (hc, mode, level) => alertColour(hc, mode, level),
+    },
+    {
+      // Full cartesian over the normal-path: hc=0, every mode 0..4 (+ out-of-band),
+      // every level -2..6.
+      name: "alert_colour mode-selected path (hc=0) over modes x levels",
+      export: "alert_colour",
+      args: [0, [-1, 6], [-2, 6]],
+      oracle: (hc, mode, level) => alertColour(hc, mode, level),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/CombatResolve/CombatResolve.affine
+++ b/proposals/idaptik/migrated/CombatResolve/CombatResolve.affine
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// CombatResolve -- the physical-combat resolution core, the pure-integer brain
+// extracted from src/app/combat/Combat.res. The ReScript original is a per-frame
+// collision dispatcher (`update`) that mutates Player / SecurityDog / GuardNPC
+// records directly and routes AABB overlap tests through the already-migrated
+// HitboxGeom co-processor. Per the DESIGN-VISION ("AffineScript is the brain,
+// JS/Pixi the senses; only primitives cross the wasm boundary"), the host KEEPS:
+// every mutable entity record and velocity field, the float AABB geometry
+// (delegated to HitboxGeom), the per-frame iteration over dogs/guards, the
+// guard-x dodge repositioning, and all the bounce-velocity writes. The brain owns
+// ONLY the deterministic rank-keyed combat-outcome bands and their integer
+// magnitudes -- the stomp dispatch, the charge dispatch, the per-rank knockdown
+// duration, the tuning velocity literals, and the body-block push direction.
+//
+// This is DISTINCT from GuardNPC.affine: that brain owns the guard
+// detection/suspicion/pursuit decision ladder; this brain owns what happens when
+// the PLAYER physically hits a guard (stomp/charge/body-block). The two never
+// overlap -- GuardNPC has no stomp/charge/knockdown-duration bands.
+//
+//## Rank ordinal encoding (shared with GuardNPC.affine; the host contract)
+//   code  rank             code  rank
+//     0   BasicGuard         4   EliteGuard
+//     1   SecurityGuard      5   SecurityChief
+//     2   AntiHacker         6   RivalHacker
+//     3   Sentinel           7   Assassin
+// Out-of-band ranks clamp to the nearest valid ordinal (0 or 7), so an unknown
+// rank resolves as the BasicGuard "normal" path rather than crashing.
+//
+//## Float boundary: velocities and durations cross as integers / MILLI-UNITS
+// The Tuning velocities are already integral px/s literals (-180, -250, -200,
+// +80), so they cross verbatim. The knockdown durations are seconds (1.5, 3.0);
+// they cross as MILLISECONDS (round(seconds * 1000) -> 1500, 3000), the same
+// milli-convention PlayerHp.affine uses for its timers. No float crosses.
+
+// =========================================================================
+// Rank taxonomy (mirrors GuardNPC.affine's 0..7 band)
+// =========================================================================
+
+enum Rank {
+  BasicGuard, SecurityGuard, AntiHacker, Sentinel, EliteGuard, SecurityChief,
+  RivalHacker, Assassin, InvalidRank(Int)
+}
+
+fn rank_of(code: Int) -> Rank {
+  if code == 0 { return BasicGuard; }
+  if code == 1 { return SecurityGuard; }
+  if code == 2 { return AntiHacker; }
+  if code == 3 { return Sentinel; }
+  if code == 4 { return EliteGuard; }
+  if code == 5 { return SecurityChief; }
+  if code == 6 { return RivalHacker; }
+  if code == 7 { return Assassin; }
+  InvalidRank(code)
+}
+
+// @clamp:declared -- out-of-band rank clamps to nearest valid ordinal (0 or 7).
+// Controlled-loss by design: the 8 valid codes 0..7 are injective; only the
+// out-of-band InvalidRank(v) is squashed, never an in-band code.
+fn clamp_rank_ordinal(v: Int) -> Int {
+  if v < 0 { return 0; }
+  7
+}
+
+fn rank_ordinal_of(r: Rank) -> Int {
+  match r {
+    BasicGuard => 0,
+    SecurityGuard => 1,
+    AntiHacker => 2,
+    Sentinel => 3,
+    EliteGuard => 4,
+    SecurityChief => 5,
+    RivalHacker => 6,
+    Assassin => 7,
+    InvalidRank(v) => clamp_rank_ordinal(v)
+  }
+}
+
+// =========================================================================
+// Tuning velocity literals (Combat.Tuning; integral px/s, sign = direction)
+// =========================================================================
+
+//## Upward bounce after a head-stomp (negative = up).
+pub fn head_stomp_bounce() -> Int { 0 - 180 }
+//## Upward bounce after a body-stomp (negative = up).
+pub fn body_stomp_bounce() -> Int { 0 - 250 }
+//## Upward bounce after stomping a guard (negative = up).
+pub fn guard_stomp_bounce() -> Int { 0 - 200 }
+//## Horizontal push-back magnitude when walking into a solid body.
+pub fn body_block_pushback() -> Int { 80 }
+//## Knockdown duration (ms) for elite ranks (SecurityChief / EliteGuard).
+pub fn elite_knockdown_ms() -> Int { 1500 }
+//## Knockdown duration (ms) for normal ranks.
+pub fn normal_knockdown_ms() -> Int { 3000 }
+
+// =========================================================================
+// Stomp dispatch (Combat.res update, guard HeadKO|BodyBounce arm, 336-370)
+// =========================================================================
+//
+// On a successful stomp the guard's rank selects the outcome:
+//   Assassin   -> dodges sideways and throws the player off   (band 3)
+//   Sentinel   -> armored; player bounces off, no knockdown   (band 2)
+//   Chief/Elite-> bounce + ELITE knockdown (1.5 s)            (band 1)
+//   all others -> bounce + NORMAL knockdown (3.0 s)           (band 0)
+
+//## Stomp outcome band for a rank.
+//   0 NormalKnockdown   1 EliteKnockdown   2 ArmoredBounce   3 AssassinDodge
+pub fn stomp_outcome(rank: Int) -> Int {
+  let r = rank_ordinal_of(rank_of(rank));
+  if r == 7 { return 3; }
+  if r == 3 { return 2; }
+  if r == 4 { return 1; }
+  if r == 5 { return 1; }
+  0
+}
+
+// =========================================================================
+// Charge dispatch (Combat.res update, guard Knockdown arm, 379-393)
+// =========================================================================
+//
+// On a sprint-charge that connects, the rank selects the outcome:
+//   Sentinel / Assassin -> immune; player bounces back        (band 2)
+//   Chief / EliteGuard  -> ELITE knockdown (1.5 s)            (band 1)
+//   all others          -> NORMAL knockdown (3.0 s)           (band 0)
+
+//## Charge outcome band for a rank.
+//   0 NormalKnockdown   1 EliteKnockdown   2 Immune
+pub fn charge_outcome(rank: Int) -> Int {
+  let r = rank_ordinal_of(rank_of(rank));
+  if r == 3 { return 2; }
+  if r == 7 { return 2; }
+  if r == 4 { return 1; }
+  if r == 5 { return 1; }
+  0
+}
+
+//## Knockdown duration (ms) a rank receives WHEN it is knocked down.
+// SecurityChief(5) / EliteGuard(4) get the short elite duration; every other
+// rank gets the normal duration. The host applies this only when the stomp /
+// charge outcome is one of the knockdown bands (0 or 1); for the armored /
+// immune / dodge bands no duration is consumed.
+pub fn knockdown_duration_ms(rank: Int) -> Int {
+  let r = rank_ordinal_of(rank_of(rank));
+  if r == 4 { return 1500; }
+  if r == 5 { return 1500; }
+  3000
+}
+
+// =========================================================================
+// Solid body-block push direction (Combat.res checkBodyBlock, 219-225)
+// =========================================================================
+
+//## Push-back direction when the player walks into a solid body.
+// The ReScript compares centres: player centre left of the entity centre pushes
+// the player LEFT (-pushback), otherwise RIGHT (+pushback). Centres cross as
+// integers (the host already has rect.x and rect.w as fixed-point, so it passes
+// the integer centre 2*x+w or any consistent scaling -- only the ordering
+// matters). Boundary follows the ReScript strict `<`: equal centres push right.
+pub fn body_block_direction(player_center: Int, entity_center: Int) -> Int {
+  if player_center < entity_center { return 0 - 80; }
+  80
+}

--- a/proposals/idaptik/migrated/CombatResolve/combatresolve.config.mjs
+++ b/proposals/idaptik/migrated/CombatResolve/combatresolve.config.mjs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for CombatResolve.affine (idaptik physical-combat
+// resolution; scalar i32 ABI). The oracle re-derives the rank-keyed stomp /
+// charge / knockdown bands and the body-block sign from Combat.res semantics in
+// plain JS, so a codegen regression surfaces as a differential mismatch.
+//
+// Rank ordinals (shared with GuardNPC): 0 BasicGuard 1 SecurityGuard 2 AntiHacker
+// 3 Sentinel 4 EliteGuard 5 SecurityChief 6 RivalHacker 7 Assassin. Out-of-band
+// clamps to 0 (negative) or 7 (>7).
+
+// Independent re-implementation: clamp a host integer to the 0..7 rank band.
+const clampRank = (rank) => (rank < 0 ? 0 : rank > 7 ? 7 : rank);
+
+// Combat.res update, HeadKO|BodyBounce arm: Assassin dodges, Sentinel armored,
+// Chief/Elite -> elite knockdown, else normal knockdown.
+const stompOutcome = (rank) => {
+  const r = clampRank(rank);
+  if (r === 7) return 3; // AssassinDodge
+  if (r === 3) return 2; // ArmoredBounce
+  if (r === 4 || r === 5) return 1; // EliteKnockdown
+  return 0; // NormalKnockdown
+};
+
+// Combat.res update, Knockdown arm: Sentinel/Assassin immune, Chief/Elite ->
+// elite knockdown, else normal knockdown.
+const chargeOutcome = (rank) => {
+  const r = clampRank(rank);
+  if (r === 3 || r === 7) return 2; // Immune
+  if (r === 4 || r === 5) return 1; // EliteKnockdown
+  return 0; // NormalKnockdown
+};
+
+// Combat.Tuning: eliteKnockdownDuration 1.5s, normalKnockdownDuration 3.0s,
+// crossing as milliseconds. Chief/Elite get the short duration.
+const knockdownMs = (rank) => {
+  const r = clampRank(rank);
+  return r === 4 || r === 5 ? 1500 : 3000;
+};
+
+// Combat.res checkBodyBlock: player centre left of entity centre -> push left
+// (-80), else push right (+80); strict `<` so equal centres push right.
+const bodyBlockDir = (pc, ec) => (pc < ec ? -80 : 80);
+
+export default {
+  affine: "CombatResolve.affine",
+  cases: [
+    { name: "head_stomp_bounce()", export: "head_stomp_bounce", args: [], oracle: () => -180 },
+    { name: "body_stomp_bounce()", export: "body_stomp_bounce", args: [], oracle: () => -250 },
+    { name: "guard_stomp_bounce()", export: "guard_stomp_bounce", args: [], oracle: () => -200 },
+    { name: "body_block_pushback()", export: "body_block_pushback", args: [], oracle: () => 80 },
+    { name: "elite_knockdown_ms()", export: "elite_knockdown_ms", args: [], oracle: () => 1500 },
+    { name: "normal_knockdown_ms()", export: "normal_knockdown_ms", args: [], oracle: () => 3000 },
+    {
+      name: "stomp_outcome over ranks [-2..9]",
+      export: "stomp_outcome",
+      args: [[-2, 9]],
+      oracle: stompOutcome,
+    },
+    {
+      name: "charge_outcome over ranks [-2..9]",
+      export: "charge_outcome",
+      args: [[-2, 9]],
+      oracle: chargeOutcome,
+    },
+    {
+      name: "knockdown_duration_ms over ranks [-2..9]",
+      export: "knockdown_duration_ms",
+      args: [[-2, 9]],
+      oracle: knockdownMs,
+    },
+    {
+      name: "body_block_direction over centres [0..6]x[0..6]",
+      export: "body_block_direction",
+      args: [[0, 6], [0, 6]],
+      oracle: bodyBlockDir,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Coprocessor/Coprocessor.affine
+++ b/proposals/idaptik/migrated/Coprocessor/Coprocessor.affine
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Coprocessor -- the co-processor-framework core, the pure-integer brain
+// extracted from idaptik src/shared/Coprocessor.res. Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; they pass primitives across
+// the wasm boundary"), the JS host keeps the Domain STRING names (Domain.toString),
+// the backend `dict<backend>` registry, every executionResult message, the
+// mutable resourceStats RECORD and its float energy field, and the power-consumer
+// callback. AffineScript owns only the integer decisions the framework makes once
+// the strings are classified: the canonical Domain ordinal band and the integer
+// resourceStats accumulation arithmetic.
+//
+// This file IS the contract the existing host bridge
+// (CoprocessorCoreCoprocessorBridge.js) links against: it expects the exports
+// domain_count / domain_clamp / accumulate_metric / increment_calls, exactly what
+// CoprocessorCoreCoprocessor.res names (domainCount, domainClamp, accumulateMetric,
+// incrementCalls). The float accumulateEnergy fold stays host-side (the energy
+// drain is a float Joule total; per the migration rule floats not integer-exact
+// stay with the senses), so it is intentionally NOT exported here.
+//
+// Re-decomposition notes (NOT a transliteration):
+//   * The Domain variant (IO..Neural) IS the integer its constructor order
+//     implies; we encode it as the closed contiguous 0..9 band, not an enum
+//     round-trip (the round-trip would be the identity), the same flat shape
+//     PortNames.affine and DeviceType.affine use.
+//   * The resourceStats record is mutable host state; the brain owns only the
+//     per-field fold STEP (total := total + delta, calls := calls + 1), pure
+//     functions of explicit Int params -- no module state.
+//
+//## Domain-ordinal encoding (the header contract for the JS host)
+//   code  domain          code  domain
+//     0   IO                5   Maths
+//     1   Vector            6   Quantum
+//     2   Tensor            7   Crypto
+//     3   Graphics          8   Audio
+//     4   Physics           9   Neural
+// The encoding is LOSSLESS: ten distinct domains map to ten distinct codes, so
+// the host round-trips domain <-> code with no collision. A code outside 0..9 is
+// not a domain: domain_clamp folds it to the out-of-band sentinel -1 -- never an
+// in-band code, so no in-band collision is introduced (this is a sentinel, not a
+// clamp; assail stays clean).
+
+// The number of canonical co-processor domains in the taxonomy.
+pub fn domain_count() -> Int { 10 }
+
+// Whether a host integer names a defined domain. 1 = valid, 0 = out of band.
+pub fn is_valid_domain(code: Int) -> Int {
+  if code < 0 { 0 } else { if code > 9 { 0 } else { 1 } }
+}
+
+// Canonicalise a host integer: identity on a valid 0..9 code, the out-of-band
+// sentinel -1 otherwise. -1 is not an in-band code, so out-of-band input can
+// never be confused with a real domain (this is a sentinel, not a clamp).
+pub fn domain_clamp(code: Int) -> Int {
+  if is_valid_domain(code) == 1 { code } else { -1 }
+}
+
+// Fold an integer metric (compute units or memory bytes) into a running total,
+// the resourceStats.totalCompute / totalMemory cumulative step. Pure: the host
+// stores the returned scalar back into its mutable record.
+pub fn accumulate_metric(running_total: Int, delta: Int) -> Int {
+  running_total + delta
+}
+
+// Advance the resourceStats call counter by one (the totalCalls step). The host
+// owns the count; the brain owns only the increment.
+pub fn increment_calls(running_calls: Int) -> Int {
+  running_calls + 1
+}

--- a/proposals/idaptik/migrated/Coprocessor/coprocessor.config.mjs
+++ b/proposals/idaptik/migrated/Coprocessor/coprocessor.config.mjs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Coprocessor.affine (idaptik co-processor framework
+// core; scalar i32 ABI). Every oracle is an INDEPENDENT JS reimplementation
+// derived from src/shared/Coprocessor.res semantics (the Domain variant order
+// and the resourceStats mutable folds) -- NOT a copy of the .affine logic -- so
+// the differential sweep is a genuine cross-check. The .res frames the Domain as
+// a string-keyed variant and the stats as a mutable record; here only the scalar
+// ordinal / fold result crosses.
+
+const validDomain = (c) => c >= 0 && c <= 9;
+
+export default {
+  affine: "Coprocessor.affine",
+  cases: [
+    {
+      name: "domain_count()",
+      export: "domain_count",
+      args: [],
+      oracle: () => 10,
+    },
+    {
+      name: "is_valid_domain over [-3..14]",
+      export: "is_valid_domain",
+      args: [[-3, 14]],
+      oracle: (c) => (validDomain(c) ? 1 : 0),
+    },
+    {
+      name: "domain_clamp over [-3..14] (sentinel -1 out of band)",
+      export: "domain_clamp",
+      args: [[-3, 14]],
+      oracle: (c) => (validDomain(c) ? c : -1),
+    },
+    {
+      name: "accumulate_metric over total in {0,10,9999}, delta in [-5..50]",
+      export: "accumulate_metric",
+      args: [{ values: [0, 10, 9999] }, [-5, 50]],
+      oracle: (t, d) => t + d,
+    },
+    {
+      name: "increment_calls over [-1..2000]",
+      export: "increment_calls",
+      args: [[-1, 2000]],
+      oracle: (n) => n + 1,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Coprocessor_IO/Coprocessor_IO.affine
+++ b/proposals/idaptik/migrated/Coprocessor_IO/Coprocessor_IO.affine
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Coprocessor_IO -- the virtual-filesystem index-and-byte core, the pure-integer
+// brain extracted from idaptik src/shared/Coprocessor_IO.res. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; they pass
+// primitives across the wasm boundary"), the JS host keeps the per-device file
+// buffers, the path and tombstone `dict`s, every path STRING, the array<int>
+// marshalling, the executionResult records and messages, and the float energy /
+// latency metrics. AffineScript owns only the integer kernels: the path-byte
+// validity test and its 7-bit mask, the content-length frame split, the stat
+// big-endian byte pair, and the integer compute-unit metrics.
+//
+// This is the file-buffer anti-pattern from the migration-playbook, re-decomposed:
+// the stateful per-device buffer stays a host SENSE; the deterministic integer
+// arithmetic over indices and bytes is the BRAIN. This file IS the contract the
+// existing host bridge (CoprocessorIOCoprocessorBridge.js) links against: it
+// expects path_byte_valid / mask_ascii / content_len / stat_hi / stat_lo /
+// write_compute / read_compute / list_compute, mirroring CoprocessorIOCoprocessor.res.
+// The float metrics (write/read energyJoules + latencyMs) are NOT integer-exact
+// and stay host-side (per the migration rule), so they are NOT exported here.
+//
+// Re-decomposition notes (NOT a transliteration):
+//   * The write/read/list/stat handlers in the .res are async (promise<
+//     executionResult>) and string-keyed; the async + string + record framing is
+//     senses-work. The BRAIN is the synchronous integer kernels the handlers
+//     compute (50 + contentLen, the >>8/&0xFF stat pair, the 0<b<128 path-byte
+//     filter, the b & 0x7F encode mask).
+//   * No module state: every kernel is a pure function of explicit Int params. The
+//     host folds the actual frame/path/buffer and passes the integer lengths.
+//   * contentLen is the write-frame split: data is [path\0content...], so the byte
+//     count after the null separator is frameLen - (nullIx + 1), floored at 0.
+
+// pathByteValid -- 1 if b is an accepted path byte (0 < b < 128), else 0. Mirrors
+// the decodePath filter `b > 0 && b < 128` (line 111): printable single-byte ASCII
+// only; 0 is the null separator and the high bytes are rejected.
+pub fn path_byte_valid(b: Int) -> Int {
+  if b > 0 { if b < 128 { 1 } else { 0 } } else { 0 }
+}
+
+// maskAscii -- b & 0x7F, the encodePath 7-bit mask (line 124,
+// Int.Bitwise.land(charCode, 0x7F)). Folds any code point onto the low 7 bits.
+pub fn mask_ascii(b: Int) -> Int {
+  b & 127
+}
+
+// contentLen -- bytes after the null separator in a write frame:
+// frameLen - (nullIx + 1), floored at 0. The host has located the null index;
+// the brain owns the floored subtraction so a missing/last-byte null can never
+// yield a negative count.
+pub fn content_len(frame_len: Int, null_ix: Int) -> Int {
+  let n = frame_len - (null_ix + 1);
+  if n < 0 { 0 } else { n }
+}
+
+// statHi -- high byte of the big-endian size pair: (size >> 8) & 0xFF. Mirrors the
+// stat 2-byte big-endian encoding (line 29 / cmdStat).
+pub fn stat_hi(size: Int) -> Int {
+  (size >> 8) & 255
+}
+
+// statLo -- low byte of the big-endian size pair: size & 0xFF.
+pub fn stat_lo(size: Int) -> Int {
+  size & 255
+}
+
+// writeCompute -- write computeUnits: 50 + contentLen (line 174).
+pub fn write_compute(content_len: Int) -> Int {
+  50 + content_len
+}
+
+// readCompute -- read computeUnits: 30 + contentLen (line 206).
+pub fn read_compute(content_len: Int) -> Int {
+  30 + content_len
+}
+
+// listCompute -- list computeUnits: 20 + livePathCount * 5 (line 238).
+pub fn list_compute(live_path_count: Int) -> Int {
+  20 + live_path_count * 5
+}

--- a/proposals/idaptik/migrated/Coprocessor_IO/coprocessor_io.config.mjs
+++ b/proposals/idaptik/migrated/Coprocessor_IO/coprocessor_io.config.mjs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Coprocessor_IO.affine (idaptik virtual-filesystem
+// index-and-byte core; scalar i32 ABI). Every oracle is an INDEPENDENT JS
+// reimplementation derived from src/shared/Coprocessor_IO.res semantics (the
+// 0<b<128 path-byte filter, the b&0x7F encode mask, the frame split, the
+// big-endian stat pair, the integer compute metrics) -- NOT a copy of the .affine
+// logic -- so the differential sweep is a genuine cross-check. The .res frames
+// these inside async file-buffer handlers; here only the scalar result crosses.
+
+const oPathByteValid = (b) => (b > 0 && b < 128 ? 1 : 0);
+const oMaskAscii = (b) => (b & 127) | 0;
+const oContentLen = (frameLen, nullIx) => {
+  const n = frameLen - (nullIx + 1);
+  return n < 0 ? 0 : n;
+};
+const oStatHi = (size) => ((size >> 8) & 255) | 0;
+const oStatLo = (size) => (size & 255) | 0;
+const oWriteCompute = (cl) => 50 + cl;
+const oReadCompute = (cl) => 30 + cl;
+const oListCompute = (n) => 20 + n * 5;
+
+export default {
+  affine: "Coprocessor_IO.affine",
+  cases: [
+    {
+      name: "path_byte_valid over [-5..200]",
+      export: "path_byte_valid",
+      args: [[-5, 200]],
+      oracle: oPathByteValid,
+    },
+    {
+      name: "mask_ascii over [0..300]",
+      export: "mask_ascii",
+      args: [[0, 300]],
+      oracle: oMaskAscii,
+    },
+    {
+      name: "content_len over frame_len in {0,1,10,64,256}, null_ix in {-1,0,5,9,63,255}",
+      export: "content_len",
+      args: [{ values: [0, 1, 10, 64, 256] }, { values: [-1, 0, 5, 9, 63, 255] }],
+      oracle: oContentLen,
+    },
+    {
+      name: "stat_hi over size in [0..70000] sampled by range",
+      export: "stat_hi",
+      args: [{ values: [0, 1, 255, 256, 257, 4096, 65535, 65536, 70000] }],
+      oracle: oStatHi,
+    },
+    {
+      name: "stat_lo over size in [0..70000] sampled",
+      export: "stat_lo",
+      args: [{ values: [0, 1, 255, 256, 257, 4096, 65535, 65536, 70000] }],
+      oracle: oStatLo,
+    },
+    {
+      name: "write_compute over content_len in [0..500]",
+      export: "write_compute",
+      args: [[0, 500]],
+      oracle: oWriteCompute,
+    },
+    {
+      name: "read_compute over content_len in [0..500]",
+      export: "read_compute",
+      args: [[0, 500]],
+      oracle: oReadCompute,
+    },
+    {
+      name: "list_compute over live_path_count in [0..200]",
+      export: "list_compute",
+      args: [[0, 200]],
+      oracle: oListCompute,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/EVIDENCE-C13-logic-sweep.adoc
+++ b/proposals/idaptik/migrated/EVIDENCE-C13-logic-sweep.adoc
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Cluster C13 (logic-directory exhaustive sweep) — migration evidence (2026-06-14)
+:toc: macro
+
+[IMPORTANT]
+====
+*Verdict: 17 new integer brains extracted; the remainder are host-side senses
+or already-migrated.*
+
+This cluster exhaustively swept the eight brain-dense logic directories
+(`src/app/devices`, `src/app/player`, `src/app/combat`, `src/app/enemies`,
+`src/app/companions`, `src/app/multiplayer`, `src/shared`, `src/app/utils`,
+`src/engine/utils`) — 159 `.res` files. Each file is classified as one of:
+MIGRATED (a new `Int(...)->Int` brain extracted), ALREADY (brain extracted in
+an earlier cluster), or NO_NEW_BRAINS (host-side sense, FFI binding shim, or a
+float/string-input core that fails the integer-only parity-harness constraint).
+
+All 17 new brains were *independently re-verified* by the parent session:
+G1 compile, G2 differential parity (all cases pass against an independent JS
+oracle), G4 assail (zero high findings). Total brain count: 62 -> 79.
+====
+
+== Disposition summary
+
+[cols="3,1,1,1,1",options="header"]
+|===
+| Directory | Files | New brains | Already | No-brain
+| `src/app/devices`            | 35 | 0 |  9 | 26
+| `src/app/player`             | 22 | 1 |  7 | 14
+| `src/app/combat`+`enemies`   | 18 | 2 | 10 |  6
+| `src/app/companions`+`multiplayer` | 22 | 4 | 3 | 15
+| `src/shared`                 | 34 | 6 | 12 | 16
+| `src/app/utils`+`engine/utils` | 28 | 4 |  2 | 22
+| *Total*                      | *159* | *17* | *43* | *99*
+|===
+
+== New brains (17) — all G1/G2/G4 green
+
+[cols="2,1,4",options="header"]
+|===
+| Brain | G2 | Extracted logic (re-decomposed, not transliterated)
+| `PlayerSprite`         | 64/64     | frame_count, anim_speed_milli (x1000), state_to_anim, facing_scale_milli, is_valid_anim
+| `CombatResolve`        | 91/91     | rank-keyed stomp/charge outcome bands + knockdown durations (x1000 ms) + bounce velocities + body-block push direction
+| `ThreatClass`          | 77/77     | 13->3 detection-source -> threat-type classifier (Physical/Cyber/Both) over detection ordinals
+| `GameI18nCore`         | 58/58     | language_clamp / next_language / prev_language over 0..4 band + select_plural_form
+| `AlertPalette`         | 219/219   | (highContrast,mode,level) -> packed RGB accessibility alert-colour lookup
+| `PeerPort`             | 68/68     | candidate_port(base,slot)=base+slot*10000 over 0..5 + opposite-family peer_base_port selector
+| `AccessClamp`          | 44/44     | accessibility x1000 clamp sub-brains separated from float/settings modules
+| `Coprocessor`          | 2207/2207 | domain 0..9 band (count/clamp/valid) + resourceStats integer folds (accumulate_metric, increment_calls)
+| `Coprocessor_IO`       | 1758/1758 | path_byte_valid, mask_ascii, content_len, stat_hi/lo, write/read/list_compute (float energy/latency host-side)
+| `Kernel_Crypto`        | 170/170   | crypto-gate status selector (rate-limit 429 / quantum-route 402 / proceed 0) + max_concurrent + crack_strength_threshold
+| `Kernel_Quantum`       | 52/52     | quantum-gate status selector (decoherence / 5000ms cooldown -> 503 / proceed 0) + decoherence_limit_mj + cooldown_ms
+| `ResourceAccounting`   | 2537/2537 | record_compute / record_memory_peak / record_energy (mJ) / end_call / pct / has_capacity (95%) / check_quota 3-way
+| `UmsLevelLoader`       | 229/229   | decode validation: is_valid_kind, subtype_in_band, is_nullary_kind, requires_capacity, normalise_condition, floor_covert_links, resolve_patrol_radius_milli
+| `MoletaireCoprocessors`| 82/82     | GURPS 3-level augment ladder (level_value/colour/next + sensor_range + capability gates)
+| `MoletaireHunger`      | 133/133   | hunger-band classifier over milli-units (behaviour / display_band / will_eat_objective / objective_at_risk)
+| `LobbyManager`         | 577/577   | lobby state machine (connection/room/ready transitions, packed-mask ready_count, all_ready, can_start, state_to_color)
+| `MultiplayerClient`    | 85/85     | stateless session brain (conn_transition state machine, player_count_after, role_clamp, has_partner)
+|===
+
+== NO_NEW_BRAINS (99) — classification categories
+
+* *FFI binding shims (`*Coprocessor.res`, ~40):* pure `@module`/`@send external`
+  declarations wrapping an already-compiled `*.wasm` brain. Zero logic; these are
+  the host bridges the new brains drop into.
+* *Render-glue / PixiJS GUI orchestrators (~25):* device/screen/companion view
+  files whose numeric decisions already route through an existing
+  `*RenderLogicCoprocessor` (float ABI). Strings/floats/DOM senses.
+* *Float-physics / float-geometry cores (~12):* positions, velocities, gravity,
+  pixel coords, devicePixelRatio, atan2 — continuous, not integer-exact; fail the
+  Int-only parity constraint. (PlayerState, KeyboardAiming, PlayerGraphics,
+  TrajectoryPreview, FontScale, GetResolution, CameraFeed, etc.)
+* *String / JSON / wire-protocol cores (~12):* PhoenixSocket V2 framing,
+  BurbleAdapter voice I/O, GossamerFs `%raw` IPC, Kernel_IO path sandbox,
+  translation dictionaries, terminal command dispatch — string-input, host-side.
+* *Host state / orchestration / registration glue (~10):* mutable refs, singletons,
+  localStorage persistence, circular-dep break refs, backend registration, async
+  Promise routing.
+
+== ALREADY migrated (43)
+
+Brains extracted in earlier clusters whose source `.res` live in these dirs:
+CovertLink, FirewallDevice, GlobalNetworkData, LaptopState, NetworkManager,
+NetworkTransfer, NetworkZones, PowerManager, Terminal (devices); CriticalRoll,
+JessicaBackground, JessicaLoadout, PlayerAttributes, QCertifications, QPrograms,
+SkillRank (player); HitboxGeom, PlayerHp, Detection, DualAlert, SecurityAi,
+DifficultyScale, Distraction, Drone, GuardNPC, SecurityDog (combat/enemies);
+Moletaire, VMMessageBus, VMNetwork (companions/multiplayer); Coprocessor_Compute,
+Coprocessor_Security, DLCLoader, DeviceType, Diagnostics, GameEvent, Inventory,
+Kernel, Kernel_Compute, PortNames, PuzzleFormat, RetryPolicy (shared); Maths,
+Random (utils).
+
+== Method note
+
+Brains stay `Int(...)->Int` because the parity harness passes integer arguments
+only; float quantities are carried as x1000 milli-units where integer-exact, else
+kept host-side. The string-wall compiler fixes (slices 8b/9/10) make string
+`==`/`!=`/`<`/`++` work in `.affine`, but string-*input* logic still stays
+host-side here for parity-testability, so this sweep remains integer-brain work.
+Several brains (ThreatClass, AlertPalette, the Coprocessor/Kernel/Resource set)
+are residual sub-brains that earlier clusters scoped out as "routing" — this
+sweep recovered them as separable pure-integer kernels.

--- a/proposals/idaptik/migrated/GameI18nCore/GameI18nCore.affine
+++ b/proposals/idaptik/migrated/GameI18nCore/GameI18nCore.affine
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// GameI18nCore -- the localisation numeric co-processor, the pure-integer core
+// extracted from idaptik src/app/utils/LanguageSettings.res and the plural rule
+// of src/app/utils/GameI18n.res (the same brain that gamei18n.wasm serves, which
+// GameI18nCoprocessor.res already binds via languageClamp / nextLanguage /
+// selectPluralForm). Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi
+// the senses; only primitives cross the wasm boundary") the JS host keeps every
+// language CODE string ("en"/"es"/...), the navigator-language sniff, the
+// translation catalogues and the mustache interpolation; AffineScript owns only
+// the canonical integer encoding of the five languages, the cycle step, and the
+// singular/plural decision.
+//
+// The ReScript original is a 5-constructor variant `language` with a
+// `languageIndex` / `languageOfIndex` pair and a `nextLanguage` cycle, plus the
+// `tn` plural selector (count == 1 -> singular, else plural). We re-decompose the
+// variant as the canonical 0..4 integer the constructor order already implies, so
+// the taxonomy is a closed band and the unknown band folds onto EN, matching
+// `languageOfIndex`'s `_ => EN` arm. No strings cross the boundary.
+//
+//## Language encoding (the header contract for the JS host)
+//   code  language        code  language
+//     0   EN (English)      3   DE (Deutsch)
+//     1   ES (Espanol)      4   JA (Japanese)
+//     2   FR (Francais)
+// The encoding is LOSSLESS over 0..4: five distinct languages map to five
+// distinct codes. Unlike DeviceType this is NOT a sentinel taxonomy -- the
+// ReScript `languageOfIndex` deliberately FOLDS every out-of-band index onto EN
+// (its `_ => EN` arm), so language_clamp returns the in-band code 0 for anything
+// outside 0..4. That fold is intentional, defined behaviour (an unknown locale
+// degrades to English), so this collapse-to-in-band is the specified contract,
+// not an undeclared clamp.
+
+//## Plural form codes
+//   0 = SINGULAR, 1 = PLURAL
+
+// The number of canonical languages in the taxonomy.
+pub fn language_count() -> Int { 5 }
+
+// Whether a host integer names a defined language. 1 = valid 0..4, 0 = otherwise.
+pub fn is_valid_language(code: Int) -> Int {
+  if code < 0 { 0 } else { if code > 4 { 0 } else { 1 } }
+}
+
+// Fold an arbitrary language index onto the valid 0..4 band; unknown -> EN (0).
+// This mirrors LanguageSettings.languageOfIndex's `_ => EN` arm: the fold to the
+// in-band code 0 is the SPECIFIED degrade-to-English behaviour, not a sentinel.
+pub fn language_clamp(code: Int) -> Int {
+  if is_valid_language(code) == 1 { code } else { 0 }
+}
+
+// Advance to the next language in the cycle EN->ES->FR->DE->JA->EN
+// (LanguageSettings.nextLanguage). The input is first folded to the valid band so
+// an unknown index cycles as if it were EN, landing on ES (1).
+pub fn next_language(code: Int) -> Int {
+  let c = language_clamp(code);
+  if c >= 4 { 0 } else { c + 1 }
+}
+
+// The previous language in the cycle (JA<-EN reversed), the inverse of
+// next_language on the closed band. Not in the ReScript source but the natural
+// companion of a cyclic enum; keeps the cycle losslessly invertible.
+pub fn prev_language(code: Int) -> Int {
+  let c = language_clamp(code);
+  if c <= 0 { 4 } else { c - 1 }
+}
+
+// Select the singular (0) or plural (1) form for a count (GameI18n.tn /
+// PolyglotI18n.tn). The ReScript checks `count == 1.0` on a Float; integer item
+// counts cross unscaled (count IS already a whole number at every call site), so
+// the rule is exactly: count == 1 -> SINGULAR (0), otherwise PLURAL (1). A count
+// of 0 is plural ("0 items"), matching the `else` arm.
+pub fn select_plural_form(count: Int) -> Int {
+  if count == 1 { 0 } else { 1 }
+}

--- a/proposals/idaptik/migrated/GameI18nCore/gamei18ncore.config.mjs
+++ b/proposals/idaptik/migrated/GameI18nCore/gamei18ncore.config.mjs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for GameI18nCore.affine (idaptik localisation numeric
+// core; scalar i32 ABI). The oracle re-derives the 0..4 language band, its cycle
+// and the singular/plural rule in plain JS, independently of the .affine, so a
+// codegen regression surfaces as a differential mismatch.
+
+const validLang = (c) => c >= 0 && c <= 4;
+// Independent re-derivation of language_clamp: fold unknown onto EN (0).
+const clampLang = (c) => (validLang(c) ? c : 0);
+// Independent re-derivation of next_language: cycle EN->ES->FR->DE->JA->EN.
+const nextLang = (c) => {
+  const k = clampLang(c);
+  return k === 4 ? 0 : k + 1;
+};
+// Independent re-derivation of prev_language: reverse cycle.
+const prevLang = (c) => {
+  const k = clampLang(c);
+  return k === 0 ? 4 : k - 1;
+};
+
+export default {
+  affine: "GameI18nCore.affine",
+  cases: [
+    { name: "language_count()", export: "language_count", args: [], oracle: () => 5 },
+    {
+      name: "is_valid_language over [-3..8]",
+      export: "is_valid_language",
+      args: [[-3, 8]],
+      oracle: (c) => (validLang(c) ? 1 : 0),
+    },
+    {
+      name: "language_clamp over [-3..8]",
+      export: "language_clamp",
+      args: [[-3, 8]],
+      oracle: clampLang,
+    },
+    {
+      name: "next_language over [-3..8]",
+      export: "next_language",
+      args: [[-3, 8]],
+      oracle: nextLang,
+    },
+    {
+      name: "prev_language over [-3..8]",
+      export: "prev_language",
+      args: [[-3, 8]],
+      oracle: prevLang,
+    },
+    {
+      name: "select_plural_form over [-2..6]",
+      export: "select_plural_form",
+      args: [[-2, 6]],
+      oracle: (count) => (count === 1 ? 0 : 1),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Kernel_Crypto/Kernel_Crypto.affine
+++ b/proposals/idaptik/migrated/Kernel_Crypto/Kernel_Crypto.affine
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Kernel_Crypto -- the crypto-domain kernel GATE, the pure-integer brain
+// extracted from idaptik src/shared/Kernel_Crypto.res. Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; they pass primitives across
+// the wasm boundary"), the JS host keeps the per-device `dict<ref<int>>` active-
+// count state, the device-id STRINGS, every executionResult message, the Promise
+// dispatch, and the registry walk (listByDomain). AffineScript owns only the
+// integer GATE decision the handler makes before dispatch: which status code the
+// two enforcement layers (concurrency rate limit; quantum gate for strong cracks)
+// select, given the device's current active count and the decoded command shape.
+//
+// Re-decomposition notes (NOT a transliteration):
+//   * Kernel_Crypto.res is async (returns promise<executionResult>) and string-
+//     keyed (cmd == "crack"). The async + string + message framing is incidental
+//     senses-work; the BRAIN is the synchronous integer status selection. The host
+//     classifies the command to a flag (is_crack) and reads data[1] as the integer
+//     strength before calling the brain.
+//   * No module state: the active count is an explicit Int param; the brain owns
+//     only the threshold comparisons, not the dict.
+//   * "no backend registered" (status 404) is registry state the host owns; the
+//     brain models the gate up to the point of dispatch -- 0 means "proceed to
+//     dispatch" (to the Crypto backend, or the Quantum backend on the strong-crack
+//     route), and the host then resolves 404 itself if the chosen domain is empty.
+//
+//## Status encoding (the header contract for the JS host)
+//   429  rate limit hit   -- active crypto ops at the per-device maximum
+//   402  quantum required -- crack strength >= 4 but no quantum backend present
+//     0  proceed          -- dispatch to the Crypto (or Quantum) backend
+// These mirror the .res `status: 429 / 402` resolutions and the `| Some(...)`
+// dispatch arms.
+
+// Maximum simultaneous crypto operations allowed per device (.res
+// maxConcurrentCrypto). At or above this, the gate returns 429.
+pub fn max_concurrent_crypto() -> Int { 3 }
+
+// The crack-strength threshold at or above which a crack is routed to the Quantum
+// domain instead of Crypto (.res `strength >= 4`).
+pub fn crack_strength_threshold() -> Int { 4 }
+
+// The crypto-gate status selector. Inputs:
+//   active      -- the device's current in-flight crypto-op count.
+//   is_crack    -- 1 if the command is "crack", else 0 (host-classified).
+//   strength    -- the decoded crack strength (data[1]; host default 3 if absent).
+//   has_quantum -- 1 if a Quantum backend is registered, else 0 (registry state).
+// Returns 429 (rate limit), 402 (quantum required), or 0 (proceed to dispatch),
+// mirroring the .res control flow exactly:
+//   1. active >= max            -> 429
+//   2. crack & strength >= 4    -> has_quantum ? 0 : 402
+//   3. otherwise                -> 0
+pub fn crypto_status(active: Int, is_crack: Int, strength: Int, has_quantum: Int) -> Int {
+  if active >= max_concurrent_crypto() {
+    429
+  } else {
+    if is_crack == 1 {
+      if strength >= crack_strength_threshold() {
+        if has_quantum == 1 { 0 } else { 402 }
+      } else { 0 }
+    } else { 0 }
+  }
+}

--- a/proposals/idaptik/migrated/Kernel_Crypto/kernel_crypto.config.mjs
+++ b/proposals/idaptik/migrated/Kernel_Crypto/kernel_crypto.config.mjs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Kernel_Crypto.affine (idaptik crypto-domain kernel
+// gate; scalar i32 ABI). Every oracle is an INDEPENDENT JS reimplementation
+// derived from src/shared/Kernel_Crypto.res semantics (the rate-limit check, the
+// strength>=4 quantum route, the 429/402/proceed selection) -- NOT a copy of the
+// .affine logic -- so the differential sweep is a genuine cross-check. The .res
+// frames these as async promise<executionResult> with message strings; here only
+// the scalar status crosses.
+
+const MAX = 3;
+const THRESHOLD = 4;
+
+const oCryptoStatus = (active, isCrack, strength, hasQuantum) => {
+  if (active >= MAX) return 429;
+  if (isCrack === 1) {
+    if (strength >= THRESHOLD) {
+      return hasQuantum === 1 ? 0 : 402;
+    }
+    return 0;
+  }
+  return 0;
+};
+
+export default {
+  affine: "Kernel_Crypto.affine",
+  cases: [
+    {
+      name: "max_concurrent_crypto()",
+      export: "max_concurrent_crypto",
+      args: [],
+      oracle: () => 3,
+    },
+    {
+      name: "crack_strength_threshold()",
+      export: "crack_strength_threshold",
+      args: [],
+      oracle: () => 4,
+    },
+    {
+      name: "crypto_status over active in [0..5], is_crack in {0,1}, strength in [0..6], has_quantum in {0,1}",
+      export: "crypto_status",
+      args: [[0, 5], { values: [0, 1] }, [0, 6], { values: [0, 1] }],
+      oracle: oCryptoStatus,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/Kernel_Quantum/Kernel_Quantum.affine
+++ b/proposals/idaptik/migrated/Kernel_Quantum/Kernel_Quantum.affine
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Kernel_Quantum -- the quantum-domain kernel GATE, the pure-integer brain
+// extracted from idaptik src/shared/Kernel_Quantum.res. Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; they pass primitives across
+// the wasm boundary"), the JS host keeps the per-device `dict<float>`
+// last-quantum-op timestamps, the device-id STRINGS, the Date.now() wall clock,
+// every executionResult message, the Promise dispatch, the [QUANTUM AUDIT] log,
+// and the registry walk. AffineScript owns only the integer GATE decision the
+// handler makes before dispatch: which status the two enforcement layers
+// (decoherence energy guard; per-device cooldown) select.
+//
+// Re-decomposition notes (NOT a transliteration):
+//   * Kernel_Quantum.res is async and float-clocked (Date.now, maxEnergy : float).
+//     The async + clock + message framing is senses-work; the BRAIN is the
+//     synchronous integer status selection. The host reads the device's
+//     accumulated energy and the elapsed-since-last-op interval and passes both as
+//     integers before calling the brain.
+//   * ENERGY crosses as integer milli-Joules (1 J = 1000 mJ): the .res guard is
+//     `maxEnergy > 50.0` J; scaled, that is `energy_mj > 50000`. TIME crosses as
+//     integer milliseconds (the .res cooldown is already 5000.0 ms; Date.now
+//     deltas are whole-ms). This is the migration rule "floats -> x1000 / integer
+//     ms when integer-expressible".
+//   * No module state: the energy total, the elapsed interval and the "has a prior
+//     op" flag are explicit Int params; the brain owns only the comparisons.
+//   * Wall-clock IS a sense (per the multiplayer-determinism model), so the
+//     host computes `now - last`; the brain receives the already-computed elapsed.
+//   * "no QPU backend" (status 404) is registry state the host owns; 0 means
+//     "proceed to dispatch", and the host resolves 404 itself if the Quantum
+//     domain is empty.
+//
+//## Status encoding (the header contract for the JS host)
+//   503  unavailable  -- decoherence (energy over limit) OR cooldown still active
+//     0  proceed      -- dispatch to the Quantum backend
+// Both 503 paths mirror the .res `status: 503` resolutions (decoherence guard and
+// cooldown check); 0 is the `| Some(b) => b.execute(...)` dispatch arm.
+
+// The cumulative-energy decoherence limit in milli-Joules (.res `maxEnergy > 50.0`
+// J, scaled by 1000). Above this the device cannot maintain qubit coherence.
+pub fn decoherence_limit_mj() -> Int { 50000 }
+
+// The per-device cooldown period in milliseconds (.res quantumCooldownMs). This
+// must elapse between successful quantum ops.
+pub fn cooldown_ms() -> Int { 5000 }
+
+// The quantum-gate status selector. Inputs:
+//   energy_mj  -- the device's cumulative energy use in milli-Joules.
+//   elapsed_ms -- ms since the device's last successful quantum op (host-computed
+//                 now - last); ignored when has_last == 0.
+//   has_last   -- 1 if the device has a prior quantum op on record (last > 0.0),
+//                 else 0 (first op is never cooldown-gated).
+// Returns 503 (decoherence or cooldown) or 0 (proceed to dispatch), mirroring the
+// .res control flow exactly:
+//   1. energy_mj > 50000                          -> 503 (decoherence)
+//   2. elapsed_ms < 5000 && has_last == 1         -> 503 (cooldown)
+//   3. otherwise                                  -> 0
+pub fn quantum_status(energy_mj: Int, elapsed_ms: Int, has_last: Int) -> Int {
+  if energy_mj > decoherence_limit_mj() {
+    503
+  } else {
+    if has_last == 1 {
+      if elapsed_ms < cooldown_ms() { 503 } else { 0 }
+    } else { 0 }
+  }
+}

--- a/proposals/idaptik/migrated/Kernel_Quantum/kernel_quantum.config.mjs
+++ b/proposals/idaptik/migrated/Kernel_Quantum/kernel_quantum.config.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for Kernel_Quantum.affine (idaptik quantum-domain kernel
+// gate; scalar i32 ABI). Every oracle is an INDEPENDENT JS reimplementation
+// derived from src/shared/Kernel_Quantum.res semantics (the >50 J decoherence
+// guard scaled to mJ, the 5000 ms cooldown, the 503/proceed selection) -- NOT a
+// copy of the .affine logic -- so the differential sweep is a genuine cross-check.
+// The .res frames these as async promise<executionResult> with message strings
+// and a float Date.now clock; here only the scalar status crosses, with energy in
+// milli-Joules and time in whole milliseconds.
+
+const LIMIT_MJ = 50000;
+const COOLDOWN_MS = 5000;
+
+const oQuantumStatus = (energyMj, elapsedMs, hasLast) => {
+  if (energyMj > LIMIT_MJ) return 503;
+  if (hasLast === 1) {
+    return elapsedMs < COOLDOWN_MS ? 503 : 0;
+  }
+  return 0;
+};
+
+export default {
+  affine: "Kernel_Quantum.affine",
+  cases: [
+    {
+      name: "decoherence_limit_mj()",
+      export: "decoherence_limit_mj",
+      args: [],
+      oracle: () => 50000,
+    },
+    {
+      name: "cooldown_ms()",
+      export: "cooldown_ms",
+      args: [],
+      oracle: () => 5000,
+    },
+    {
+      name: "quantum_status over energy {0,49999,50000,50001,80000}, elapsed {0,4999,5000,5001,12000}, has_last {0,1}",
+      export: "quantum_status",
+      args: [
+        { values: [0, 49999, 50000, 50001, 80000] },
+        { values: [0, 4999, 5000, 5001, 12000] },
+        { values: [0, 1] },
+      ],
+      oracle: oQuantumStatus,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/LobbyManager/LobbyManager.affine
+++ b/proposals/idaptik/migrated/LobbyManager/LobbyManager.affine
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// LobbyManager -- the lobby-state co-processor, the pure-integer core extracted
+// from idaptik src/app/multiplayer/LobbyManager.res (multiplayer-lobby state
+// management). Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the
+// senses; only primitives cross the wasm boundary") and the SHAPE-A note on the
+// host binding (LobbyManagerCoprocessor.res / its Bridge.js), the model never lives
+// in wasm: "the HOST owns every room record and its string id and name, the array
+// of player entries, the selected-room option, the player name, the error string
+// and every Phoenix channel push" (LobbyManagerCoprocessor.res:14-19). Each kernel
+// takes the relevant current scalar(s) plus event args and returns the new scalar,
+// which the caller stores back. Only the lobby-state ordinal, the role ordinal, the
+// packed ready-bit mask and the counts cross. Every export is i32 -> i32 (scalar ABI).
+//
+//## Why this split, not a port of LobbyManager.res
+// LobbyManager.res entangles (a) the lobbyState transitions (setConnectionState,
+// enterRoom, leaveRoom, setReady, unsetReady, res:69-175), (b) the role toggle
+// (toggleRole, res:89-96), (c) the per-player readiness over the player list
+// (setPlayerReady, allPlayersReady, canStartGame, res:147-199), and (d) a great
+// deal of STRING/record/array work (room records, playerEntry arrays, the player
+// name, the role strings "q"/"observer", the error option, stateToString,
+// roleDisplayName, roleDescription, res:24-50, 178-241). Only (a)-(c) are integer
+// decisions; (d) is host senses. The player LIST stays host-side as a SHAPE-A
+// array; what crosses for readiness is its packed bit-mask (bit i = player i is
+// ready) plus the live-player count. This file is the verified core of the
+// transition + predicate kernels the host binding already contracts for
+// (LobbyManagerCoprocessor.res:67-100: stateOfConnection / enterRoomState /
+// leaveRoomState / setReadyState / unsetReadyState / toggleRole / setPlayerReady /
+// allPlayersReady / canStartGame / readyCount / stateToColor).
+//
+//## lobbyState encoding (declaration order of `lobbyState`, res:16-22)
+//   code  state         meaning
+//     0   Disconnected  not connected to the sync server
+//     1   Connecting    WebSocket opening
+//     2   Connected     socket open, not yet in a room
+//     3   InRoom        joined a room (host keeps the room id string)
+//     4   Ready         in a room and marked ready
+// A state ordinal outside 0..4 is not a defined lobby state: unset_ready_state
+// passes it through untouched (its "otherwise unchanged" arm) and state_to_color
+// reports the OUT-OF-BAND SENTINEL -1 (never an in-band colour, so no collision).
+//
+//## connectionState encoding (declaration order of PhoenixSocket.connectionState)
+//   0 Disconnected   1 Connecting   2 Connected
+// state_of_connection maps these onto the lobbyState band; a connection ordinal
+// outside 0..2 is undefined and yields the SENTINEL -1.
+//
+//## role encoding (the host's "q"/"observer" strings, read as ordinals)
+//   0 Q (hacker)   1 Observer/Operator
+// The host parses the role string; the kernel flips the ordinal. Mirrors the .res
+// `if role == "q" { "observer" } else { "q" }` -- ANY non-Q ordinal toggles to Q.
+//
+//## ready-mask encoding
+// The packed ready mask is an i32 with bit i set iff player i (in the host's array
+// order) is ready. `count` is the number of live players (0..MAX_PLAYERS). The
+// "live bits" are the low `count` bits; all_players_ready asks they are all set,
+// ready_count tallies them. MAX_PLAYERS caps the mask at a realistic lobby size so
+// the bit idiom stays well inside i32 (asymmetric co-op needs only a handful).
+
+//## The lobby player cap. The asymmetric co-op design seats only a few players per
+// room; 16 is a generous ceiling that keeps the 2^count live-mask inside i32.
+fn max_players() -> Int { 16 }
+
+//## The bit value for a player index, built by repeated doubling (the proven idiom
+// for 2^index with a small non-negative exponent; 1 << index is avoided in favour
+// of the portable multiply, mirroring LaptopState.bit_of).
+fn bit_of(index: Int) -> Int {
+  let mut value = 1;
+  let mut k = 0;
+  while k < index {
+    value = value * 2;
+    k = k + 1;
+  }
+  value
+}
+
+//## Whether a player index addresses a live seat (0 .. MAX_PLAYERS-1). An
+// out-of-band index is a phantom seat and every mask kernel no-ops on it.
+fn valid_index(index: Int) -> Int {
+  if index < 0 { return 0; }
+  if index >= max_players() { return 0; }
+  1
+}
+
+//## state_of_connection -- map a PhoenixSocket connectionState ordinal onto the
+// lobbyState ordinal. The integer core of LobbyManager.setConnectionState
+// (res:69-76): Connected -> Connected, Connecting -> Connecting, Disconnected ->
+// Disconnected. lobbyState and connectionState are DISTINCT enums (hence the
+// binding's stateOfConnection); they happen to agree on these three ordinals, but
+// we map explicitly so a future reorder of either enum is caught by parity rather
+// than silently aliased. An undefined connection ordinal yields the OUT-OF-BAND
+// SENTINEL -1 (not an in-band lobby state; sentinel, not a clamp).
+pub fn state_of_connection(conn: Int) -> Int {
+  if conn == 0 { return 0; }   // Disconnected -> Disconnected
+  if conn == 1 { return 1; }   // Connecting   -> Connecting
+  if conn == 2 { return 2; }   // Connected    -> Connected
+  -1                           // undefined connection ordinal
+}
+
+//## enter_room_state -- the lobby state after a successful channel join.
+// The integer core of LobbyManager.enterRoom (res:104-112): joining a room moves
+// the lobby to InRoom(3) regardless of the prior state (the host stores the room
+// id string separately). Constant InRoom(3).
+pub fn enter_room_state(prev: Int) -> Int {
+  let _ = prev;
+  3
+}
+
+//## leave_room_state -- the lobby state after leaving a room.
+// The integer core of LobbyManager.leaveRoom (res:115-124): leaving returns the
+// lobby to Connected(2) (socket still open, no room). Constant Connected(2).
+pub fn leave_room_state(prev: Int) -> Int {
+  let _ = prev;
+  2
+}
+
+//## set_ready_state -- the lobby state after marking self ready.
+// The integer core of LobbyManager.setReady (res:161-163): marking ready moves the
+// lobby to Ready(4). Constant Ready(4).
+pub fn set_ready_state(prev: Int) -> Int {
+  let _ = prev;
+  4
+}
+
+//## unset_ready_state -- the lobby state after unmarking ready.
+// The integer core of LobbyManager.unsetReady (res:166-175): ONLY from Ready(4)
+// does unmarking do anything -- it drops to InRoom(3) when a room is still selected
+// (has_room != 0) else to Connected(2). From any other state it is a no-op and the
+// state is returned UNCHANGED (res:172 `| _ => model`). An out-of-band state is not
+// Ready and is likewise passed through untouched (sentinel-preserving: we never
+// fabricate an in-band state from an undefined one).
+pub fn unset_ready_state(state: Int, has_room: Int) -> Int {
+  if state == 4 {
+    if has_room != 0 { return 3; }   // back to InRoom (room still selected)
+    return 2;                        // back to Connected (no room)
+  }
+  state                              // not Ready: unchanged
+}
+
+//## toggle_role -- flip the role ordinal Q <-> Observer.
+// The integer core of LobbyManager.toggleRole (res:89-96): the .res flips on the
+// string identity `role == "q"`, so Q(0) -> Observer(1) and ANY non-Q ordinal ->
+// Q(0). This makes Q the canonical "off-Observer" fixpoint exactly as the string
+// logic does (a stray ordinal toggles back to Q, never to a phantom role).
+pub fn toggle_role(role: Int) -> Int {
+  if role == 0 { 1 } else { 0 }
+}
+
+//## set_player_ready -- set or clear the ready bit for player `index` in the mask.
+// The integer core of LobbyManager.setPlayerReady (res:147-158): the host marks
+// one player in its array ready/not, which here is one bit toggle on the packed
+// mask. `ready` non-zero SETS bit `index`, zero CLEARS it; the new mask is returned
+// for the host to store back. An out-of-band index addresses no live seat and
+// leaves the mask untouched (the no-op a phantom player id would amount to).
+// Built from add/subtract of the bit value (mirroring LaptopState.service_set), so
+// no unary ~ is needed (that opcode mis-compiles; see VmBitwise EVIDENCE).
+pub fn set_player_ready(mask: Int, index: Int, ready: Int) -> Int {
+  if valid_index(index) == 0 { return mask; }
+  let bit = bit_of(index);
+  let is_set = (mask / bit) % 2 == 1;
+  if ready != 0 {
+    if is_set { mask } else { mask + bit }
+  } else {
+    if is_set { mask - bit } else { mask }
+  }
+}
+
+//## ready_count -- the number of players currently ready (the "k of n" readout).
+// Companion to LobbyManager.allPlayersReady (res:190-193) and the binding's
+// readyCount (res:96-97): popcount of the LOW `count` bits of the mask, i.e. how
+// many of the `count` live players have their ready bit set. A non-positive count
+// has no live players and tallies 0; the count is capped at MAX_PLAYERS so the scan
+// is bounded. Implemented as a bounded bit-scan (while loop, mirroring the
+// LaptopState idiom) rather than a SWAR popcount, to stay clear of the arithmetic
+// `>>` sign-propagation on the high bit.
+pub fn ready_count(mask: Int, count: Int) -> Int {
+  let mut live = count;
+  if live < 0 { live = 0; }
+  if live > max_players() { live = max_players(); }
+  let mut acc = 0;
+  let mut bit = 1;
+  let mut k = 0;
+  while k < live {
+    if (mask / bit) % 2 == 1 { acc = acc + 1; }
+    bit = bit * 2;
+    k = k + 1;
+  }
+  acc
+}
+
+//## all_players_ready -- whether every live player is ready.
+// The integer core of LobbyManager.allPlayersReady (res:190-193): true iff there is
+// at least one player AND all of them are ready. Over the packed mask that is
+// `count > 0 AND ready_count(mask, count) == count` -- the low `count` bits are all
+// set. Returns 1 = all ready, 0 = not. A zero/negative count returns 0 (an empty
+// lobby is never "all ready"), mirroring res:191 `Array.length > 0`.
+pub fn all_players_ready(mask: Int, count: Int) -> Int {
+  if count <= 0 { return 0; }
+  if ready_count(mask, count) == count { 1 } else { 0 }
+}
+
+//## can_start_game -- whether the Start Game button should enable.
+// The integer core of LobbyManager.canStartGame (res:197-199): the host may start
+// iff it IS the host AND all players are ready. `is_host` non-zero means host.
+// Returns 1 = enable, 0 = disable.
+pub fn can_start_game(is_host: Int, mask: Int, count: Int) -> Int {
+  if is_host == 0 { return 0; }
+  all_players_ready(mask, count)
+}
+
+//## state_to_color -- the status-indicator hex colour for a lobby-state ordinal.
+// The integer core of LobbyManager.stateToColor (res:213-221): red Disconnected,
+// orange Connecting, green Connected, blue InRoom, teal Ready. Total over the 0..4
+// band, each state a distinct hex (no collision). An out-of-band state ordinal is
+// not a defined state and yields the OUT-OF-BAND SENTINEL -1 (not an in-band
+// colour; sentinel, not a clamp; assail PA-AFF-001 stays clean). Values mirror
+// res:214-220 exactly.
+pub fn state_to_color(state: Int) -> Int {
+  if state == 0 { return 16729156; }   // 0xff4444 -- Disconnected (red)
+  if state == 1 { return 16755268; }   // 0xffaa44 -- Connecting (orange)
+  if state == 2 { return 4521796; }    // 0x44ff44 -- Connected (green)
+  if state == 3 { return 4491519; }    // 0x4488ff -- InRoom (blue)
+  if state == 4 { return 4521898; }    // 0x44ffaa -- Ready (teal)
+  -1                                   // out of band: not a defined lobby state
+}

--- a/proposals/idaptik/migrated/LobbyManager/lobbymanager.config.mjs
+++ b/proposals/idaptik/migrated/LobbyManager/lobbymanager.config.mjs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for LobbyManager.affine (idaptik multiplayer-lobby state
+// kernel; SHAPE-A; scalar i32 ABI). Each oracle re-derives the rule straight from
+// the ReScript source / the host binding contract in plain JS, INDEPENDENTLY of the
+// .affine, so a codegen regression surfaces as a differential mismatch.
+//
+// Oracle re-derivation (rule <- source site), independent of the .affine.
+// lobbyState {Disconnected0,Connecting1,Connected2,InRoom3,Ready4};
+// connectionState {Disconnected0,Connecting1,Connected2}; role {Q0,Observer1};
+// MAX_PLAYERS = 16.
+//   state_of_connection(c) = (0<=c<=2) ? c : -1                  (setConnectionState, res:69-76)
+//   enter_room_state(_)    = 3                                   (enterRoom, res:104-112)
+//   leave_room_state(_)    = 2                                   (leaveRoom, res:115-124)
+//   set_ready_state(_)     = 4                                   (setReady, res:161-163)
+//   unset_ready_state(s,r) = s===4 ? (r?3:2) : s                 (unsetReady, res:166-175)
+//   toggle_role(r)         = r===0 ? 1 : 0                       (toggleRole, res:89-96)
+//   set_player_ready(m,i,r)= toggle bit i of m by r, no-op off-band  (setPlayerReady, res:147-158)
+//   ready_count(m,n)       = popcount of low clamp(n,0,16) bits of m (allPlayersReady/binding)
+//   all_players_ready(m,n) = n>0 && ready_count(m,n)===n         (allPlayersReady, res:190-193)
+//   can_start_game(h,m,n)  = h ? all_players_ready(m,n) : 0      (canStartGame, res:197-199)
+//   state_to_color(s)      = palette[s] ?? -1                    (stateToColor, res:213-221)
+
+const MAX = 16;
+const clampCount = (n) => (n < 0 ? 0 : n > MAX ? MAX : n);
+
+const stateOfConnection = (c) => (c >= 0 && c <= 2 ? c : -1);
+const enterRoomState = (_) => 3;
+const leaveRoomState = (_) => 2;
+const setReadyState = (_) => 4;
+const unsetReadyState = (s, r) => (s === 4 ? (r !== 0 ? 3 : 2) : s);
+const toggleRole = (r) => (r === 0 ? 1 : 0);
+
+// Bit toggle on the packed mask; out-of-band index (>= MAX or < 0) is a no-op.
+const validIndex = (i) => i >= 0 && i < MAX;
+const setPlayerReady = (m, i, r) => {
+  if (!validIndex(i)) return m;
+  const bit = 2 ** i;
+  const isSet = Math.floor(m / bit) % 2 === 1;
+  if (r !== 0) return isSet ? m : m + bit;
+  return isSet ? m - bit : m;
+};
+// Popcount of the low clamp(n,0,16) bits of m.
+const readyCount = (m, n) => {
+  const live = clampCount(n);
+  let acc = 0;
+  let bit = 1;
+  for (let k = 0; k < live; k++) {
+    if (Math.floor(m / bit) % 2 === 1) acc++;
+    bit *= 2;
+  }
+  return acc;
+};
+const allPlayersReady = (m, n) => (n > 0 && readyCount(m, n) === n ? 1 : 0);
+const canStartGame = (h, m, n) => (h !== 0 ? allPlayersReady(m, n) : 0);
+const PALETTE = { 0: 0xff4444, 1: 0xffaa44, 2: 0x44ff44, 3: 0x4488ff, 4: 0x44ffaa };
+const stateToColor = (s) => (s in PALETTE ? PALETTE[s] : -1);
+
+// Sweep ranges. State/connection/role over their bands + out-of-band guards.
+// Masks: a spread of bit patterns incl. 0, all-low-bits-set, and gaps. Counts:
+// 0 (empty), small lobbies, and just past MAX to exercise the clamp.
+const STATE = [-1, 0, 1, 2, 3, 4, 5, 7];
+const CONN = [-1, 0, 1, 2, 3];
+const ROLE = [-1, 0, 1, 2];
+const FLAG = [0, 1];
+const MASK = [0, 1, 2, 3, 5, 7, 8, 15, 31, 255];
+const COUNT = [-1, 0, 1, 2, 3, 4, 8, 16, 17];
+const INDEX = [-1, 0, 1, 2, 7, 15, 16, 20];
+
+export default {
+  affine: "LobbyManager.affine",
+  cases: [
+    { name: "state_of_connection over conn band + out-of-band", export: "state_of_connection", args: [{ values: CONN }], oracle: stateOfConnection },
+    { name: "enter_room_state over state band", export: "enter_room_state", args: [{ values: STATE }], oracle: enterRoomState },
+    { name: "leave_room_state over state band", export: "leave_room_state", args: [{ values: STATE }], oracle: leaveRoomState },
+    { name: "set_ready_state over state band", export: "set_ready_state", args: [{ values: STATE }], oracle: setReadyState },
+    { name: "unset_ready_state over state x has-room", export: "unset_ready_state", args: [{ values: STATE }, { values: FLAG }], oracle: unsetReadyState },
+    { name: "toggle_role over role band + out-of-band", export: "toggle_role", args: [{ values: ROLE }], oracle: toggleRole },
+    { name: "set_player_ready over mask x index x ready-flag", export: "set_player_ready", args: [{ values: MASK }, { values: INDEX }, { values: FLAG }], oracle: setPlayerReady },
+    { name: "ready_count over mask x count", export: "ready_count", args: [{ values: MASK }, { values: COUNT }], oracle: readyCount },
+    { name: "all_players_ready over mask x count", export: "all_players_ready", args: [{ values: MASK }, { values: COUNT }], oracle: allPlayersReady },
+    { name: "can_start_game over host-flag x mask x count", export: "can_start_game", args: [{ values: FLAG }, { values: MASK }, { values: COUNT }], oracle: canStartGame },
+    { name: "state_to_color over state band + out-of-band", export: "state_to_color", args: [{ values: STATE }], oracle: stateToColor },
+  ],
+};

--- a/proposals/idaptik/migrated/MoletaireCoprocessors/MoletaireCoprocessors.affine
+++ b/proposals/idaptik/migrated/MoletaireCoprocessors/MoletaireCoprocessors.affine
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// MoletaireCoprocessors -- the coprocessor-effect co-processor, the pure-integer
+// core extracted from idaptik src/app/companions/MoletaireCoprocessors.res (the
+// GURPS-style 3-level computational augments for the Moletaire companion). Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only primitives
+// cross the wasm boundary") and the host binding contract
+// (MoletaireCoprocessorsCoprocessor.res / its Bridge.js), the model never lives in
+// wasm: the host keeps the coprocessorBay record, every coprocessor STRING (name,
+// description), the variant `level` and `coprocessorType`, and the FeaturePacks
+// flag plumbing. The kernel sees only the LEVEL ORDINAL 0..3 the host derives from
+// the `level` variant via levelValue, and returns the per-augment effect as a
+// scalar. Every export is i32 -> i32 (scalar ABI).
+//
+//## Why this split, not a port of MoletaireCoprocessors.res
+// MoletaireCoprocessors.res entangles (a) the level<->ordinal mapping (levelValue,
+// res:41-47), (b) the per-augment integer-effect ladders keyed by that ordinal
+// (audioSoundCount 0/3/6/10 res:222-238; sensorRange 1/3/5/8 res:275-291; the
+// MK-III gate predicates canMimicVoice/canDetectVaultWeakPoints res:240-251,
+// 295-305; the >= Enhanced gate canCarryFragile res:370-371; the 0..3 vibration
+// band res:319-346), (c) the upgrade step (Stock->Basic->Enhanced->Overclocked or
+// none, res:171-186), and (d) the badge colour map (levelColor, res:59-65). Plus
+// two FLOAT effects (pathEfficiency, eatChanceMultiplier res:255-271, 350-366) and
+// all the STRING work (coprocessorName/Description, res:98-119). Only (a)-(d) are
+// integer decisions; the floats cross in milli-units host-side per the binding
+// (Bridge divides by 1000) and the strings are host senses. This file is the
+// verified core of the integer kernels the host binding already contracts for
+// (MoletaireCoprocessorsCoprocessor.res:47-78: audioSoundCount / canMimicVoice /
+// sensorRange / canDetectVaultWeakPoints / vibrationQuality / canCarryFragile /
+// levelValue / levelColour / nextLevel).
+//
+//## Level-ordinal encoding (the header contract for the JS host)
+// The host derives the ordinal from the `level` variant (declaration order,
+// res:30-47) and hands the kernel the ordinal, never the variant:
+//   code  level         meaning
+//     0   Stock         no coprocessor installed (baseline)
+//     1   Basic         MK-I  -- basic augment
+//     2   Enhanced      MK-II -- enhanced augment
+//     3   Overclocked   MK-III -- overclocked (max capability)
+// The encoding is LOSSLESS over its closed 0..3 band. A level ordinal outside
+// 0..3 is not a defined level: level_value clamps it to the nearest in-band
+// endpoint (it is a numeric magnitude, so clamping to the band is meaningful --
+// this IS a clamp, mirroring res:41-47's total switch over the four constructors),
+// while the per-augment ladders fail safe to the Stock effect for any undefined
+// ordinal, and next_level returns the OUT-OF-BAND SENTINEL -1 past Overclocked.
+
+//## The number of canonical augment levels in the GURPS ladder (Stock..Overclocked).
+pub fn level_count() -> Int { 4 }
+
+//## level_value -- canonicalise a host level ordinal onto the closed 0..3 band.
+// The integer core of MoletaireCoprocessors.levelValue (res:41-47): a total map
+// from the four-constructor `level` variant to its numeric magnitude 0..3. Because
+// the band is a magnitude (more level = more capability), an out-of-band ordinal
+// is CLAMPED to the nearest endpoint rather than sentinelled: a negative ordinal
+// floors to Stock(0), an ordinal above Overclocked ceils to Overclocked(3). The
+// in-band 0..3 is the identity. (This is the one true clamp in the module; every
+// other export uses a 0/-1 predicate or sentinel.)
+pub fn level_value(lvl: Int) -> Int {
+  if lvl < 0 { return 0; }
+  if lvl > 3 { return 3; }
+  lvl
+}
+
+//## level_colour -- the 24-bit RGB badge colour for a level ordinal.
+// The integer core of MoletaireCoprocessors.levelColor (res:59-65): the upgrade
+// UI badge hex, keyed by the canonicalised level. Stock grey, Basic green,
+// Enhanced blue, Overclocked orange (the host palette, read as its ordinal). An
+// out-of-band ordinal is canonicalised first via level_value, so the colour map is
+// total over the band and never collides (each of the four levels has a distinct
+// hex). The values mirror res:59-65 exactly.
+pub fn level_colour(lvl: Int) -> Int {
+  let c = level_value(lvl);
+  if c == 0 { return 5592405; }    // 0x555555 -- Stock (grey)
+  if c == 1 { return 4500036; }    // 0x44aa44 -- Basic (green)
+  if c == 2 { return 4491519; }    // 0x4488ff -- Enhanced (blue)
+  16746564                         // 0xff8844 -- Overclocked (orange)
+}
+
+//## next_level -- the level ordinal after an upgrade, or -1 when maxed.
+// The integer core of MoletaireCoprocessors.upgrade's next-level step
+// (res:171-186): Stock->Basic->Enhanced->Overclocked advances by one, and an
+// Overclocked coprocessor has NO next level (upgrade returns false, res:178/184).
+// So this returns lvl+1 on the closed 0..2 band and the OUT-OF-BAND SENTINEL -1 at
+// Overclocked(3) -- and likewise -1 for any out-of-band ordinal, which is not a
+// defined level and therefore has no successor. -1 is not an in-band level, so "no
+// upgrade available" can never be confused with a real level (sentinel, not a
+// clamp; assail PA-AFF-001 stays clean).
+pub fn next_level(lvl: Int) -> Int {
+  if lvl < 0 { return -1; }   // out of band: not a defined level
+  if lvl >= 3 { return -1; }  // Overclocked or above: no next level
+  lvl + 1
+}
+
+//## audio_sound_count -- distinct synthesised-sound count for a level.
+// The integer core of MoletaireCoprocessors.audioSoundCount (res:222-238): the
+// AudioSynthesiser augment yields 0 sounds at Stock, 3 at Basic, 6 at Enhanced,
+// 10 at Overclocked. An undefined level is not an installed augment and fails safe
+// to the Stock effect (0 sounds).
+pub fn audio_sound_count(lvl: Int) -> Int {
+  if lvl == 1 { return 3; }
+  if lvl == 2 { return 6; }
+  if lvl == 3 { return 10; }
+  0   // Stock or undefined: no synthesised sounds
+}
+
+//## sensor_range -- detection range ahead underground, in grid cells, for a level.
+// The integer core of MoletaireCoprocessors.sensorRange (res:275-291): the
+// SignalProcessor augment detects 1 cell at Stock (only the adjacent cell), 3 at
+// Basic, 5 at Enhanced, 8 at Overclocked. An undefined level fails safe to the
+// Stock effect (range 1) -- never 0, since even with no augment the mole sees the
+// adjacent cell.
+pub fn sensor_range(lvl: Int) -> Int {
+  if lvl == 1 { return 3; }
+  if lvl == 2 { return 5; }
+  if lvl == 3 { return 8; }
+  1   // Stock or undefined: only the directly-adjacent cell
+}
+
+//## can_mimic_voice -- whether voice mimicry (ventriloquism) is available.
+// The integer core of MoletaireCoprocessors.canMimicVoice (res:240-251): the
+// AudioSynthesiser unlocks voice mimicry ONLY at Overclocked (res:249,
+// `level == Overclocked`). Returns 1 iff the level is exactly Overclocked(3), else
+// 0. Any other (incl. out-of-band) ordinal is not Overclocked and returns 0.
+pub fn can_mimic_voice(lvl: Int) -> Int {
+  if lvl == 3 { 1 } else { 0 }
+}
+
+//## can_detect_vault_weak_points -- whether vault-wall weak points are detectable.
+// The integer core of MoletaireCoprocessors.canDetectVaultWeakPoints (res:295-305):
+// the SignalProcessor reveals vault weak points (needed for the plasma cutter)
+// ONLY at Overclocked (res:303, `level == Overclocked`). Returns 1 iff the level is
+// exactly Overclocked(3), else 0.
+pub fn can_detect_vault_weak_points(lvl: Int) -> Int {
+  if lvl == 3 { 1 } else { 0 }
+}
+
+//## can_carry_fragile -- whether fragile items can be carried without breaking.
+// The integer core of MoletaireCoprocessors.canCarryFragile (res:370-371): the
+// StabilisationCore lets the mole carry fragile items at Enhanced OR ABOVE
+// (res:371, `level >= Enhanced`). This is the one inequality gate (not an equality
+// gate), so it returns 1 for Enhanced(2) and Overclocked(3), and 0 for Stock(0)
+// and Basic(1). An out-of-band negative ordinal is below Enhanced and returns 0.
+pub fn can_carry_fragile(lvl: Int) -> Int {
+  if lvl >= 2 { 1 } else { 0 }
+}
+
+//## vibration_quality -- the above-ground-movement reading band for a level.
+// The integer core of MoletaireCoprocessors.vibrationQuality + vibrationOfBand
+// (res:319-346): the VibrationAnalyser's reading quality is NoData at Stock,
+// DirectionOnly at Basic, DirectionAndIntent at Enhanced, FullProfile at
+// Overclocked -- i.e. the reading band IS the level band (res:339-344 maps each
+// level onto the same-index variant, and vibrationOfBand res:320-326 maps it
+// back). So over the defined band this is the identity; an out-of-band ordinal is
+// not a defined level and fails safe to the NoData band (0), mirroring
+// vibrationOfBand's `| _ => FullProfile` only ever being reached for in-band 3.
+pub fn vibration_quality(lvl: Int) -> Int {
+  if lvl < 0 { return 0; }   // out of band: no reading
+  if lvl > 3 { return 0; }   // out of band: no reading
+  lvl                        // NoData=0 / DirectionOnly=1 / DirectionAndIntent=2 / FullProfile=3
+}

--- a/proposals/idaptik/migrated/MoletaireCoprocessors/moletairecoprocessors.config.mjs
+++ b/proposals/idaptik/migrated/MoletaireCoprocessors/moletairecoprocessors.config.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for MoletaireCoprocessors.affine (idaptik companion
+// coprocessor-effect kernel; scalar i32 ABI). Each oracle re-derives the rule
+// straight from the ReScript source / the host binding contract in plain JS,
+// INDEPENDENTLY of the .affine, so a codegen regression surfaces as a differential
+// mismatch.
+//
+// Oracle re-derivation (rule <- source site), independent of the .affine:
+//   level_value(l)               = clamp(l, 0, 3)                  (levelValue, res:41-47)
+//   level_colour(l)              = palette[clamp(l,0,3)]           (levelColor, res:59-65)
+//   next_level(l)                = (0<=l<=2) ? l+1 : -1            (upgrade, res:171-186)
+//   audio_sound_count(l)         = {1:3,2:6,3:10}[l] ?? 0          (audioSoundCount, res:222-238)
+//   sensor_range(l)              = {1:3,2:5,3:8}[l] ?? 1           (sensorRange, res:275-291)
+//   can_mimic_voice(l)           = l === 3 ? 1 : 0                 (canMimicVoice, res:240-251)
+//   can_detect_vault_weak_points = l === 3 ? 1 : 0                 (canDetectVaultWeakPoints, res:295-305)
+//   can_carry_fragile(l)         = l >= 2 ? 1 : 0                  (canCarryFragile, res:370-371)
+//   vibration_quality(l)         = (0<=l<=3) ? l : 0              (vibrationQuality+vibrationOfBand, res:319-346)
+
+// Level magnitude: clamp onto the closed 0..3 band (Stock..Overclocked).
+const levelValue = (l) => (l < 0 ? 0 : l > 3 ? 3 : l);
+// Badge palette, keyed by the canonicalised level (res:59-65 hex, decimal here).
+const PALETTE = [0x555555, 0x44aa44, 0x4488ff, 0xff8844];
+const levelColour = (l) => PALETTE[levelValue(l)];
+// Upgrade step: advance on the 0..2 band, out-of-band sentinel -1 at/above Overclocked.
+const nextLevel = (l) => (l >= 0 && l <= 2 ? l + 1 : -1);
+// AudioSynthesiser sound count; fails safe to Stock (0) off-band.
+const audioSoundCount = (l) => (l === 1 ? 3 : l === 2 ? 6 : l === 3 ? 10 : 0);
+// SignalProcessor sensor range; fails safe to Stock (1) off-band.
+const sensorRange = (l) => (l === 1 ? 3 : l === 2 ? 5 : l === 3 ? 8 : 1);
+// Voice mimicry: Overclocked-only equality gate.
+const canMimicVoice = (l) => (l === 3 ? 1 : 0);
+// Vault weak-point detection: Overclocked-only equality gate.
+const canDetectVaultWeakPoints = (l) => (l === 3 ? 1 : 0);
+// Fragile-carry: the one inequality gate -- Enhanced(2) or above.
+const canCarryFragile = (l) => (l >= 2 ? 1 : 0);
+// Vibration reading band == level band over 0..3; off-band -> NoData (0).
+const vibrationQuality = (l) => (l >= 0 && l <= 3 ? l : 0);
+
+// Sweep [-2..6] so both out-of-band guards (negative and above-Overclocked) and
+// all four in-band levels (Stock/Basic/Enhanced/Overclocked) fire on every export.
+const LEVEL = [-2, 6];
+
+export default {
+  affine: "MoletaireCoprocessors.affine",
+  cases: [
+    { name: "level_count()", export: "level_count", args: [], oracle: () => 4 },
+    { name: "level_value over [-2..6]", export: "level_value", args: [LEVEL], oracle: levelValue },
+    { name: "level_colour over [-2..6]", export: "level_colour", args: [LEVEL], oracle: levelColour },
+    { name: "next_level over [-2..6]", export: "next_level", args: [LEVEL], oracle: nextLevel },
+    { name: "audio_sound_count over [-2..6]", export: "audio_sound_count", args: [LEVEL], oracle: audioSoundCount },
+    { name: "sensor_range over [-2..6]", export: "sensor_range", args: [LEVEL], oracle: sensorRange },
+    { name: "can_mimic_voice over [-2..6]", export: "can_mimic_voice", args: [LEVEL], oracle: canMimicVoice },
+    { name: "can_detect_vault_weak_points over [-2..6]", export: "can_detect_vault_weak_points", args: [LEVEL], oracle: canDetectVaultWeakPoints },
+    { name: "can_carry_fragile over [-2..6]", export: "can_carry_fragile", args: [LEVEL], oracle: canCarryFragile },
+    { name: "vibration_quality over [-2..6]", export: "vibration_quality", args: [LEVEL], oracle: vibrationQuality },
+  ],
+};

--- a/proposals/idaptik/migrated/MoletaireHunger/MoletaireHunger.affine
+++ b/proposals/idaptik/migrated/MoletaireHunger/MoletaireHunger.affine
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// MoletaireHunger -- the hunger-classification co-processor, the pure-integer core
+// extracted from idaptik src/app/companions/MoletaireHunger.res (the gravity-based
+// hunger system for the Moletaire companion). Per the DESIGN-VISION ("AffineScript
+// is the brain, JS/Pixi the senses; only primitives cross the wasm boundary") and
+// the host binding contract (MoletaireHungerCoprocessor.res / its Bridge.js), the
+// kernel never sees the world model: the host keeps the edibleObject array, the
+// hungerConfig records, the gravity float maths and every world position. Hunger
+// crosses the boundary in MILLI-UNITS -- the host passes round(hunger * 1000) as an
+// i32, exactly as the binding header prescribes ("Hunger crosses in milli-units:
+// pass round(hunger *. 1000.0) as an Int, since the f64 boundary truncates",
+// MoletaireHungerCoprocessor.res:9-12). Every export is i32 -> i32 (scalar ABI).
+//
+//## Why this split, not a port of MoletaireHunger.res
+// MoletaireHunger.res entangles (a) the gravity/pull FLOAT maths (calculatePull,
+// calculateTotalPull, calculateHungerRate, res:121-219 -- inverse-square law,
+// hunger multipliers, force capping), (b) the discrete hunger STATE classification
+// (getBehaviour over the threshold bands, res:241-253), (c) the HUD band index
+// (hungerDisplayString, res:256-270, read as its 0..5 band), (d) the indicator
+// colour (hungerColor, res:273-283), and (e) the two objective-risk predicates
+// (willEatObjective res:293-294, objectiveAtRisk res:298-299). Only (b)-(e) are
+// integer decisions over the hunger scalar; (a) is continuous float physics and
+// stays host-side (the binding does not even expose it). This file is the verified
+// core of the five integer kernels the host binding already contracts for
+// (MoletaireHungerCoprocessor.res:45-57: behaviour / displayBand / hungerColour /
+// willEatObjective / objectiveAtRisk), over the milli-unit hunger scalar.
+//
+//## Hunger scalar + threshold encoding (the header contract for the JS host)
+// Hunger is a milli-unit i32: 0 = full, 1000 = maximally starving (the host's
+// 0.0..1.0 float * 1000). The .res thresholds become integer milli-unit cuts,
+// preserving the original strict-comparison boundary semantics exactly:
+//   peckish      = 0.4 -> 400      (res:92  -- also the hungry cut, res:95)
+//   starving     = 0.8 -> 800      (res:99)
+//   objective-eat= 0.9 -> 900      (res:104)
+// plus the display-only cuts 0.1->100 and 0.6->600 (res:257,262).
+//
+//## behaviour-state encoding (declaration order of `hungerBehaviour`, res:226-237)
+//   code  state         getBehaviour branch (res:241-253)
+//     0   Cooperative   hunger <= 400 (full player control)
+//     1   Resisting     400 < hunger <= 800 (periodic input override)
+//     2   Devouring     hunger > 800 AND an edible is nearby (locked on, eats)
+//     3   Wandering     hunger > 800 AND no edible nearby (aimless, needs rescue)
+//
+//## display-band encoding (order of hungerDisplayString's strings, res:256-270)
+//     0 FULL (<100)  1 CONTENT (<400)  2 PECKISH (<600)  3 HUNGRY (<800)
+//     4 STARVING (<900)  5 RAVENOUS (>=900)
+
+//## behaviour -- the discrete hunger behaviour state for a hunger scalar + edible flag.
+// The integer core of MoletaireHunger.getBehaviour (res:241-253). The host passes
+// hunger in milli-units and the nearby-edible flag as 0/1 (any non-zero counts as
+// "present", so a stray host encoding still resolves a definite branch). Above the
+// starving cut (hunger > 800) the mole is Devouring(2) when something is edible
+// nearby else Wandering(3); above the hungry cut (hunger > 400) it is Resisting(1);
+// otherwise Cooperative(0). Note the boundary is STRICT (> 800, > 400) exactly as
+// the .res source, so hunger == 800 is Resisting and hunger == 400 is Cooperative.
+pub fn behaviour(hunger_milli: Int, has_edible: Int) -> Int {
+  if hunger_milli > 800 {
+    if has_edible != 0 { return 2; }   // Devouring -- locked onto a nearby edible
+    return 3;                          // Wandering -- starving, nothing nearby
+  }
+  if hunger_milli > 400 { return 1; }  // Resisting -- periodic input override
+  0                                    // Cooperative -- full player control
+}
+
+//## display_band -- the HUD hunger-band index 0..5 for a hunger scalar.
+// The integer core of MoletaireHunger.hungerDisplayString (res:256-270), read as
+// the index of the band string in declaration order. The cuts are STRICT-less-than
+// on the milli-unit scalar, faithful to the .res `<` chain: FULL below 100, CONTENT
+// below 400, PECKISH below 600, HUNGRY below 800, STARVING below 900, RAVENOUS at
+// or above 900. Total over all i32 inputs (a negative hunger is below 100 -> FULL,
+// the well-fed endpoint; a hunger above 1000 is at-or-above 900 -> RAVENOUS).
+pub fn display_band(hunger_milli: Int) -> Int {
+  if hunger_milli < 100 { return 0; }   // FULL
+  if hunger_milli < 400 { return 1; }   // CONTENT
+  if hunger_milli < 600 { return 2; }   // PECKISH
+  if hunger_milli < 800 { return 3; }   // HUNGRY
+  if hunger_milli < 900 { return 4; }   // STARVING
+  5                                     // RAVENOUS
+}
+
+//## hunger_colour -- the 24-bit RGB hunger-indicator colour for a hunger scalar.
+// The integer core of MoletaireHunger.hungerColor (res:273-283): green when
+// well-fed (below the peckish cut 400), yellow-green when peckish (below 600),
+// orange when hungry (below the starving cut 800), red when starving (at or above
+// 800). The cuts are the same STRICT-less-than milli-unit boundaries as the .res
+// `<` chain. Total over all i32 inputs; each of the four bands maps to a distinct
+// hex so the colour map never collides. Values mirror res:274-282 exactly.
+pub fn hunger_colour(hunger_milli: Int) -> Int {
+  if hunger_milli < 400 { return 4521796; }   // 0x44ff44 -- green (well-fed)
+  if hunger_milli < 600 { return 11206468; }  // 0xaaff44 -- yellow-green (peckish)
+  if hunger_milli < 800 { return 16755268; }  // 0xffaa44 -- orange (hungry)
+  16729156                                    // 0xff4444 -- red (starving)
+}
+
+//## will_eat_objective -- whether the mole eats a mission objective on contact.
+// The integer core of MoletaireHunger.willEatObjective (res:293-294): the mole
+// WILL eat the objective once hunger exceeds the objective-eat cut (0.9 -> 900).
+// STRICT-greater, faithful to the .res `>`, so hunger == 900 does NOT yet eat it.
+// Returns 1 = will eat (mission fail risk), 0 = safe.
+pub fn will_eat_objective(hunger_milli: Int) -> Int {
+  if hunger_milli > 900 { 1 } else { 0 }
+}
+
+//## objective_at_risk -- whether the objective is at risk soon (warning indicator).
+// The integer core of MoletaireHunger.objectiveAtRisk (res:298-299): the objective
+// is flagged at risk once hunger exceeds the starving cut (0.8 -> 800), slightly
+// below the actual eat cut so the warning fires before the mole eats it.
+// STRICT-greater, faithful to the .res `>`. Returns 1 = at risk (flash the icon),
+// 0 = not yet.
+pub fn objective_at_risk(hunger_milli: Int) -> Int {
+  if hunger_milli > 800 { 1 } else { 0 }
+}

--- a/proposals/idaptik/migrated/MoletaireHunger/moletairehunger.config.mjs
+++ b/proposals/idaptik/migrated/MoletaireHunger/moletairehunger.config.mjs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for MoletaireHunger.affine (idaptik companion hunger-
+// classification kernel; scalar i32 ABI; hunger in milli-units). Each oracle
+// re-derives the rule straight from the ReScript source / the host binding
+// contract in plain JS, INDEPENDENTLY of the .affine, so a codegen regression
+// surfaces as a differential mismatch.
+//
+// Oracle re-derivation (rule <- source site), independent of the .affine.
+// Thresholds in milli-units: peckish/hungry 400, starving 800, objective-eat 900;
+// display-only cuts 100 and 600.
+//   behaviour(h,e)        = h>800 ? (e?2:3) : h>400 ? 1 : 0     (getBehaviour, res:241-253)
+//   display_band(h)       = h<100?0 : h<400?1 : h<600?2 : h<800?3 : h<900?4 : 5  (res:256-270)
+//   hunger_colour(h)      = h<400?G : h<600?YG : h<800?O : R      (hungerColor, res:273-283)
+//   will_eat_objective(h) = h>900 ? 1 : 0                         (willEatObjective, res:293-294)
+//   objective_at_risk(h)  = h>800 ? 1 : 0                         (objectiveAtRisk, res:298-299)
+
+// Discrete hunger state; STRICT boundaries faithful to the .res `>` chain.
+const behaviour = (h, e) => (h > 800 ? (e !== 0 ? 2 : 3) : h > 400 ? 1 : 0);
+// HUD band index 0..5; STRICT-less-than cuts faithful to the .res `<` chain.
+const displayBand = (h) =>
+  h < 100 ? 0 : h < 400 ? 1 : h < 600 ? 2 : h < 800 ? 3 : h < 900 ? 4 : 5;
+// Indicator colour (res hex, decimal here); STRICT-less-than cuts.
+const hungerColour = (h) =>
+  h < 400 ? 0x44ff44 : h < 600 ? 0xaaff44 : h < 800 ? 0xffaa44 : 0xff4444;
+// Objective gets eaten above the 900 cut; STRICT-greater.
+const willEatObjective = (h) => (h > 900 ? 1 : 0);
+// Objective flagged at risk above the 800 cut; STRICT-greater.
+const objectiveAtRisk = (h) => (h > 800 ? 1 : 0);
+
+// Sweep hunger over the exact band edges + just-inside/just-outside each cut, plus
+// the full 0..1000 milli-unit range and out-of-band negatives/overflow, so every
+// branch and every boundary (99/100, 399/400, 599/600, 799/800, 899/900) fires.
+const HUNGER = [
+  -50, 0, 99, 100, 101, 399, 400, 401, 599, 600, 601, 799, 800, 801, 899, 900, 901, 1000, 1500,
+];
+// Edible-present flag over {0,1,2}: tests the 0 branch + the "any non-zero" truthiness.
+const EDIBLE = [0, 1, 2];
+
+export default {
+  affine: "MoletaireHunger.affine",
+  cases: [
+    {
+      name: "behaviour over hunger x edible-flag",
+      export: "behaviour",
+      args: [{ values: HUNGER }, { values: EDIBLE }],
+      oracle: behaviour,
+    },
+    { name: "display_band over hunger band edges", export: "display_band", args: [{ values: HUNGER }], oracle: displayBand },
+    { name: "hunger_colour over hunger band edges", export: "hunger_colour", args: [{ values: HUNGER }], oracle: hungerColour },
+    { name: "will_eat_objective over hunger band edges", export: "will_eat_objective", args: [{ values: HUNGER }], oracle: willEatObjective },
+    { name: "objective_at_risk over hunger band edges", export: "objective_at_risk", args: [{ values: HUNGER }], oracle: objectiveAtRisk },
+  ],
+};

--- a/proposals/idaptik/migrated/MultiplayerClient/MultiplayerClient.affine
+++ b/proposals/idaptik/migrated/MultiplayerClient/MultiplayerClient.affine
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// MultiplayerClient -- the multiplayer-session co-processor, the pure-integer core
+// extracted from idaptik src/app/multiplayer/MultiplayerClient.res (the high-level
+// co-op multiplayer client wrapping PhoenixSocket). Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; only primitives cross the wasm
+// boundary") and the host binding contract (MultiplayerClientCoprocessor.res), the
+// model never lives in wasm: the host keeps the PhoenixSocket, the gameChannel, the
+// coopPlayers dict, the chatHistory, every JSON payload, the player-id and
+// session-id strings, and every channel push/parse. The kernel is "the pure
+// connection/session state-machine, player-list counter, role-enum and partner-
+// predicate kernels the ReScript side calls across the boundary in i32 primitives"
+// (MultiplayerClientCoprocessor.res:5-8). Every export is i32 -> i32 (scalar ABI).
+//
+//## Why this split, not a port of MultiplayerClient.res
+// MultiplayerClient.res is overwhelmingly STRING/JSON/socket I/O: the V2 payload
+// builders (makePayload, jsonString, res:84-119), every channel handler that parses
+// player_id / role / device_id / instruction / connection_id out of JSON
+// (setupChannelHandlers, res:201-355), every outbound push (sendPosition /
+// sendVMExecute / sendChat / ..., res:421-584) and the terminal formatters
+// (formatStatus, formatChat, res:606-636). NONE of that crosses. What survives as
+// the integer brain are four stateless decisions the binding contracts for: the
+// connection/session STATE MACHINE (connect/disconnect/joinSession/leaveSession set
+// client.state, res:173-409), the co-op player-LIST COUNTER (the coopPlayers dict
+// grows on player:joined, shrinks on player:left, clears on leaveSession,
+// res:213-412), the ROLE enum decode/clamp (roleFromString, res:77-82), and the
+// PARTNER predicate (getCoopPartner non-empty, res:592-594). The diff harness
+// vm/tests/multiplayerclient_diff.ts proves parity over a 17-step connect/join/
+// move/leave lifecycle against the compiled oracle (binding res:13-15).
+//
+//## multiplayerState encoding (declaration order of `multiplayerState`, res:33-37)
+//   code  state        meaning
+//     0   Offline      not connected to the sync server
+//     1   InLobby      connected, not in a game session
+//     2   InSession    in a game session (host keeps the session-id string)
+//
+//## connection/session event encoding (CONN_EVENT, binding res:30-37)
+//   0 SOCKET_CONNECTED      socket open      -> InLobby   (connect, res:173-176)
+//   1 SOCKET_DISCONNECTED   socket closed    -> Offline   (connect/disconnect, res:177-196)
+//   2 JOIN_SESSION          joined a session -> InSession (joinSession, res:396)
+//   3 LEAVE_SESSION         left a session   -> InLobby   (leaveSession, res:409)
+// Each defined event sets an ABSOLUTE target state (the .res assignments are
+// unconditional). An undefined event is a no-op and returns the state UNCHANGED, so
+// a stray host event can never knock the machine into a fabricated state.
+//
+//## player-list event encoding (PLAYER_EVENT, binding res:40-45)
+//   0 PLAYER_JOINED   a co-op player joined -> count + 1            (res:213)
+//   1 PLAYER_LEFT     a co-op player left   -> max(0, count - 1)    (res:223)
+//   2 SESSION_LEFT    left the session      -> 0 (clear all)        (res:411-412)
+// The count is floored at 0 (binding res:62-63): a PLAYER_LEFT at count 0 stays 0.
+//
+//## playerRole encoding (declaration order of `playerRole`, res:15-17)
+//   0 Q (primary: VM/hack/navigate)   1 Observer (support: cameras/intel)
+
+//## The number of multiplayer-session states (Offline / InLobby / InSession).
+pub fn state_count() -> Int { 3 }
+
+//## conn_transition -- advance the connection/session state machine.
+// The integer core of the four state assignments in MultiplayerClient.res
+// (connect res:173-186, disconnect res:188-197, joinSession res:396, leaveSession
+// res:409). Each defined CONN_EVENT moves the machine to its absolute target
+// regardless of the prior state (faithful to the .res's unconditional `client.state
+// = ...`): SOCKET_CONNECTED -> InLobby(1), SOCKET_DISCONNECTED -> Offline(0),
+// JOIN_SESSION -> InSession(2), LEAVE_SESSION -> InLobby(1). An undefined event is a
+// no-op and returns `state` unchanged (the machine never invents a state from an
+// unrecognised event; the Connecting case of the .res is likewise a no-op,
+// res:181).
+pub fn conn_transition(state: Int, event: Int) -> Int {
+  if event == 0 { return 1; }   // SOCKET_CONNECTED    -> InLobby
+  if event == 1 { return 0; }   // SOCKET_DISCONNECTED -> Offline
+  if event == 2 { return 2; }   // JOIN_SESSION        -> InSession
+  if event == 3 { return 1; }   // LEAVE_SESSION       -> InLobby
+  state                         // undefined event: no-op
+}
+
+//## player_count_after -- the co-op player-list size after a lifecycle event.
+// The integer core of the coopPlayers dict's growth/shrink/clear (binding
+// res:62-63): PLAYER_JOINED grows the list by one (Dict.set on a new pid,
+// res:213), PLAYER_LEFT shrinks it by one FLOORED AT 0 (Dict.delete, res:223 --
+// never negative), SESSION_LEFT clears the whole list to 0 (leaveSession's
+// forEach-delete, res:411-412). The host passes the current size and the event; the
+// kernel returns the new size to store back. An undefined event leaves the size
+// unchanged (no phantom growth). A negative incoming count is treated as the empty
+// list (floored to 0) before applying the event, so the size stays a valid count.
+pub fn player_count_after(count: Int, event: Int) -> Int {
+  let mut c = count;
+  if c < 0 { c = 0; }
+  if event == 0 { return c + 1; }            // PLAYER_JOINED
+  if event == 1 {                            // PLAYER_LEFT (floored at 0)
+    if c <= 0 { return 0; }
+    return c - 1;
+  }
+  if event == 2 { return 0; }                // SESSION_LEFT (clear)
+  c                                          // undefined event: unchanged
+}
+
+//## role_from_string -- decode a playerRole from the "is exactly observer" flag.
+// The integer core of MultiplayerClient.roleFromString (res:77-82): the host
+// resolves whether the role string equals "observer" (the only non-default), and
+// the kernel turns that flag into the role ordinal -- Observer(1) when the flag is
+// set, Q(0) otherwise (res:80, `| _ => Q`). Any non-zero flag counts as observer,
+// mirroring the binding's bool argument (res:65-66). The string compare itself is a
+// host SENSE; only the resolved flag crosses.
+pub fn role_from_string(is_observer: Int) -> Int {
+  if is_observer != 0 { 1 } else { 0 }
+}
+
+//## role_clamp -- canonicalise a role ordinal onto the two-value band.
+// The integer core of the binding's roleClamp (res:68-69): "0 Q, anything else
+// Observer". Q is the single canonical value 0; every other ordinal (including
+// out-of-band) collapses to Observer(1). This mirrors roleFromString's `_ => Q`
+// defaulting in the opposite polarity: there is no third role, so any non-Q input
+// is read as Observer. Total over all i32 inputs; the two roles are distinct (0 vs
+// 1) so no collision.
+pub fn role_clamp(role: Int) -> Int {
+  if role == 0 { 0 } else { 1 }
+}
+
+//## has_partner -- whether at least one co-op partner is present.
+// The integer core of MultiplayerClient.getCoopPartner non-empty (res:592-594) /
+// the binding's hasPartner (res:71-72): the coopPlayers dict holds the OTHER
+// players (self is never inserted), so a partner exists iff the list is non-empty.
+// Returns 1 when count > 0, else 0. A non-positive count is an empty list and
+// returns 0.
+pub fn has_partner(count: Int) -> Int {
+  if count > 0 { 1 } else { 0 }
+}

--- a/proposals/idaptik/migrated/MultiplayerClient/multiplayerclient.config.mjs
+++ b/proposals/idaptik/migrated/MultiplayerClient/multiplayerclient.config.mjs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for MultiplayerClient.affine (idaptik co-op multiplayer-
+// session kernel; scalar i32 ABI). Each oracle re-derives the rule straight from
+// the ReScript source / the host binding contract in plain JS, INDEPENDENTLY of the
+// .affine, so a codegen regression surfaces as a differential mismatch.
+//
+// Oracle re-derivation (rule <- source site), independent of the .affine.
+// multiplayerState {Offline0,InLobby1,InSession2};
+// CONN_EVENT {SOCKET_CONNECTED0,SOCKET_DISCONNECTED1,JOIN_SESSION2,LEAVE_SESSION3};
+// PLAYER_EVENT {PLAYER_JOINED0,PLAYER_LEFT1,SESSION_LEFT2}; role {Q0,Observer1}.
+//   conn_transition(s,e)    = {0:1,1:0,2:2,3:1}[e] ?? s          (state assigns, res:173-409)
+//   player_count_after(c,e) = c0=max(0,c); {0:c0+1,1:max(0,c0-1),2:0}[e] ?? c0  (coopPlayers dict)
+//   role_from_string(f)     = f!==0 ? 1 : 0                      (roleFromString, res:77-82)
+//   role_clamp(r)           = r===0 ? 0 : 1                      (binding roleClamp, res:68-69)
+//   has_partner(c)          = c>0 ? 1 : 0                        (getCoopPartner, res:592-594)
+
+// Connection/session machine: defined events set an absolute target; undefined
+// event is a no-op (returns prior state). Mirrors the .res unconditional assigns.
+const connTransition = (s, e) =>
+  e === 0 ? 1 : e === 1 ? 0 : e === 2 ? 2 : e === 3 ? 1 : s;
+// Player-list counter: join +1, left max(0,-1), session-left clear; floored at 0.
+const playerCountAfter = (c, e) => {
+  const c0 = c < 0 ? 0 : c;
+  if (e === 0) return c0 + 1;
+  if (e === 1) return c0 <= 0 ? 0 : c0 - 1;
+  if (e === 2) return 0;
+  return c0;
+};
+// Role decode from the "is observer" flag; any non-zero is Observer.
+const roleFromString = (f) => (f !== 0 ? 1 : 0);
+// Role clamp: Q is the single 0; anything else is Observer.
+const roleClamp = (r) => (r === 0 ? 0 : 1);
+// Partner present iff the co-op list is non-empty.
+const hasPartner = (c) => (c > 0 ? 1 : 0);
+
+// Sweep states/events/roles over their bands + out-of-band guards; counts incl.
+// 0 (empty list) and the floor edge (a PLAYER_LEFT/has_partner at 0 and negatives).
+const STATE = [-1, 0, 1, 2, 3];
+const CONN_EVENT = [-1, 0, 1, 2, 3, 4];
+const PLAYER_EVENT = [-1, 0, 1, 2, 3];
+const ROLE = [-2, -1, 0, 1, 2, 5];
+const COUNT = [-2, -1, 0, 1, 2, 5, 17];
+
+export default {
+  affine: "MultiplayerClient.affine",
+  cases: [
+    { name: "state_count()", export: "state_count", args: [], oracle: () => 3 },
+    {
+      name: "conn_transition over state x event (incl. out-of-band event)",
+      export: "conn_transition",
+      args: [{ values: STATE }, { values: CONN_EVENT }],
+      oracle: connTransition,
+    },
+    {
+      name: "player_count_after over count x event (incl. floor at 0)",
+      export: "player_count_after",
+      args: [{ values: COUNT }, { values: PLAYER_EVENT }],
+      oracle: playerCountAfter,
+    },
+    { name: "role_from_string over flag {-2..5}", export: "role_from_string", args: [{ values: ROLE }], oracle: roleFromString },
+    { name: "role_clamp over role band + out-of-band", export: "role_clamp", args: [{ values: ROLE }], oracle: roleClamp },
+    { name: "has_partner over count {-2..17}", export: "has_partner", args: [{ values: COUNT }], oracle: hasPartner },
+  ],
+};

--- a/proposals/idaptik/migrated/PeerPort/PeerPort.affine
+++ b/proposals/idaptik/migrated/PeerPort/PeerPort.affine
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// PeerPort -- the peer-port arithmetic co-processor, the pure-integer core
+// extracted from src/app/utils/PeerDetection.res `getCandidatePorts` /
+// `getPeerCandidatePorts`. Per the DESIGN-VISION ("AffineScript is the brain,
+// JS/Pixi the senses; only primitives cross the wasm boundary") the JS host keeps
+// the actual fetch, the /__idaptik_health probe, the AbortController timeout and
+// the navigator/env mode sniff; AffineScript owns only the integer port-candidate
+// arithmetic and the base-port selection.
+//
+// The ReScript original builds a six-element candidate array
+//   [basePort, 10000+basePort, 20000+basePort, ..., 50000+basePort]
+// and picks the peer's base port by mode: a browser instance (8080 family) looks
+// for a Gossamer peer (8008 family) and vice versa. We re-decompose the array
+// constructor as an indexed pure function (slot in, port out) and the mode pick
+// as a boolean-flag selector, so no array and no string cross the boundary.
+//
+//## Candidate slot encoding (the header contract for the JS host)
+//   slot 0 -> basePort + 0       slot 3 -> basePort + 30000
+//   slot 1 -> basePort + 10000   slot 4 -> basePort + 40000
+//   slot 2 -> basePort + 20000   slot 5 -> basePort + 50000
+// There are exactly six candidate slots (PeerDetection's fixed array length).
+
+//## Port-family bases
+//   8080 = browser family base, 8008 = Gossamer family base.
+
+// The number of candidate ports generated per base (PeerDetection's array length).
+pub fn candidate_slot_count() -> Int { 6 }
+
+// Whether a slot index is within the valid 0..5 candidate band.
+pub fn is_valid_slot(slot: Int) -> Int {
+  if slot < 0 { 0 } else { if slot > 5 { 0 } else { 1 } }
+}
+
+// The candidate port for a base port and a slot index: basePort + slot * 10000.
+// Out-of-band slots return the sentinel -1 (PeerDetection only ever indexes 0..5;
+// -1 is below every real port so it can never be mistaken for a candidate). This
+// is a guard sentinel, not a fold onto an in-band port.
+pub fn candidate_port(base_port: Int, slot: Int) -> Int {
+  if is_valid_slot(slot) == 1 { base_port + slot * 10000 } else { -1 }
+}
+
+// The peer's base port given OUR mode. is_gossamer is the host mode flag crossed
+// as 0 (we are the browser instance) or 1 (we are the Gossamer instance). The
+// ReScript picks the OPPOSITE family: a browser instance (we == 0) seeks a
+// Gossamer peer on the 8008 base; a Gossamer instance (we == 1) seeks a browser
+// peer on the 8080 base. Any non-zero flag is treated as Gossamer.
+pub fn peer_base_port(is_gossamer: Int) -> Int {
+  if is_gossamer != 0 { 8080 } else { 8008 }
+}
+
+// Convenience composite: the peer candidate port for OUR mode flag and a slot.
+// Folds peer_base_port into candidate_port so the host can ask for a peer probe
+// target in one call (out-of-band slot still yields the -1 guard sentinel).
+pub fn peer_candidate_port(is_gossamer: Int, slot: Int) -> Int {
+  candidate_port(peer_base_port(is_gossamer), slot)
+}

--- a/proposals/idaptik/migrated/PeerPort/peerport.config.mjs
+++ b/proposals/idaptik/migrated/PeerPort/peerport.config.mjs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for PeerPort.affine (idaptik peer-port arithmetic; scalar
+// i32 ABI). The oracle re-derives the candidate-port arithmetic and the
+// opposite-family base selection from PeerDetection.res INDEPENDENTLY in plain JS,
+// so a codegen regression surfaces as a differential mismatch.
+
+const validSlot = (s) => s >= 0 && s <= 5;
+const candidatePort = (base, slot) => (validSlot(slot) ? base + slot * 10000 : -1);
+// We seek the OPPOSITE family: browser(0)->8008 peer, gossamer(1)->8080 peer.
+const peerBase = (isGossamer) => (isGossamer !== 0 ? 8080 : 8008);
+const peerCandidate = (isGossamer, slot) => candidatePort(peerBase(isGossamer), slot);
+
+export default {
+  affine: "PeerPort.affine",
+  cases: [
+    { name: "candidate_slot_count()", export: "candidate_slot_count", args: [], oracle: () => 6 },
+    {
+      name: "is_valid_slot over [-3..9]",
+      export: "is_valid_slot",
+      args: [[-3, 9]],
+      oracle: (s) => (validSlot(s) ? 1 : 0),
+    },
+    {
+      // Sweep both real port families x slots incl. out-of-band slots.
+      name: "candidate_port over {8080,8008} x [-2..7]",
+      export: "candidate_port",
+      args: [{ values: [8080, 8008] }, [-2, 7]],
+      oracle: (base, slot) => candidatePort(base, slot),
+    },
+    {
+      name: "peer_base_port over [0..3]",
+      export: "peer_base_port",
+      args: [[0, 3]],
+      oracle: (g) => peerBase(g),
+    },
+    {
+      name: "peer_candidate_port over [0..2] x [-2..7]",
+      export: "peer_candidate_port",
+      args: [[0, 2], [-2, 7]],
+      oracle: (g, slot) => peerCandidate(g, slot),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/PlayerSprite/PlayerSprite.affine
+++ b/proposals/idaptik/migrated/PlayerSprite/PlayerSprite.affine
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// PlayerSprite -- the player animation-decision co-processor, the pure-integer
+// core extracted from idaptik src/app/player/PlayerSprite.res (the `spr_*`
+// kernels the PlayerRenderLogicCoprocessorBridge.js already names). Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; they pass
+// primitives across the wasm boundary"), the JS host keeps every AnimatedSprite
+// call, the dict of placeholder frames, the texture array, the hex palette and
+// the float damage-flash timer; AffineScript owns only the discrete frame-count
+// / animation-speed / state-to-animation / facing-flip decisions, which are
+// total functions over small integer bands.
+//
+// RE-DECOMPOSITION (not transliteration): the ReScript original keys four
+// switches on two variants -- `animationId` (8 constructors) and
+// `PlayerState.visualState` (6 constructors). PlayerSprite.res already pins the
+// ordinal encodings it sends across the boundary (animOrdinal / stateOrdinal /
+// animFromOrdinal), so the variants ARE these dense integers and no string
+// crosses. We collapse each switch to a flat sequence of guarded returns (the
+// same shape SkillRank.affine uses) so the wasm backend's parser stays within
+// its nesting tolerance. The one float in the source set -- animSpeed, a frames-
+// per-tick rate in 0.04..0.20 -- is exactly representable in milli-units (x1000,
+// so 40..200), so it stays in the brain as anim_speed_milli; the host divides by
+// 1000. The remaining float kernels in the bridge (gfx_* geometry in pixels,
+// traj_* arc maths, damage alpha/flash over a float timer) are genuinely
+// continuous and stay host-side / belong to the float render-logic and CombatFx
+// co-processors -- they are NOT part of this integer brain.
+//
+//## animationId encoding (the header contract for the JS host)
+//   code  animation        frames  speed(milli)
+//     0   Idle               4         50
+//     1   Walk               8        150
+//     2   Jump               4        100
+//     3   Interact           4        120
+//     4   Crouch             2         40
+//     5   Stunned            4        200
+//     6   ChargingJump       2         80
+//     7   Sprint             8        200
+//
+//## visualState encoding (state_to_anim input)
+//   code  visualState      -> animationId code
+//     0   Idle             -> 0  (Idle)
+//     1   Walking          -> 1  (Walk)
+//     2   Sprinting        -> 7  (Sprint)
+//     3   Crouching        -> 4  (Crouch)
+//     4   Jumping          -> 2  (Jump)
+//     5   ChargingJump     -> 6  (ChargingJump)
+//
+// An animationId outside 0..7 is no animation: frame_count reports 0 and
+// anim_speed_milli returns the out-of-band sentinel -1. A visualState outside
+// 0..5 returns the sentinel -1 from state_to_anim. These sentinels are never an
+// in-band code, so out-of-band input can never collide with a real decision.
+
+//## Frame count for an animation
+// frameCount(anim): the number of placeholder/sheet frames for an animationId
+// ordinal (0..7). Off-domain indices yield 0, a sentinel the JS host can treat
+// as "no such animation".
+pub fn frame_count(anim: Int) -> Int {
+  if anim == 0 { return 4; }
+  if anim == 1 { return 8; }
+  if anim == 2 { return 4; }
+  if anim == 3 { return 4; }
+  if anim == 4 { return 2; }
+  if anim == 5 { return 4; }
+  if anim == 6 { return 2; }
+  if anim == 7 { return 8; }
+  0
+}
+
+//## Animation speed in milli-units (frames per tick x 1000)
+// animSpeed(anim): the per-animation playback rate. The ReScript source carries
+// it as a float in 0.04..0.20; here it is x1000 (40..200), exactly representable
+// as Int, and the host divides by 1000. Off-domain indices yield the out-of-band
+// sentinel -1 (a real speed is always positive, so -1 is unambiguous).
+pub fn anim_speed_milli(anim: Int) -> Int {
+  if anim == 0 { return 50; }
+  if anim == 1 { return 150; }
+  if anim == 2 { return 100; }
+  if anim == 3 { return 120; }
+  if anim == 4 { return 40; }
+  if anim == 5 { return 200; }
+  if anim == 6 { return 80; }
+  if anim == 7 { return 200; }
+  -1
+}
+
+//## Map a visualState ordinal to its animationId ordinal
+// stateToAnim(state): the gameplay-state -> animation decision. visualState
+// 0..5 maps onto the animationId band per the header table; off-domain states
+// yield the out-of-band sentinel -1 (the host's animFromOrdinal default of Idle
+// covers the fallthrough, but the brain reports the miss honestly).
+pub fn state_to_anim(state: Int) -> Int {
+  if state == 0 { return 0; }
+  if state == 1 { return 1; }
+  if state == 2 { return 7; }
+  if state == 3 { return 4; }
+  if state == 4 { return 2; }
+  if state == 5 { return 6; }
+  -1
+}
+
+//## Horizontal flip scale in milli-units (x1000)
+// facingScaleX(isLeft): the sprite mirror decision. The ReScript call passes 0
+// for left-facing and 1 otherwise; left flips to -1.0, else +1.0. Here that is
+// x1000: input 0 -> -1000, any other input -> 1000. The host divides by 1000 to
+// recover the +/-1.0 scale.
+pub fn facing_scale_milli(is_left: Int) -> Int {
+  if is_left == 0 { return -1000; }
+  1000
+}
+
+//## Whether an animationId names a defined animation
+// 1 = valid (0..7), 0 = out of band. A convenience guard for the host.
+pub fn is_valid_anim(anim: Int) -> Int {
+  if anim < 0 { return 0; }
+  if anim > 7 { return 0; }
+  1
+}

--- a/proposals/idaptik/migrated/PlayerSprite/playersprite.config.mjs
+++ b/proposals/idaptik/migrated/PlayerSprite/playersprite.config.mjs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for PlayerSprite.affine (idaptik player animation
+// decisions; scalar i32 ABI). The oracle re-derives each kernel independently
+// from the original PlayerSprite.res semantics (frameCount / animSpeed /
+// stateToAnim switches and the facingScaleX call convention) so a codegen
+// regression surfaces as a differential mismatch.
+//
+// Source semantics (PlayerSprite.res):
+//   animationId ordinals (animOrdinal): Idle=0 Walk=1 Jump=2 Interact=3
+//     Crouch=4 Stunned=5 ChargingJump=6 Sprint=7
+//   frameCount:  Idle=4 Walk=8 Jump=4 Interact=4 Crouch=2 Stunned=4
+//                ChargingJump=2 Sprint=8 ; off-domain -> 0
+//   animSpeed:   Idle=.05 Walk=.15 Jump=.10 Interact=.12 Crouch=.04
+//                Stunned=.20 ChargingJump=.08 Sprint=.20 (x1000 -> milli);
+//                off-domain -> -1
+//   stateToAnim (visualState ord -> animationId ord):
+//                Idle(0)->Idle(0)  Walking(1)->Walk(1)  Sprinting(2)->Sprint(7)
+//                Crouching(3)->Crouch(4)  Jumping(4)->Jump(2)
+//                ChargingJump(5)->ChargingJump(6) ; off-domain -> -1
+//   facingScaleX: call passes 0 (left)-> -1.0, else 1.0 (x1000 -> milli)
+
+// Independent re-derivation of frameCount over animationId ordinals.
+const frameCount = (a) => {
+  switch (a) {
+    case 0: return 4; // Idle
+    case 1: return 8; // Walk
+    case 2: return 4; // Jump
+    case 3: return 4; // Interact
+    case 4: return 2; // Crouch
+    case 5: return 4; // Stunned
+    case 6: return 2; // ChargingJump
+    case 7: return 8; // Sprint
+    default: return 0;
+  }
+};
+
+// Independent re-derivation of animSpeed (as milli-units, x1000).
+const animSpeedMilli = (a) => {
+  const speeds = { 0: 50, 1: 150, 2: 100, 3: 120, 4: 40, 5: 200, 6: 80, 7: 200 };
+  return Object.prototype.hasOwnProperty.call(speeds, a) ? speeds[a] : -1;
+};
+
+// Independent re-derivation of stateToAnim (visualState ord -> animationId ord).
+const stateToAnim = (s) => {
+  const map = { 0: 0, 1: 1, 2: 7, 3: 4, 4: 2, 5: 6 };
+  return Object.prototype.hasOwnProperty.call(map, s) ? map[s] : -1;
+};
+
+// Independent re-derivation of facingScaleX (milli-units): 0 -> -1000 else 1000.
+const facingScaleMilli = (isLeft) => (isLeft === 0 ? -1000 : 1000);
+
+// Independent re-derivation of the validity guard for animationId.
+const isValidAnim = (a) => (a >= 0 && a <= 7 ? 1 : 0);
+
+export default {
+  affine: "PlayerSprite.affine",
+  cases: [
+    {
+      name: "frame_count over [-3..11]",
+      export: "frame_count",
+      args: [[-3, 11]],
+      oracle: (a) => frameCount(a),
+    },
+    {
+      name: "anim_speed_milli over [-3..11]",
+      export: "anim_speed_milli",
+      args: [[-3, 11]],
+      oracle: (a) => animSpeedMilli(a),
+    },
+    {
+      name: "state_to_anim over [-3..9]",
+      export: "state_to_anim",
+      args: [[-3, 9]],
+      oracle: (s) => stateToAnim(s),
+    },
+    {
+      name: "facing_scale_milli over [-2..3]",
+      export: "facing_scale_milli",
+      args: [[-2, 3]],
+      oracle: (isLeft) => facingScaleMilli(isLeft),
+    },
+    {
+      name: "is_valid_anim over [-3..11]",
+      export: "is_valid_anim",
+      args: [[-3, 11]],
+      oracle: (a) => isValidAnim(a),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/ResourceAccounting/ResourceAccounting.affine
+++ b/proposals/idaptik/migrated/ResourceAccounting/ResourceAccounting.affine
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// ResourceAccounting -- the per-device resource-accounting core, the pure-integer
+// brain extracted from idaptik src/shared/ResourceAccounting.res. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; they pass
+// primitives across the wasm boundary"), the JS host keeps the per-device
+// `deviceResourceState` record, the `dict<deviceResourceState>` registry, the
+// device-id STRINGS, the FeaturePacks/wasm-handle routing and the lazy creation.
+// AffineScript owns only the integer transition kernels: the cumulative
+// compute/energy folds, the memory PEAK, the active-call decrement, the floored
+// utilisation percentage, the saturation predicate, and the quota-fit gate.
+//
+// SHAPE-A (per ResourceAccountingCoprocessor.res): the MODEL never lives in wasm.
+// The host keeps the account and threads each field through a kernel, storing the
+// returned scalar back. ENERGY crosses as integer milli-Joules (1 J = 1000 mJ):
+// the .res holds energy as a float Joule total, but the kernel boundary is i32, so
+// the host scales J -> mJ before calling and the brain folds the integer. This is
+// the migration rule "floats -> x1000 when integer-expressible".
+//
+// This file IS the contract the existing host bridge
+// (ResourceAccountingCoprocessorBridge.js) links against: it expects the exports
+// record_compute / record_memory_peak / record_energy / end_call / pct /
+// has_capacity, exactly what ResourceAccountingCoprocessor.res names. We add
+// check_quota (the integer form of checkQuota), whose three sub-predicates the
+// .res spells out (computeOk && memOk && energyOk) -- the fit gate the kernel
+// applies before dispatch.
+//
+// Re-decomposition notes (NOT a transliteration):
+//   * Compute and energy are CUMULATIVE (running total += op); memory is PEAK
+//     (keep the larger). The .res getUsagePercentage / hasCapacity use a 95%
+//     hard cutoff (>= 95% saturated); pct floors to an integer percent.
+//   * No module state: each kernel is a pure function of explicit Int params.
+//   * The float pctInt/pctFloat helpers in the .res are unified here as one
+//     integer pct (used*100/avail, floored), with avail<=0 -> 0 guarding the
+//     NaN/infinity the .res guarded with `if avail <= 0`.
+
+// |n| without a library call.
+fn iabs(n: Int) -> Int {
+  if n < 0 { 0 - n } else { n }
+}
+
+// recordCompute -- fold one operation's compute units into the running total
+// (cumulative). The host stores the returned scalar back into used.maxCompute.
+pub fn record_compute(running_total: Int, units: Int) -> Int {
+  running_total + units
+}
+
+// recordMemoryPeak -- keep the largest single-operation memory allocation (PEAK
+// semantics; the game models memory as "maximum live allocation"). Mirrors the
+// .res `if bytes > peak then bytes else peak`.
+pub fn record_memory_peak(current_peak: Int, bytes: Int) -> Int {
+  if bytes > current_peak { bytes } else { current_peak }
+}
+
+// recordEnergy -- fold one operation's energy drain (milli-Joules) into the total
+// (cumulative). Integer mJ; the host has scaled Joules -> mJ before the call.
+pub fn record_energy(running_total_mj: Int, op_mj: Int) -> Int {
+  running_total_mj + op_mj
+}
+
+// endCall -- decrement the concurrent-operation count on completion, floored at
+// zero (the .res decrement is always-positive, but the brain floors so an
+// out-of-order decrement can never go negative). DECLARED floor at 0.
+pub fn end_call(active: Int) -> Int {
+  if active <= 0 { 0 } else { active - 1 }
+}
+
+// pct -- floored integer utilisation percentage (used*100/avail). When capacity
+// is non-positive returns 0 (guarding the NaN/infinity the .res guarded with
+// `if avail <= 0 { 0.0 }`), matching the floor of getUsagePercentage's value.
+pub fn pct(used: Int, avail: Int) -> Int {
+  if avail <= 0 { 0 } else { iabs(used) * 100 / avail }
+}
+
+// hasCapacity -- saturation predicate over two already-computed percentages:
+// 1 iff BOTH sit below 95, else 0. Mirrors the .res `computeRatio < 0.95 &&
+// energyRatio < 0.95` 95%-cutoff (here in integer percent, so < 95).
+pub fn has_capacity(pct_a: Int, pct_b: Int) -> Int {
+  if pct_a < 95 { if pct_b < 95 { 1 } else { 0 } } else { 0 }
+}
+
+// check_quota -- the integer form of checkQuota: 1 iff the operation FITS the
+// device quota on all three dimensions, else 0. Compute and energy are checked
+// cumulatively (used + op <= limit); memory is checked against the limit alone
+// (peak semantics: the new op's allocation must fit regardless of current peak),
+// exactly as the .res `computeOk && memOk && energyOk`. Energy is in mJ on both
+// the used and the limit side.
+pub fn check_quota(
+  used_compute: Int,
+  op_compute: Int,
+  limit_compute: Int,
+  op_memory: Int,
+  limit_memory: Int,
+  used_energy_mj: Int,
+  op_energy_mj: Int,
+  limit_energy_mj: Int,
+) -> Int {
+  let compute_ok = used_compute + op_compute <= limit_compute;
+  let mem_ok = op_memory <= limit_memory;
+  let energy_ok = used_energy_mj + op_energy_mj <= limit_energy_mj;
+  if compute_ok {
+    if mem_ok {
+      if energy_ok { 1 } else { 0 }
+    } else { 0 }
+  } else { 0 }
+}

--- a/proposals/idaptik/migrated/ResourceAccounting/resourceaccounting.config.mjs
+++ b/proposals/idaptik/migrated/ResourceAccounting/resourceaccounting.config.mjs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for ResourceAccounting.affine (idaptik per-device
+// resource-accounting core; scalar i32 ABI). Every oracle is an INDEPENDENT JS
+// reimplementation derived from src/shared/ResourceAccounting.res semantics (the
+// cumulative folds, the memory PEAK, the 95% saturation cutoff, the checkQuota
+// three-way fit) -- NOT a copy of the .affine logic -- so the differential sweep
+// is a genuine cross-check. Energy is integer milli-Joules (the host's J->mJ
+// scaling) on both sides.
+
+const iabs = (n) => (n < 0 ? -n : n);
+
+const oRecordCompute = (t, u) => t + u;
+const oRecordMemoryPeak = (peak, bytes) => (bytes > peak ? bytes : peak);
+const oRecordEnergy = (t, m) => t + m;
+const oEndCall = (a) => (a <= 0 ? 0 : a - 1);
+const oPct = (used, avail) => (avail <= 0 ? 0 : Math.trunc((iabs(used) * 100) / avail));
+const oHasCapacity = (a, b) => (a < 95 && b < 95 ? 1 : 0);
+const oCheckQuota = (uc, oc, lc, om, lm, ue, oe, le) => {
+  const computeOk = uc + oc <= lc;
+  const memOk = om <= lm;
+  const energyOk = ue + oe <= le;
+  return computeOk && memOk && energyOk ? 1 : 0;
+};
+
+export default {
+  affine: "ResourceAccounting.affine",
+  cases: [
+    {
+      name: "record_compute over total in {0,500,9999}, units in [0..40]",
+      export: "record_compute",
+      args: [{ values: [0, 500, 9999] }, [0, 40]],
+      oracle: oRecordCompute,
+    },
+    {
+      name: "record_memory_peak over peak in {0,1024,65536}, bytes in {0,512,1024,2048,131072}",
+      export: "record_memory_peak",
+      args: [{ values: [0, 1024, 65536] }, { values: [0, 512, 1024, 2048, 131072] }],
+      oracle: oRecordMemoryPeak,
+    },
+    {
+      name: "record_energy over total in {0,1000,50000}, op in [0..30]",
+      export: "record_energy",
+      args: [{ values: [0, 1000, 50000] }, [0, 30]],
+      oracle: oRecordEnergy,
+    },
+    {
+      name: "end_call over [-2..2000]",
+      export: "end_call",
+      args: [[-2, 2000]],
+      oracle: oEndCall,
+    },
+    {
+      name: "pct over used in {0,47,95,100,9500,10001}, avail in {0,-5,100,10000}",
+      export: "pct",
+      args: [{ values: [0, 47, 95, 100, 9500, 10001] }, { values: [0, -5, 100, 10000] }],
+      oracle: oPct,
+    },
+    {
+      name: "has_capacity over a,b in {0,50,94,95,96,100}^2",
+      export: "has_capacity",
+      args: [{ values: [0, 50, 94, 95, 96, 100] }, { values: [0, 50, 94, 95, 96, 100] }],
+      oracle: oHasCapacity,
+    },
+    {
+      name: "check_quota over a representative fit/overflow grid",
+      export: "check_quota",
+      args: [
+        { values: [0, 5000, 9999] }, // used_compute
+        { values: [1, 100, 5000] }, // op_compute
+        { values: [10000] }, // limit_compute
+        { values: [512, 1048576, 2000000] }, // op_memory
+        { values: [1048576] }, // limit_memory
+        { values: [0, 50000, 99999] }, // used_energy_mj
+        { values: [1, 1000, 60000] }, // op_energy_mj
+        { values: [100000] }, // limit_energy_mj
+      ],
+      oracle: oCheckQuota,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/ThreatClass/ThreatClass.affine
+++ b/proposals/idaptik/migrated/ThreatClass/ThreatClass.affine
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// ThreatClass -- the detection-source threat classifier, the pure-integer brain
+// extracted from src/app/enemies/DualAlertBridge.res (classifyThreat). The
+// ReScript bridge is otherwise a pure routing shim over mutable JS services
+// (reportDetection, triggerPhysical/triggerCyber); the existing DualAlert.affine
+// header rightly noted the trigger-CONVERSION half (sourceToPhysicalTrigger /
+// sourceToCyberTrigger -> option<...> feeding service calls) stays host-side. But
+// the classifyThreat map itself is a total, string-free 13 -> 3 enum function:
+// it reads the detection source's variant ORDINAL and returns the threat-type
+// ordinal, with no string and no service handle ever crossing. That is a genuine,
+// previously-overlooked integer brain, separable from both the DualAlert level
+// machine and the host routing.
+//
+// Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), the host keeps the detectionSource
+// constructors and their string payloads (the device / IP ids) and every service
+// mutation; AffineScript owns only "is this source a physical, cyber, or both
+// threat?" -- which the host then uses to decide which trigger(s) to fire.
+//
+//## Detection-source ordinal encoding (from DetectionSystem.res variant order)
+//   code  source            code  source            code  source
+//     0   GuardSight          5   CanaryTripped       10   DistractionExpired
+//     1   GuardHearing        6   PortScanDetected    11   ContactDamage
+//     2   DogDetection        7   CrackFailed         12   ManualAlert
+//     3   DogHearing          8   FirewallBlock
+//     4   CameraMotion        9   CovertLinkProbe
+// The 13 valid codes are 0..12; the encoding is lossless. Out-of-band input
+// clamps to the nearest valid ordinal (0 or 12) before classification, so an
+// unknown source resolves as GuardSight's physical class rather than crashing.
+//
+//## Threat-type band (the result contract for the JS host)
+//   0  PhysicalThreat   -- a body in the building (guards, dogs, distraction, contact)
+//   1  CyberThreat      -- a network intrusion (canary, port scan, crack, firewall, link)
+//   2  BothThreats      -- physical presence detected via cyber means (camera, manual)
+
+enum Source {
+  GuardSight, GuardHearing, DogDetection, DogHearing, CameraMotion,
+  CanaryTripped, PortScanDetected, CrackFailed, FirewallBlock, CovertLinkProbe,
+  DistractionExpired, ContactDamage, ManualAlert, InvalidSource(Int)
+}
+
+fn source_of(code: Int) -> Source {
+  if code == 0 { return GuardSight; }
+  if code == 1 { return GuardHearing; }
+  if code == 2 { return DogDetection; }
+  if code == 3 { return DogHearing; }
+  if code == 4 { return CameraMotion; }
+  if code == 5 { return CanaryTripped; }
+  if code == 6 { return PortScanDetected; }
+  if code == 7 { return CrackFailed; }
+  if code == 8 { return FirewallBlock; }
+  if code == 9 { return CovertLinkProbe; }
+  if code == 10 { return DistractionExpired; }
+  if code == 11 { return ContactDamage; }
+  if code == 12 { return ManualAlert; }
+  InvalidSource(code)
+}
+
+// @clamp:declared -- out-of-band source clamps to nearest valid ordinal (0 or 12).
+// Controlled-loss by design: the 13 valid codes 0..12 are injective; only the
+// out-of-band InvalidSource(v) is squashed, never an in-band code.
+fn clamp_source_ordinal(v: Int) -> Int {
+  if v < 0 { return 0; }
+  12
+}
+
+fn source_ordinal_of(s: Source) -> Int {
+  match s {
+    GuardSight => 0,
+    GuardHearing => 1,
+    DogDetection => 2,
+    DogHearing => 3,
+    CameraMotion => 4,
+    CanaryTripped => 5,
+    PortScanDetected => 6,
+    CrackFailed => 7,
+    FirewallBlock => 8,
+    CovertLinkProbe => 9,
+    DistractionExpired => 10,
+    ContactDamage => 11,
+    ManualAlert => 12,
+    InvalidSource(v) => clamp_source_ordinal(v)
+  }
+}
+
+//## Number of canonical detection sources.
+pub fn source_count() -> Int { 13 }
+
+//## Source ordinal (canonicalise a host integer to a valid source code).
+pub fn source_value(code: Int) -> Int {
+  source_ordinal_of(source_of(code))
+}
+
+//## Threat classification (classifyThreat).
+// Returns the threat-type band: 0 Physical, 1 Cyber, 2 Both. Mirrors the
+// DualAlertBridge.res switch exactly:
+//   guard/dog (sight+hearing), distraction-expired, contact -> Physical
+//   canary, port-scan, crack-failed, firewall, covert-link  -> Cyber
+//   camera-motion, manual-alert                              -> Both
+pub fn classify_threat(source: Int) -> Int {
+  let s = source_ordinal_of(source_of(source));
+  if s == 4 { return 2; }
+  if s == 12 { return 2; }
+  if s == 5 { return 1; }
+  if s == 6 { return 1; }
+  if s == 7 { return 1; }
+  if s == 8 { return 1; }
+  if s == 9 { return 1; }
+  0
+}
+
+//## Does this source raise a physical alert? (1 = yes)
+// Physical iff the threat class is Physical(0) or Both(2). Lets the host gate the
+// triggerPhysical call without re-deriving the class.
+pub fn raises_physical(source: Int) -> Int {
+  let t = classify_threat(source);
+  if t == 1 { return 0; }
+  1
+}
+
+//## Does this source raise a cyber alert? (1 = yes)
+// Cyber iff the threat class is Cyber(1) or Both(2).
+pub fn raises_cyber(source: Int) -> Int {
+  let t = classify_threat(source);
+  if t == 0 { return 0; }
+  1
+}

--- a/proposals/idaptik/migrated/ThreatClass/threatclass.config.mjs
+++ b/proposals/idaptik/migrated/ThreatClass/threatclass.config.mjs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for ThreatClass.affine (idaptik detection-source threat
+// classifier; scalar i32 ABI). The oracle re-derives the classifyThreat map from
+// DualAlertBridge.res semantics in plain JS, keyed by the DetectionSystem.res
+// variant ordinal, so a codegen regression surfaces as a differential mismatch.
+//
+// Source ordinals (DetectionSystem.res variant order):
+//   0 GuardSight 1 GuardHearing 2 DogDetection 3 DogHearing 4 CameraMotion
+//   5 CanaryTripped 6 PortScanDetected 7 CrackFailed 8 FirewallBlock
+//   9 CovertLinkProbe 10 DistractionExpired 11 ContactDamage 12 ManualAlert
+// Out-of-band clamps to 0 (negative) or 12 (>12).
+//
+// Threat band: 0 Physical, 1 Cyber, 2 Both.
+
+const clampSource = (s) => (s < 0 ? 0 : s > 12 ? 12 : s);
+
+// Independent re-implementation of DualAlertBridge.res classifyThreat, by source.
+// Physical sources: guards (sight 0, hearing 1), dogs (detection 2, hearing 3),
+//                   distraction-expired 10, contact-damage 11.
+// Cyber sources:    canary 5, port-scan 6, crack-failed 7, firewall 8, link 9.
+// Both sources:     camera-motion 4, manual-alert 12.
+const PHYSICAL = new Set([0, 1, 2, 3, 10, 11]);
+const CYBER = new Set([5, 6, 7, 8, 9]);
+const BOTH = new Set([4, 12]);
+
+const classifyThreat = (source) => {
+  const s = clampSource(source);
+  if (BOTH.has(s)) return 2;
+  if (CYBER.has(s)) return 1;
+  if (PHYSICAL.has(s)) return 0;
+  return 0; // unreachable for 0..12, but defensive
+};
+
+// Physical alert iff Physical(0) or Both(2).
+const raisesPhysical = (source) => (classifyThreat(source) === 1 ? 0 : 1);
+// Cyber alert iff Cyber(1) or Both(2).
+const raisesCyber = (source) => (classifyThreat(source) === 0 ? 0 : 1);
+
+export default {
+  affine: "ThreatClass.affine",
+  cases: [
+    { name: "source_count()", export: "source_count", args: [], oracle: () => 13 },
+    {
+      name: "source_value over [-3..15]",
+      export: "source_value",
+      args: [[-3, 15]],
+      oracle: clampSource,
+    },
+    {
+      name: "classify_threat over sources [-3..15]",
+      export: "classify_threat",
+      args: [[-3, 15]],
+      oracle: classifyThreat,
+    },
+    {
+      name: "raises_physical over sources [-3..15]",
+      export: "raises_physical",
+      args: [[-3, 15]],
+      oracle: raisesPhysical,
+    },
+    {
+      name: "raises_cyber over sources [-3..15]",
+      export: "raises_cyber",
+      args: [[-3, 15]],
+      oracle: raisesCyber,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/UmsLevelLoader/UmsLevelLoader.affine
+++ b/proposals/idaptik/migrated/UmsLevelLoader/UmsLevelLoader.affine
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// UmsLevelLoader -- the UMS level-decode validation core, the pure-integer brain
+// extracted from idaptik src/shared/UmsLevelLoader.res. Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; they pass primitives across
+// the wasm boundary"), the JS host keeps the JSON, every Dict lookup, all the
+// item/subtype/condition STRINGS, the record assembly, and the FeaturePacks/wasm-
+// handle routing. AffineScript owns only the integer/enum validation decisions
+// the decoder makes once the strings are classified to ordinals: the item-kind
+// band predicate, the (kind, subtype) arm membership, the nullary/capacity
+// discriminants, the condition normalisation + its validity predicate, the
+// covert-link floor, and the patrol-radius default (in milli-units).
+//
+// This file IS the contract the existing host bridge
+// (UmsLevelLoaderCoprocessorBridge.js) links against: it expects is_valid_kind /
+// subtype_in_band / is_nullary_kind / requires_capacity / normalise_condition /
+// is_valid_condition / floor_covert_links / resolve_patrol_radius_milli, mirroring
+// UmsLevelLoaderCoprocessor.res. The float-INPUT helpers toIntTrunc(float) and
+// cableLengthPresent(float) are pure float truncation / a `== 0.0` test, NOT
+// integer-expressible as an i32->i32 kernel; per the migration rule they stay
+// host-side (Float.toInt and the `len == 0.0 ? absent` check), so they are
+// intentionally NOT exported here.
+//
+// Re-decomposition notes (NOT a transliteration):
+//   * UmsLevelLoader.res decodes string-keyed JSON arms (Some("Cable") => ...).
+//     The string classification IS senses-work; the BRAIN is the ordinal-shaped
+//     membership the arms encode. The host maps "Cable"/"Ethernet"/"Good" to the
+//     Inventory.itemKind / itemCondition declaration-order ordinals before calling.
+//   * No module state: every kernel is a pure function of explicit Int params.
+//   * patrolRadius is a float (.res default 200.0); it crosses as integer milli-
+//     units (200.0 -> 200000) per the "floats -> x1000 when integer-expressible"
+//     rule, so resolve_patrol_radius_milli is the integer form of resolvePatrolRadius.
+//
+//## itemKind ordinals (mirror of Inventory.itemKind declaration order)
+//   0 Cable   1 Adapter   2 Tool   3 Module   4 Storage   5 Consumable
+//   6 Keycard 7 Radio
+//## itemCondition ordinals (mirror of Inventory.itemCondition declaration order)
+//   0 Pristine   1 Good   2 Worn   3 Damaged   4 Broken
+// Keycard (6) carries a STRING level and Radio (7) is nullary, so neither has an
+// integer subtype: subtype_in_band reports 0 for both (the host owns the Keycard
+// string and the Radio nullary arm). normalise_condition DECLARES the loss for an
+// out-of-band condition by folding it to Good (1), mirroring the .res
+// `decodeCondition(...)->Option.getOr(Good)` fallback (a controlled collapse, not
+// a sentinel).
+
+// The number of canonical itemKind tags.
+pub fn kind_count() -> Int { 8 }
+
+// The number of canonical itemCondition values.
+pub fn condition_count() -> Int { 5 }
+
+// Whether a kind ordinal names a real itemKind tag: 1 when 0..7, else 0.
+pub fn is_valid_kind(kind: Int) -> Int {
+  if kind < 0 { 0 } else { if kind > 7 { 0 } else { 1 } }
+}
+
+// Whether a kind is nullary (needs no subtype): 1 for Radio (7), else 0. Mirrors
+// the .res `Some("Radio") => Some(Radio)` arm (no subtype lookup).
+pub fn is_nullary_kind(kind: Int) -> Int {
+  if kind == 7 { 1 } else { 0 }
+}
+
+// Whether a kind requires an int capacity: 1 for Storage (4), else 0. Mirrors the
+// .res Storage arm pairing the subtype with `getInt(dict, "capacity")`.
+pub fn requires_capacity(kind: Int) -> Int {
+  if kind == 4 { 1 } else { 0 }
+}
+
+// Whether a (kind, subtype) ordinal pair is an accepted itemKind arm: 1 when the
+// subtype is within the kind's declared subtype band, else 0. Per-kind bands
+// (mirroring the .res subtype switch arms):
+//   Cable(0)      subtype 0..5   (6 arms)
+//   Adapter(1)    subtype 0..3   (4 arms)
+//   Tool(2)       subtype 0..5   (6 arms)
+//   Module(3)     subtype 0..3   (4 arms)
+//   Storage(4)    subtype 0..1   (2 arms: USBDrive, SDCard)
+//   Consumable(5) subtype 0..3   (4 arms)
+//   Keycard(6)    -- string level, no integer subtype -> 0
+//   Radio(7)      -- nullary, no subtype             -> 0
+pub fn subtype_in_band(kind: Int, subtype: Int) -> Int {
+  if subtype < 0 { return 0; }
+  if kind == 0 { if subtype <= 5 { return 1; } else { return 0; } }
+  if kind == 1 { if subtype <= 3 { return 1; } else { return 0; } }
+  if kind == 2 { if subtype <= 5 { return 1; } else { return 0; } }
+  if kind == 3 { if subtype <= 3 { return 1; } else { return 0; } }
+  if kind == 4 { if subtype <= 1 { return 1; } else { return 0; } }
+  if kind == 5 { if subtype <= 3 { return 1; } else { return 0; } }
+  0
+}
+
+// Condition validity predicate: 1 when the ordinal is 0..4, else 0.
+pub fn is_valid_condition(condition: Int) -> Int {
+  if condition < 0 { 0 } else { if condition > 4 { 0 } else { 1 } }
+}
+
+// Normalise a condition ordinal: identity on the valid 0..4 band, folding any
+// out-of-band ordinal to Good (1) -- the .res decodeCondition `Option.getOr(Good)`
+// fallback. This is a DECLARED collapse over the condition ordinal, not a sentinel.
+pub fn normalise_condition(condition: Int) -> Int {
+  if is_valid_condition(condition) == 1 { condition } else { 1 }
+}
+
+// numberOfCovertLinks floor: never below zero (the .res floorCovertLinks). A
+// negative parsed count is folded up to 0.
+pub fn floor_covert_links(n: Int) -> Int {
+  if n < 0 { 0 } else { n }
+}
+
+// Guard patrolRadius default, in milli-units (the .res 200.0 default scaled by
+// 1000 -> 200000). present == 0 means the field was absent -> the default; any
+// non-zero present means the parsed value (already in milli-units) is used.
+pub fn resolve_patrol_radius_milli(present: Int, value_milli: Int) -> Int {
+  if present == 0 { 200000 } else { value_milli }
+}

--- a/proposals/idaptik/migrated/UmsLevelLoader/umslevelloader.config.mjs
+++ b/proposals/idaptik/migrated/UmsLevelLoader/umslevelloader.config.mjs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for UmsLevelLoader.affine (idaptik UMS level-decode
+// validation core; scalar i32 ABI). Every oracle is an INDEPENDENT JS
+// reimplementation derived from src/shared/UmsLevelLoader.res semantics (the
+// itemKind/subtype decoder arms, the condition fallback-to-Good, the covert-link
+// floor, the 200.0 patrol-radius default) -- NOT a copy of the .affine logic --
+// so the differential sweep is a genuine cross-check. The .res frames these as
+// string-keyed JSON decoding; here only the scalar ordinal result crosses, with
+// patrol radius in milli-units (200.0 J-equivalent -> 200000).
+
+const oIsValidKind = (k) => (k >= 0 && k <= 7 ? 1 : 0);
+const oIsNullaryKind = (k) => (k === 7 ? 1 : 0);
+const oRequiresCapacity = (k) => (k === 4 ? 1 : 0);
+
+// Per-kind subtype band (independent table from the .res decoder switch arms).
+const SUBTYPE_MAX = { 0: 5, 1: 3, 2: 5, 3: 3, 4: 1, 5: 3 };
+const oSubtypeInBand = (kind, subtype) => {
+  if (subtype < 0) return 0;
+  if (!(kind in SUBTYPE_MAX)) return 0; // Keycard(6)/Radio(7)/out-of-band
+  return subtype <= SUBTYPE_MAX[kind] ? 1 : 0;
+};
+
+const oIsValidCondition = (c) => (c >= 0 && c <= 4 ? 1 : 0);
+const oNormaliseCondition = (c) => (c >= 0 && c <= 4 ? c : 1); // fallback Good
+const oFloorCovertLinks = (n) => (n < 0 ? 0 : n);
+const oResolvePatrolRadiusMilli = (present, valueMilli) => (present === 0 ? 200000 : valueMilli);
+
+export default {
+  affine: "UmsLevelLoader.affine",
+  cases: [
+    { name: "kind_count()", export: "kind_count", args: [], oracle: () => 8 },
+    { name: "condition_count()", export: "condition_count", args: [], oracle: () => 5 },
+    {
+      name: "is_valid_kind over [-2..11]",
+      export: "is_valid_kind",
+      args: [[-2, 11]],
+      oracle: oIsValidKind,
+    },
+    {
+      name: "is_nullary_kind over [-2..11]",
+      export: "is_nullary_kind",
+      args: [[-2, 11]],
+      oracle: oIsNullaryKind,
+    },
+    {
+      name: "requires_capacity over [-2..11]",
+      export: "requires_capacity",
+      args: [[-2, 11]],
+      oracle: oRequiresCapacity,
+    },
+    {
+      name: "subtype_in_band over kind in [-1..9], subtype in [-1..7]",
+      export: "subtype_in_band",
+      args: [[-1, 9], [-1, 7]],
+      oracle: oSubtypeInBand,
+    },
+    {
+      name: "is_valid_condition over [-2..8]",
+      export: "is_valid_condition",
+      args: [[-2, 8]],
+      oracle: oIsValidCondition,
+    },
+    {
+      name: "normalise_condition over [-2..8] (out-of-band -> Good=1)",
+      export: "normalise_condition",
+      args: [[-2, 8]],
+      oracle: oNormaliseCondition,
+    },
+    {
+      name: "floor_covert_links over [-5..50]",
+      export: "floor_covert_links",
+      args: [[-5, 50]],
+      oracle: oFloorCovertLinks,
+    },
+    {
+      name: "resolve_patrol_radius_milli over present in {0,1}, value in {0,50000,200000,1000000}",
+      export: "resolve_patrol_radius_milli",
+      args: [{ values: [0, 1] }, { values: [0, 50000, 200000, 1000000] }],
+      oracle: oResolvePatrolRadiusMilli,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Exhaustive sweep of the eight brain-dense idaptik logic directories (`devices`, `player`, `combat`, `enemies`, `companions`, `multiplayer`, `src/shared`, `utils` — **159 `.res` files**), extracting **17 new `Int(...)->Int` brains** and classifying every remaining file. Brain count **62 → 79**.

## New brains (17) — independently re-verified G1/G2/G4 green

`PlayerSprite` (64) · `CombatResolve` (91) · `ThreatClass` (77) · `GameI18nCore` (58) · `AlertPalette` (219) · `PeerPort` (68) · `AccessClamp` (44) · `Coprocessor` (2207) · `Coprocessor_IO` (1758) · `Kernel_Crypto` (170) · `Kernel_Quantum` (52) · `ResourceAccounting` (2537) · `UmsLevelLoader` (229) · `MoletaireCoprocessors` (82) · `MoletaireHunger` (133) · `LobbyManager` (577) · `MultiplayerClient` (85)

(`N` = differential-parity cases, all passing against an independent JS oracle.) **~8,450 cases total**, every brain assail-clean. Verified by the parent session, not just agent-reported.

## Disposition (159 files)

| | count |
|---|---|
| New brains | 17 |
| Already migrated (earlier clusters) | 43 |
| `NO_NEW_BRAINS` | 99 |

The 99 break down as FFI binding shims (`*Coprocessor.res`, ~40), render-glue/PixiJS orchestrators (~25), float-physics/geometry cores (~12), string/JSON/wire-protocol cores (~12), and host state/orchestration glue (~10). Full per-file ledger in `EVIDENCE-C13-logic-sweep.adoc`.

## Notes

- Brains stay `Int->Int` because the parity harness passes integer args only; floats are carried as ×1000 milli-units where integer-exact, else kept host-side.
- Several brains are **residual sub-brains earlier clusters scoped out as "routing"** — `ThreatClass` (from `DualAlertBridge`), the `Coprocessor`/`Kernel`/`Resource` set (from the shared coprocessor layer) — recovered here as separable pure-integer kernels.
- Each new brain's exported signature matches an existing `*Coprocessor.res` host bridge, so the wasm targets drop into the already-written FFI shims.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_