### PR TITLE
migration: 12 integer-brain kernels from idaptik sense-heavy sweep (cluster C14)

### DIFF
--- a/proposals/idaptik/migrated/AmbushObjective/AmbushObjective.affine
+++ b/proposals/idaptik/migrated/AmbushObjective/AmbushObjective.affine
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// AmbushObjective -- the assassin-survival objective co-processor, the pure
+// integer core extracted from idaptik src/app/screens/training/AssassinTraining.res
+// (the onUpdate ambush-counter logic, res:144-161). Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; only primitives cross the wasm
+// boundary"), the host keeps the guard array, the pulsing warning Text, the HUD
+// string formatting and the victory-delay float timer; AffineScript owns only the
+// integer objective accounting over the assassin's failed-ambush count.
+//
+//## Why this split, not a port of AssassinTraining.res
+// AssassinTraining.res entangles (a) the Text pulse `0.5 +. 0.5 *. sin(t*3)` and
+// every container/position float (res:140-141), (b) the victory-delay countdown
+// `victoryDelay -. dt` (res:164-169), (c) the HUD string interpolation
+// "Ambushes survived: N / 3" (res:150,160), and (d) the integer objective decision:
+// sum the per-guard `getAssassinKillAttempts` into `attempts`, declare victory once
+// `attempts >= 3` (res:152). Only (d) is an integer decision; (a)-(c) are float
+// physics, async timing and string rendering that stay host-side. This file is the
+// verified core of that one decision, plus the two display read-outs the HUD needs
+// (clamped progress, remaining-to-go) so the host never re-derives the 0..3 band.
+//
+//## Objective encoding (the header contract for the JS host)
+// The assassin demo is won by forcing THREE failed ambushes. `attempts` is the host's
+// summed `getAssassinKillAttempts` over the guard array (a non-negative i32 in normal
+// play). The target is the literal 3 from res:152 (`attempts >= 3`). Boundary is
+// GREATER-OR-EQUAL, faithful to the .res `>=`, so attempts == 3 already wins and
+// attempts == 2 does not. All read-outs are total over every i32 input: a negative
+// host count (malformed) reads as zero progress / full remaining / not-met, never an
+// out-of-band code, so a stray encoding cannot spuriously complete the objective.
+
+// The number of failed ambushes that complete the objective (AssassinTraining
+// res:152 -- the literal 3 in `attempts >= 3`). The single source of truth for the
+// band width; every read-out below is stated against it.
+pub fn ambush_target() -> Int { 3 }
+
+//## is_objective_met -- whether the survive-the-assassin objective is complete.
+// The integer core of AssassinTraining res:152 (`attempts >= 3`). Boundary is
+// GREATER-OR-EQUAL, faithful to the .res `>=`. Returns 1 = met (fire the victory
+// transition), 0 = not yet. Total over every i32: a negative count is below 3 -> 0.
+pub fn is_objective_met(attempts: Int) -> Int {
+  if attempts >= 3 { 1 } else { 0 }
+}
+
+//## ambushes_survived -- the clamped 0..3 progress for the HUD read-out.
+// The display value behind "Ambushes survived: N / 3" (res:150,160). The raw host
+// count is clamped onto the closed 0..3 band so the HUD never shows a negative or an
+// over-count: a malformed negative reads 0, anything at or past the target reads 3
+// (the objective is complete, no further progress is meaningful). The clamp is to an
+// IN-BAND value (0 or 3), never an out-of-band sentinel, so assail stays clean and
+// no in-band code is shadowed.
+pub fn ambushes_survived(attempts: Int) -> Int {
+  if attempts < 0 { return 0; }
+  if attempts > 3 { return 3; }
+  attempts
+}
+
+//## ambushes_remaining -- failed ambushes still needed to win.
+// The complement of progress: how many more failed ambushes the assassin must be
+// forced into. Defined as 3 minus the clamped progress, so it is total and never
+// negative: at or past the target it is 0 (objective met), at a malformed negative
+// count it is the full 3. Mirrors the HUD's "/ 3" denominator semantics exactly.
+pub fn ambushes_remaining(attempts: Int) -> Int {
+  if attempts < 0 { return 3; }
+  if attempts >= 3 { return 0; }
+  3 - attempts
+}

--- a/proposals/idaptik/migrated/AmbushObjective/ambushobjective.config.mjs
+++ b/proposals/idaptik/migrated/AmbushObjective/ambushobjective.config.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for AmbushObjective.affine (idaptik AssassinTraining
+// survival-objective kernel; scalar i32 ABI). Each oracle re-derives the rule
+// straight from AssassinTraining.res INDEPENDENTLY of the .affine, so a codegen
+// regression surfaces as a differential mismatch.
+//
+// Oracle re-derivation (rule <- source site), independent of the .affine:
+//   ambush_target()         = 3                                   (res:152, the literal 3)
+//   is_objective_met(a)     = a >= 3 ? 1 : 0                      (res:152, `attempts >= 3`)
+//   ambushes_survived(a)    = clamp a onto 0..3                   (HUD "N / 3", res:150,160)
+//   ambushes_remaining(a)   = a<0 ? 3 : a>=3 ? 0 : 3-a            (complement of progress)
+
+// GREATER-OR-EQUAL boundary, faithful to the .res `>=` at res:152.
+const isObjectiveMet = (a) => (a >= 3 ? 1 : 0);
+// Clamp the host count onto the closed 0..3 band (negatives -> 0, over -> 3).
+const ambushesSurvived = (a) => (a < 0 ? 0 : a > 3 ? 3 : a);
+// Complement of the clamped progress against the target 3; total, never negative.
+const ambushesRemaining = (a) => (a < 0 ? 3 : a >= 3 ? 0 : 3 - a);
+
+// Sweep the host count across the band edges and just-inside/just-outside each cut:
+// the malformed negatives, 0, the 1/2/3 progression (2 = not-yet, 3 = exact win),
+// and over-counts (4..6) plus a large overflow so every clamp branch fires.
+const ATTEMPTS = [-5, -1, 0, 1, 2, 3, 4, 5, 6, 100];
+
+export default {
+  affine: "AmbushObjective.affine",
+  cases: [
+    { name: "ambush_target()", export: "ambush_target", args: [], oracle: () => 3 },
+    {
+      name: "is_objective_met over [-5..6]",
+      export: "is_objective_met",
+      args: [{ values: ATTEMPTS }],
+      oracle: isObjectiveMet,
+    },
+    {
+      name: "ambushes_survived over [-5..6]",
+      export: "ambushes_survived",
+      args: [{ values: ATTEMPTS }],
+      oracle: ambushesSurvived,
+    },
+    {
+      name: "ambushes_remaining over [-5..6]",
+      export: "ambushes_remaining",
+      args: [{ values: ATTEMPTS }],
+      oracle: ambushesRemaining,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/BalanceAnalyser/BalanceAnalyser.affine
+++ b/proposals/idaptik/migrated/BalanceAnalyser/BalanceAnalyser.affine
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// BalanceAnalyser -- the pure-integer impact-classification brain extracted from
+// src/app/screens/BalanceAnalyserModel.res (the numeric core its
+// BalanceAnalyserCoprocessor.res binding routes to balanceanalyser.wasm). The
+// model is overwhelmingly senses: it PARSES the balance-report JSON (every
+// string key, every Float field), formats recommendation STRINGS, and builds
+// the PixiJS display lines. Per the DESIGN-VISION ("AffineScript is the brain,
+// JS/Pixi the senses; only primitives cross the wasm boundary"), all of that
+// -- the JSON, the version/parameter/reason strings, the win-rate and
+// difficulty FLOATS, the per-impact colour ints -- stays host-side.
+//
+// RE-DECOMPOSITION. The separable integer decisions are the impact-level
+// comparison (getByImpact's filter) and the critical-issue test
+// (hasCriticalIssues). The ReScript switches the `impactLevel` variant
+// (Minor | Moderate | Major) to a 0..2 ordinal (impactValue) and then compares
+// ordinals; we re-decompose the variant as that 0..2 ordinal directly -- the
+// order the .res `impactValue` switch already imposes (Minor < Moderate <
+// Major). The variant IS the ordinal; no impact strings cross. The float
+// rounding helpers (round1 / pct100 / winRatePct) are senses and stay host-side.
+//
+//## Impact-level encoding (the header contract for the JS host)
+//   ord  level       (mirrors BalanceAnalyserCoprocessor IMPACT.{MINOR,MODERATE,MAJOR})
+//     0  Minor
+//     1  Moderate
+//     2  Major
+//   An ordinal outside 0..2 is not a defined impact: impact_valid reports 0 and
+//   impact_value returns the out-of-band sentinel -1 (never an in-band ordinal),
+//   so an off-domain input cannot pass as a real impact. -1 is a sentinel, not a
+//   clamp (assail stays clean).
+//
+//## Filter / threshold contract (the decisions getByImpact + hasCriticalIssues make)
+//   passes_impact(item_ord, min_ord) -> 1 when the item's impact meets or
+//     exceeds the minimum (item_ord >= min_ord), else 0. This is getByImpact's
+//     `impactValue(item.impact) >= impactValue(minImpact)` kept-row test.
+//   has_critical_issues(major_count) -> 1 when the report has any major issue
+//     (major_count > 0), else 0. This is hasCriticalIssues' `majorIssues > 0`.
+//   Both treat their inputs as plain counts/ordinals; the host owns the
+//   recommendation array, the strings, and the float fields.
+//
+// PURE: integers only, no floats, no strings, no arrays, no effects, no I/O.
+
+//## The number of impact levels (Minor, Moderate, Major).
+pub fn impact_level_count() -> Int { 3 }
+
+//## Whether a host integer names a defined impact level. 1 = valid, 0 = out of band.
+pub fn impact_valid(ord: Int) -> Int {
+  if ord < 0 { 0 } else { if ord > 2 { 0 } else { 1 } }
+}
+
+//## Canonicalise an impact ordinal: identity on a valid 0..2 ordinal, the
+// out-of-band sentinel -1 otherwise. Mirrors impactValue's role as the
+// variant's ordinal; -1 is never an in-band ordinal so out-of-band input can
+// never be confused with a real impact (sentinel, not a clamp).
+pub fn impact_value(ord: Int) -> Int {
+  if impact_valid(ord) == 1 { ord } else { -1 }
+}
+
+//## Whether an item's impact meets or exceeds the minimum: 1 keep, 0 drop.
+// getByImpact's `impactValue(item) >= impactValue(min)` row filter.
+pub fn passes_impact(item_ord: Int, min_ord: Int) -> Int {
+  if item_ord >= min_ord { 1 } else { 0 }
+}
+
+//## Whether the report has any major issue (majorIssues > 0): 1 yes, 0 no.
+// hasCriticalIssues' test. A non-positive count is never positive -> 0.
+pub fn has_critical_issues(major_count: Int) -> Int {
+  if major_count > 0 { 1 } else { 0 }
+}

--- a/proposals/idaptik/migrated/BalanceAnalyser/balanceanalyser.config.mjs
+++ b/proposals/idaptik/migrated/BalanceAnalyser/balanceanalyser.config.mjs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for BalanceAnalyser.affine (idaptik impact-classification
+// brain; scalar i32 ABI). The oracle re-derives each function from the ORIGINAL
+// BalanceAnalyserModel.res semantics (NOT from the .affine) so a codegen
+// regression surfaces as a differential mismatch.
+//
+// From BalanceAnalyserModel.res:
+//   getByImpact (lines 348-356): impactValue Minor=>0 Moderate=>1 Major=>2;
+//     keep iff impactValue(item.impact) >= impactValue(minImpact)
+//   hasCriticalIssues (lines 435-439): r.majorIssues > 0
+// Impact variant Minor/Moderate/Major maps to ordinals 0/1/2.
+
+// Independent re-derivation of the impact validity from the .res ordinal domain.
+const impactValid = (o) => (o >= 0 && o <= 2 ? 1 : 0);
+
+// Independent re-derivation of impactValue (the variant's ordinal) from the .res.
+const impactValue = (o) => (impactValid(o) ? o : -1);
+
+// Independent re-derivation of getByImpact's row filter from the .res.
+const passesImpact = (item, min) => (item >= min ? 1 : 0);
+
+// Independent re-derivation of hasCriticalIssues from the .res.
+const hasCritical = (n) => (n > 0 ? 1 : 0);
+
+export default {
+  affine: "BalanceAnalyser.affine",
+  cases: [
+    {
+      name: "impact_level_count()",
+      export: "impact_level_count",
+      args: [],
+      oracle: () => 3,
+    },
+    {
+      name: "impact_valid over ord[-3..6]",
+      export: "impact_valid",
+      args: [[-3, 6]],
+      oracle: (o) => impactValid(o),
+    },
+    {
+      name: "impact_value over ord[-3..6]",
+      export: "impact_value",
+      args: [[-3, 6]],
+      oracle: (o) => impactValue(o),
+    },
+    {
+      name: "passes_impact over (item[-1..3], min[-1..3])",
+      export: "passes_impact",
+      args: [[-1, 3], [-1, 3]],
+      oracle: (item, min) => passesImpact(item, min),
+    },
+    {
+      name: "passes_impact exact impact pairs 0..2 x 0..2",
+      export: "passes_impact",
+      args: [{ values: [0, 1, 2] }, { values: [0, 1, 2] }],
+      oracle: (item, min) => passesImpact(item, min),
+    },
+    {
+      name: "has_critical_issues over major_count[-2..10]",
+      export: "has_critical_issues",
+      args: [[-2, 10]],
+      oracle: (n) => hasCritical(n),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/EVIDENCE-C14-sense-sweep.adoc
+++ b/proposals/idaptik/migrated/EVIDENCE-C14-sense-sweep.adoc
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Cluster C14 (sense-heavy directory sweep) — migration evidence (2026-06-14)
+:toc: macro
+
+[IMPORTANT]
+====
+*Verdict: 12 new integer brains extracted; the remainder are host-side senses,
+FFI binding shims, or already-migrated.*
+
+This cluster completes the exhaustive corpus sweep begun in C13, covering the
+six remaining sense-heavy directory groups: `src/app/screens` (top-level),
+`src/app/screens/{training,locations}`, `vm/lib/ocaml`, `src/engine` +
+`shared/src`, `src/app/{verisimdb,proven}`, and the long-tail grab-bag
+(`narrative`, `tools`, `tea`, `pickups`, `pixi`, `burble`, `vm`, `bindings`,
+`idaptik-ums/src`, loose `src`/`src/app`). 148 `.res` files.
+
+All 12 new brains were *independently re-verified* by the parent session
+(G1 compile, G2 differential parity all-pass vs an independent JS oracle,
+G4 assail zero high findings). Total brain count: 79 -> 91.
+====
+
+== Disposition summary
+
+[cols="3,1,1,1,1",options="header"]
+|===
+| Directory group | Files | New | Already | No-brain
+| `src/app/screens` (top-level)        | 25 | 5 |  1 | 19
+| `screens/training`+`locations`       | 23 | 2 |  0 | 21
+| `vm/lib/ocaml`                       | 34 | 1 | 27 |  6
+| `src/engine`+`shared/src`            | 27 | 0 | 17 | 10
+| `src/app/verisimdb`+`proven`         | 16 | 3 |  0 | 13
+| long-tail grab-bag                   | 23 | 1 |  0 | 22
+| *Total*                              | *148* | *12* | *45* | *91*
+|===
+
+== New brains (12) — all G1/G2/G4 green
+
+[cols="2,1,4",options="header"]
+|===
+| Brain | G2 | Extracted logic
+| `VictoryScreen`         | 2430/2430 | performance-grade: victory_score (100 base, alert/time/command penalties, covert/crit bonuses) + S/A/B/C/D banding (4..0)
+| `PlayTimeSplit`         | 2040/2040 | total_minutes -> hours(/60)/minutes(%60)/has_hours (harness-Int form of the float-seconds render kernel)
+| `VeriSimError`          | 859/859   | HTTP status -> 20-category ordinal + is_retryable(category) + is_status_retryable
+| `MissionBriefing`       | 285/285   | difficulty/guard-count/threshold, objective-state predicates, completion + progress%, par-time & S-grade alert budget
+| `IntroScreen`           | 254/254   | tutorial paginator state machine: next_page (bounded), is_last_page, 1-based page_label
+| `InstructionCoprocessor`| 175/175   | opcode arity-and-reversibility taxonomy: count/valid/arity/tier/is_self_inverse/invert/invert_round_trip
+| `SkillTreeScreen`       | 114/114   | XP-threshold classification: rank 0..4 -> threshold, is_maxed, xp_fill_permille (0..1000)
+| `VeriSimModality`       | 80/80     | 8-member modality band (0..7) + 5-member drift-level ordinal (0..4) + drift_is_actionable/critical
+| `BalanceAnalyser`       | 68/68     | impact-level classification (Minor/Moderate/Major -> 0..2) + passes_impact + has_critical_issues
+| `LocationData`          | 61/61     | world-map attributes: location_count, environment_kind (idx -> ordinal), device_count
+| `AmbushObjective`       | 31/31     | 3-failed-ambush survival objective: is_objective_met (attempts>=3), clamped progress, remaining
+| `HighwayHits`           | 28/28     | hit-budget accounting (max 3, game_over, clamped remaining) + per-lane traffic-direction parity (+/-1)
+|===
+
+== NO_NEW_BRAINS (91) and ALREADY (45)
+
+* *Screens / locations (~40):* PixiJS lifecycle orchestrators, navigation, static
+  LocationData-record screens, i18n string menus, float layout/camera math.
+* *FFI binding shims + render-glue (~30):* `*Coprocessor.res`, Pixi/Motion/Sound
+  bindings (`Pixi.res` 321 externals), render-decision bridges (float ABI).
+* *Float-domain cores (~10):* SafeFloat/SafeAngle (NaN-guarded f64), Resize,
+  glitch-FX, training dt-physics state machines.
+* *String/JSON/HTTP cores (~15):* VeriSim HTTP/JSON FFI bridges, PhoenixSocket,
+  SafeJson, lore/DataFiles, terminal/editor IPC glue.
+* *Orchestration / host state (~10):* Main, GameLoop, GetEngine, VM orchestrator,
+  SubroutineRegistry, registries and circular-dep-breaker refs.
+* *VM instructions (23, ALREADY):* `Add.res`..`Xor.res` are each covered by the
+  migrated `Vm{Arith,Bitwise,MulDiv,Stack,Memory,Port,Control,Ancilla,Instruction}`
+  category brains (confirmed by reading each category `.affine`).
+* *`shared/src` (17, ALREADY):* a duplicate tree of `src/shared`; every brain was
+  already extracted (Coprocessor, Kernel_*, ResourceAccounting, DeviceType, ...).
+
+== Residual gap (closed in a follow-up)
+
+The screens sweep covered the top level and `training`/`locations`; the small
+`screens/main` (3), `screens/hub` (1), `vm/wasm/src` (2), and `devices/{types,
+common}` (2) leaves are swept separately. (`docs/.../templates/*.res` is a
+template, not source.)
+
+== Method note
+
+Brains stay `Int(...)->Int` (the parity harness passes integer arguments only);
+floats are carried as x1000 milli-units / permille where integer-exact, else
+host-side. Two recurring AffineScript authoring landmines were re-confirmed and
+worked around: `total` is a *reserved word* (use `acc`/`req_total`), and the flat
+early-`return N;` idiom (not deeply nested deferred-brace `if/else`) is the
+reliable many-branch style that stays G4-clean. Several brains are residual
+sub-brains earlier clusters scoped out (the Coprocessor/Kernel/Resource set,
+ThreatClass, the screen score/grade kernels), recovered here as separable
+pure-integer kernels matching the existing `*Coprocessor.res` host bridges.

--- a/proposals/idaptik/migrated/HighwayHits/HighwayHits.affine
+++ b/proposals/idaptik/migrated/HighwayHits/HighwayHits.affine
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// HighwayHits -- the Frogger-crossing hit-budget + lane-traffic co-processor, the
+// pure integer core extracted from idaptik
+// src/app/screens/training/HighwayCrossingTraining.res. Per the DESIGN-VISION
+// ("AffineScript is the brain, JS/Pixi the senses; only primitives cross the wasm
+// boundary"), the host keeps every vehicle position, the nausea float meter, the
+// hop animation timers, the spawn-interval randomness and all Text rendering;
+// AffineScript owns only (1) the integer hit-budget accounting that decides
+// game-over and (2) the per-lane traffic-direction parity that the spawner and the
+// arrow renderer both read.
+//
+//## Why this split, not a port of HighwayCrossingTraining.res
+// HighwayCrossingTraining.res is overwhelmingly float physics: vehicle x = x +.
+// speed *. dt, the 0..1 nausea meter with its near-miss spikes and decay, hop
+// interpolation, swept-AABB collision (res:424-461), and the random spawn cadence.
+// None of that crosses. Two things ARE integer decisions: the hit budget -- the mole
+// has `Tuning.maxHits = 3` lives (res:78), each collision does `mole.hits = hits + 1`
+// then `if mole.hits >= maxHits { gameOver }` (res:791), and the HUD shows
+// `maxHits - hits` remaining (res:489); and the lane traffic direction -- lane `i`
+// runs right when `mod(i,2)==0` else left (res:564 for speed sign, res:344 for the
+// ">>>"/"<<<" arrow). This file is the verified core of just those two: the host
+// passes the running hit count / a lane index and reads back the budget verdict /
+// the direction sign. The ±1.0 float the host multiplies speed by is encoded here as
+// the integer sign ±1 (the host re-floats it); no float crosses.
+//
+//## Hit-budget encoding (the header contract for the JS host)
+// `hits` is the host's running collision count (a non-negative i32 in normal play,
+// 0 at spawn). The cap is the literal 3 from Tuning.maxHits (res:78). Game-over
+// boundary is GREATER-OR-EQUAL, faithful to the .res `>=` at res:791, so hits == 3
+// is over and hits == 2 is not. Remaining is the clamped `maxHits - hits` (res:489),
+// floored at 0 so a past-cap count never reads negative.
+//
+//## Lane-direction encoding (the second contract for the JS host)
+// A lane index `i` (0-based, 0..laneCount-1) maps to a traffic-direction SIGN:
+//   even i -> +1  (traffic moves RIGHT; res:564 `1.0`, res:344 ">>>")
+//   odd  i -> -1  (traffic moves LEFT;  res:564 `-1.0`, res:344 "<<<")
+// The host multiplies a positive base speed by this sign to get signed velocity, and
+// picks the arrow glyph by it. The parity is total over every i32 index (a negative
+// index still has a defined parity), so a stray host index always resolves to a
+// definite ±1 direction, never an out-of-band value.
+
+// The number of lanes on the highway (Tuning.laneCount, res:39). Provided so the
+// host can bound its lane loop against the same constant the direction parity
+// assumes.
+pub fn lane_count() -> Int { 5 }
+
+// The hit budget: collisions allowed before the run ends (Tuning.maxHits, res:78).
+// The single source of truth for the budget; the read-outs below are stated against
+// it.
+pub fn max_hits() -> Int { 3 }
+
+//## is_game_over -- whether the accumulated hits end the crossing.
+// The integer core of res:791 (`mole.hits >= Tuning.maxHits`). Boundary is
+// GREATER-OR-EQUAL, faithful to the .res `>=`. Returns 1 = over (fire the Defeat
+// transition), 0 = still crossing. Total over every i32: a negative count is below 3
+// -> 0.
+pub fn is_game_over(hits: Int) -> Int {
+  if hits >= 3 { 1 } else { 0 }
+}
+
+//## hits_remaining -- lives left for the HUD "Hits remaining" read-out (res:489).
+// The clamped `Tuning.maxHits - hits`: full budget at a malformed negative count,
+// floored at 0 once the cap is reached so the HUD never shows a negative. The clamp
+// targets the IN-BAND 0..3 range (0 or maxHits-attempts), never an out-of-band
+// sentinel, so assail stays clean and no in-band value is shadowed.
+pub fn hits_remaining(hits: Int) -> Int {
+  if hits < 0 { return 3; }
+  if hits >= 3 { return 0; }
+  3 - hits
+}
+
+//## lane_direction -- the traffic-direction sign for a lane index.
+// The integer core of the lane parity at res:564 / res:344: even lane index -> +1
+// (rightward), odd -> -1 (leftward). The host multiplies its positive base speed by
+// this sign and selects the ">>>"/"<<<" arrow by it. Computed by the low bit of the
+// index so it is total and parity-correct for negative indices too (a negative even
+// index is still rightward). Never returns 0, so "no direction" cannot occur.
+pub fn lane_direction(lane_index: Int) -> Int {
+  if (lane_index % 2) == 0 { 1 } else { -1 }
+}

--- a/proposals/idaptik/migrated/HighwayHits/highwayhits.config.mjs
+++ b/proposals/idaptik/migrated/HighwayHits/highwayhits.config.mjs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for HighwayHits.affine (idaptik HighwayCrossingTraining
+// hit-budget + lane-direction kernel; scalar i32 ABI). Each oracle re-derives the
+// rule straight from HighwayCrossingTraining.res INDEPENDENTLY of the .affine, so a
+// codegen regression surfaces as a differential mismatch.
+//
+// Oracle re-derivation (rule <- source site), independent of the .affine:
+//   lane_count()        = 5                                  (Tuning.laneCount, res:39)
+//   max_hits()          = 3                                  (Tuning.maxHits, res:78)
+//   is_game_over(h)     = h >= 3 ? 1 : 0                      (res:791, `hits >= maxHits`)
+//   hits_remaining(h)   = h<0 ? 3 : h>=3 ? 0 : 3-h           (HUD maxHits-hits, res:489)
+//   lane_direction(i)   = (i % 2) === 0 ? 1 : -1             (res:564 sign / res:344 arrow)
+
+// GREATER-OR-EQUAL boundary, faithful to the .res `>=` at res:791.
+const isGameOver = (h) => (h >= 3 ? 1 : 0);
+// Clamped maxHits - hits: full at negatives, floored at 0 past the cap.
+const hitsRemaining = (h) => (h < 0 ? 3 : h >= 3 ? 0 : 3 - h);
+// Lane traffic-direction sign by index parity; written as the SAME `i % 2` expression
+// the .affine uses, so truncated-modulo semantics for negatives must agree on both
+// sides (a differential failure here would itself be the signal).
+const laneDirection = (i) => ((i % 2) === 0 ? 1 : -1);
+
+// Hit count across the band: malformed negatives, 0, the 1/2/3 progression
+// (2 = still alive, 3 = exact game-over), over-cap (4..5) plus an overflow.
+const HITS = [-3, -1, 0, 1, 2, 3, 4, 5, 100];
+// Lane index over the real 0..laneCount-1 domain (0..4) plus a couple of negatives to
+// probe modulo agreement between the JS oracle and the AffineScript `%`.
+const LANES = [-2, -1, 0, 1, 2, 3, 4, 5];
+
+export default {
+  affine: "HighwayHits.affine",
+  cases: [
+    { name: "lane_count()", export: "lane_count", args: [], oracle: () => 5 },
+    { name: "max_hits()", export: "max_hits", args: [], oracle: () => 3 },
+    {
+      name: "is_game_over over hit band",
+      export: "is_game_over",
+      args: [{ values: HITS }],
+      oracle: isGameOver,
+    },
+    {
+      name: "hits_remaining over hit band",
+      export: "hits_remaining",
+      args: [{ values: HITS }],
+      oracle: hitsRemaining,
+    },
+    {
+      name: "lane_direction over lane indices",
+      export: "lane_direction",
+      args: [{ values: LANES }],
+      oracle: laneDirection,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/InstructionCoprocessor/InstructionCoprocessor.affine
+++ b/proposals/idaptik/migrated/InstructionCoprocessor/InstructionCoprocessor.affine
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// InstructionCoprocessor -- the opcode arity-and-reversibility taxonomy of the
+// idaptik reversible VM, the pure-integer core behind the @send bridge declared
+// in vm/lib/ocaml/InstructionCoprocessor.res (whose ground-truth semantics live
+// in InstructionCoprocessorBridge.js's OPCODE table + the exported integer ops).
+// Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; they
+// pass primitives across the wasm boundary"), the JS host keeps every mnemonic
+// STRING ("ADD", "SUB", ...) and the operand-token arrays; AffineScript owns
+// only the canonical opcode encoding, the per-opcode operand count, the VM tier,
+// and the reversible pairing that Instruction.res's execute/invert closures
+// imply. Only integer opcodes cross the boundary; the strings never do.
+//
+// WHY THIS IS NOT VmInstruction.affine. The migrated VmInstruction brain encodes
+// the *tier-ordered* instruction set (NOOP=0, ADD=1, ..., 23 opcodes) and answers
+// count / validity / tier / tier-admission. THIS module is the distinct
+// co-processor surface the InstructionCoprocessorBridge.js exposes: it uses the
+// *register-arithmetic-first* encoding (ADD=0, SUB=1, ..., 22 opcodes, byte-
+// identical to VmCoprocessorBridge.OPCODE) and additionally answers the three
+// questions VmInstruction does not -- operand arity, self-inverse-ness, and the
+// structural inverse opcode -- which are the encoded form of the VM's
+// reversibility guarantee (Add.invert is Sub, Sub.invert is Add; Negate/Flip/
+// Swap/Xor/Noop are their own inverse). The two encodings are deliberately
+// different bands; a host that wants the tier-ordered view calls VmInstruction,
+// a host that drives this co-processor calls here. No strings cross either.
+//
+//## Opcode encoding (the header contract for the JS host)
+// The register-arithmetic band 0..12 is BYTE-IDENTICAL to VmCoprocessorBridge's
+// OPCODE table, so this module's encoding and the live VM dispatch agree; the
+// higher tiers extend it contiguously.
+//   opcode  mnemonic  tier  arity        opcode  mnemonic  tier  arity
+//      0    ADD         0     2             11    NOOP        0     0
+//      1    SUB         0     2             12    DIV         0     4
+//      2    NEGATE      0     1             13    IF_ZERO     1     3
+//      3    MUL         0     3             14    IF_POS      1     3
+//      4    AND         0     3             15    PUSH        2     1
+//      5    OR          0     3             16    POP         2     1
+//      6    XOR         0     2             17    LOAD        2     2
+//      7    FLIP        0     1             18    STORE       2     2
+//      8    SWAP        0     2             19    CALL        3     1
+//      9    ROL         0     1             20    SEND        4     2
+//     10    ROR         0     1             21    RECV        4     2
+// The encoding is LOSSLESS: 22 instructions map to 22 distinct opcodes, so the
+// host round-trips instruction <-> opcode with no collision. An opcode outside
+// 0..21 is not an instruction: every query below returns the out-of-band
+// sentinel -1, never an in-band value, so a malformed host opcode can never be
+// confused with a real instruction (sentinel, not clamp; assail stays clean).
+
+//## The opcode count (the closed band size).
+// The single source of truth for how many opcodes this co-processor recognises.
+pub fn opcode_count() -> Int { 22 }
+
+//## Validity: is this integer a recognised opcode (0..21)?
+// 1 for an in-band opcode, 0 otherwise. The defended boundary: the host marshals
+// a bare integer and this is the only gate on it.
+pub fn is_valid_opcode(op: Int) -> Int {
+  if op < 0 { return 0; }
+  if op > 21 { return 0; }
+  1
+}
+
+//## Operand arity: the operand count InstructionParser checks per mnemonic,
+// expressed purely as a function of the opcode. Flat guarded returns (no deep
+// nesting). An out-of-band opcode yields the sentinel -1 ("no such instruction").
+pub fn opcode_arity(op: Int) -> Int {
+  if op == 0 { return 2; }   // ADD
+  if op == 1 { return 2; }   // SUB
+  if op == 2 { return 1; }   // NEGATE
+  if op == 3 { return 3; }   // MUL
+  if op == 4 { return 3; }   // AND
+  if op == 5 { return 3; }   // OR
+  if op == 6 { return 2; }   // XOR
+  if op == 7 { return 1; }   // FLIP
+  if op == 8 { return 2; }   // SWAP
+  if op == 9 { return 1; }   // ROL
+  if op == 10 { return 1; }  // ROR
+  if op == 11 { return 0; }  // NOOP
+  if op == 12 { return 4; }  // DIV
+  if op == 13 { return 3; }  // IF_ZERO
+  if op == 14 { return 3; }  // IF_POS
+  if op == 15 { return 1; }  // PUSH
+  if op == 16 { return 1; }  // POP
+  if op == 17 { return 2; }  // LOAD
+  if op == 18 { return 2; }  // STORE
+  if op == 19 { return 1; }  // CALL
+  if op == 20 { return 2; }  // SEND
+  if op == 21 { return 2; }  // RECV
+  -1
+}
+
+//## Tier classification: which VM tier an opcode belongs to.
+// Tier 0 register arithmetic (0..12), Tier 1 conditionals (13..14), Tier 2
+// stack/memory (15..18), Tier 3 subroutines (19), Tier 4 I/O (20..21). An
+// out-of-band opcode yields -1.
+pub fn opcode_tier(op: Int) -> Int {
+  if op < 0 { return -1; }
+  if op <= 12 { return 0; }
+  if op <= 14 { return 1; }
+  if op <= 18 { return 2; }
+  if op == 19 { return 3; }
+  if op <= 21 { return 4; }
+  -1
+}
+
+//## Self-inverse predicate: is an opcode its own inverse?
+// The reversible-VM property lifted to the encoding. NEGATE, XOR, FLIP, SWAP,
+// NOOP are self-inverse (applying twice restores state); every other recognised
+// opcode pairs with a distinct inverse (ADD<->SUB, resolved by invert_opcode).
+// 1 for self-inverse, 0 otherwise, -1 for an out-of-band opcode.
+pub fn is_self_inverse(op: Int) -> Int {
+  if is_valid_opcode(op) == 0 { return -1; }
+  if op == 2 { return 1; }   // NEGATE
+  if op == 6 { return 1; }   // XOR
+  if op == 7 { return 1; }   // FLIP
+  if op == 8 { return 1; }   // SWAP
+  if op == 11 { return 1; }  // NOOP
+  0
+}
+
+//## The structural inverse opcode (the reversible pairing, by construction).
+// ADD<->SUB are the only non-self-inverse pair in the encoded set; every other
+// recognised opcode is returned unchanged (it is either self-inverse or its own
+// structural undo at this interface). Out-of-band opcode yields -1. This is the
+// opcode-level recovery of Instruction.res's invert closure.
+pub fn invert_opcode(op: Int) -> Int {
+  if is_valid_opcode(op) == 0 { return -1; }
+  if op == 0 { return 1; }   // ADD -> SUB
+  if op == 1 { return 0; }   // SUB -> ADD
+  op
+}
+
+//## Round trip: invert an opcode twice, expect the original.
+// Inverting twice must restore any recognised opcode (ADD->SUB->ADD; a
+// self-inverse op->op->op). This is the encoded form of the VM's reversibility
+// guarantee and what the differential harness exercises directly. Returns the
+// recovered opcode, or -1 for an out-of-band input.
+pub fn invert_round_trip(op: Int) -> Int {
+  if is_valid_opcode(op) == 0 { return -1; }
+  invert_opcode(invert_opcode(op))
+}

--- a/proposals/idaptik/migrated/InstructionCoprocessor/instructioncoprocessor.config.mjs
+++ b/proposals/idaptik/migrated/InstructionCoprocessor/instructioncoprocessor.config.mjs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for InstructionCoprocessor.affine (idaptik VM opcode
+// arity-and-reversibility taxonomy; scalar i32 ABI). The oracle independently
+// re-derives the register-arithmetic-first 0..21 opcode band, the per-opcode
+// operand arity, the tier classifier, the self-inverse predicate, and the
+// structural inverse pairing in plain JS so a codegen regression surfaces as a
+// differential mismatch. This re-implementation is deliberately NOT a call into
+// the wasm -- it mirrors InstructionCoprocessorBridge.js's OPCODE table by hand.
+
+const validOp = (op) => op >= 0 && op <= 21;
+
+// Per-opcode operand counts, indexed by opcode 0..21 (the register-arith-first
+// encoding: ADD=0 .. RECV=21). Independent transcription of the header table.
+const ARITY = [
+  2, // 0  ADD
+  2, // 1  SUB
+  1, // 2  NEGATE
+  3, // 3  MUL
+  3, // 4  AND
+  3, // 5  OR
+  2, // 6  XOR
+  1, // 7  FLIP
+  2, // 8  SWAP
+  1, // 9  ROL
+  1, // 10 ROR
+  0, // 11 NOOP
+  4, // 12 DIV
+  3, // 13 IF_ZERO
+  3, // 14 IF_POS
+  1, // 15 PUSH
+  1, // 16 POP
+  2, // 17 LOAD
+  2, // 18 STORE
+  1, // 19 CALL
+  2, // 20 SEND
+  2, // 21 RECV
+];
+
+const tierOf = (op) => {
+  if (op < 0) return -1;
+  if (op <= 12) return 0;
+  if (op <= 14) return 1;
+  if (op <= 18) return 2;
+  if (op === 19) return 3;
+  if (op <= 21) return 4;
+  return -1;
+};
+
+// NEGATE(2), XOR(6), FLIP(7), SWAP(8), NOOP(11) are their own inverse.
+const selfInverseSet = new Set([2, 6, 7, 8, 11]);
+const isSelfInverse = (op) => (!validOp(op) ? -1 : (selfInverseSet.has(op) ? 1 : 0));
+
+const invertOpcode = (op) => {
+  if (!validOp(op)) return -1;
+  if (op === 0) return 1; // ADD -> SUB
+  if (op === 1) return 0; // SUB -> ADD
+  return op;
+};
+
+export default {
+  affine: "InstructionCoprocessor.affine",
+  cases: [
+    {
+      name: "opcode_count()",
+      export: "opcode_count",
+      args: [],
+      oracle: () => 22,
+    },
+    {
+      name: "is_valid_opcode over [-3..25]",
+      export: "is_valid_opcode",
+      args: [[-3, 25]],
+      oracle: (op) => (validOp(op) ? 1 : 0),
+    },
+    {
+      name: "opcode_arity over [-3..25]",
+      export: "opcode_arity",
+      args: [[-3, 25]],
+      oracle: (op) => (validOp(op) ? ARITY[op] : -1),
+    },
+    {
+      name: "opcode_tier over [-3..25]",
+      export: "opcode_tier",
+      args: [[-3, 25]],
+      oracle: (op) => tierOf(op),
+    },
+    {
+      name: "is_self_inverse over [-3..25]",
+      export: "is_self_inverse",
+      args: [[-3, 25]],
+      oracle: (op) => isSelfInverse(op),
+    },
+    {
+      name: "invert_opcode over [-3..25]",
+      export: "invert_opcode",
+      args: [[-3, 25]],
+      oracle: (op) => invertOpcode(op),
+    },
+    {
+      name: "invert_round_trip over [-3..25]",
+      export: "invert_round_trip",
+      args: [[-3, 25]],
+      oracle: (op) => (validOp(op) ? invertOpcode(invertOpcode(op)) : -1),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/IntroScreen/IntroScreen.affine
+++ b/proposals/idaptik/migrated/IntroScreen/IntroScreen.affine
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// IntroScreen -- the pure-integer paginator brain extracted from
+// src/app/screens/IntroScreen.res (the tutorial page-flip state machine). The
+// screen is senses: the per-page title/body STRINGS (all GameI18n.t lookups),
+// the highlight colour strings, the Pixi Text/Graphics page render, the
+// feature-pack page filter, and the Next/Skip button wiring. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), every string and Pixi object stays
+// host-side; AffineScript owns only the page-INDEX arithmetic that the Next
+// button and page indicator reduce to.
+//
+// RE-DECOMPOSITION. The ReScript keeps a `currentPage = ref(0)` and, on Next,
+// does `if currentPage < length - 1 { currentPage := currentPage + 1 }` (else
+// it starts the game), shows `currentPage + 1 / length` in the indicator, and
+// swaps the button label to "Start" on the last page. We re-decompose the ref
+// into explicit (current, count) Int params -- no module state -- so each
+// transition is a pure function of where you are and how many pages there are.
+// The page COUNT is host data (it varies with the InvertibleProgramming
+// feature flag, which filters the page array), so it is passed in rather than
+// hard-coded: the brain owns the bounded-advance arithmetic, the host owns
+// which pages exist. The string render stays host-side entirely.
+//
+//## Paginator contract (the header contract for the JS host)
+//   page indices are 0-based and dense; `count` is the number of pages the
+//   host's feature-filtered array currently holds (>= 1 in practice -- the
+//   welcome/controls/alerts/coop pages are always present).
+//   intro_next_page(current, count) -> the index after pressing Next: current
+//     + 1 while more pages remain, else stays on the last page (the .res only
+//     increments when current < count - 1; on the last page Next instead
+//     starts the game, so the index itself does not advance).
+//   intro_is_last_page(current, count) -> 1 when current is the final page
+//     (current == count - 1), else 0. This is the .res "swap Next -> Start"
+//     test and the "Next starts the game" branch condition.
+//   intro_page_label(current) -> the 1-based page number shown in the "N / M"
+//     indicator: current + 1.
+//   A current index outside 0..count-1, or a non-positive count, is off-domain;
+//   the guarded kernels return the out-of-band sentinel -1 rather than an
+//   in-band index (-1 is a sentinel, not a clamp; assail stays clean).
+//
+// PURE: integers only, no floats, no strings, no arrays, no effects, no I/O.
+
+//## Whether (current, count) is a valid paginator position: count >= 1 and
+// 0 <= current < count. 1 = valid, 0 = off-domain.
+pub fn intro_pos_valid(current: Int, count: Int) -> Int {
+  if count < 1 { 0 } else {
+    if current < 0 { 0 } else {
+      if current >= count { 0 } else { 1 }
+    }
+  }
+}
+
+//## Whether the current page is the last one (current == count - 1): 1 if so,
+// else 0. Off-domain positions yield 0 (no spurious "last page").
+pub fn intro_is_last_page(current: Int, count: Int) -> Int {
+  if intro_pos_valid(current, count) == 1 {
+    if current == count - 1 { 1 } else { 0 }
+  } else { 0 }
+}
+
+//## The page index after pressing Next: current + 1 while pages remain, else
+// the unchanged last index (the .res increments only when current < count - 1;
+// on the last page Next starts the game and the index stays put). Off-domain
+// positions yield the out-of-band sentinel -1.
+pub fn intro_next_page(current: Int, count: Int) -> Int {
+  if intro_pos_valid(current, count) == 1 {
+    if current < count - 1 { current + 1 } else { current }
+  } else { -1 }
+}
+
+//## The 1-based page number for the "N / M" indicator: current + 1. Guarded so
+// a negative current cannot show a zero-or-negative page number (-1 sentinel).
+pub fn intro_page_label(current: Int) -> Int {
+  if current < 0 { -1 } else { current + 1 }
+}

--- a/proposals/idaptik/migrated/IntroScreen/introscreen.config.mjs
+++ b/proposals/idaptik/migrated/IntroScreen/introscreen.config.mjs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for IntroScreen.affine (idaptik tutorial paginator brain;
+// scalar i32 ABI). The oracle re-derives each function from the ORIGINAL
+// IntroScreen.res page-flip semantics (NOT from the .affine) so a codegen
+// regression surfaces as a differential mismatch.
+//
+// From IntroScreen.res Next handler (lines 240-249):
+//   if currentPage.contents < Array.length(pages) - 1 {
+//     currentPage := currentPage.contents + 1; renderPage()
+//   } else { goToWorldMap() }     // last page: start the game, index unchanged
+// From the indicator (line 213): `${currentPage + 1} / ${length}`
+// From the last-page test (line 217): currentPage == Array.length(pages) - 1
+// The page count is host data (feature-filtered array), passed in as `count`.
+
+// Independent re-derivation of the paginator validity (count >= 1, in-range).
+const posValid = (cur, count) => (count >= 1 && cur >= 0 && cur < count ? 1 : 0);
+
+// Independent re-derivation of the last-page test from the .res.
+const isLast = (cur, count) => {
+  if (!posValid(cur, count)) return 0;
+  return cur === count - 1 ? 1 : 0;
+};
+
+// Independent re-derivation of the Next-button index transition from the .res.
+const nextPage = (cur, count) => {
+  if (!posValid(cur, count)) return -1;
+  return cur < count - 1 ? cur + 1 : cur; // last page: index stays put
+};
+
+// Independent re-derivation of the 1-based indicator number from the .res.
+const pageLabel = (cur) => (cur < 0 ? -1 : cur + 1);
+
+export default {
+  affine: "IntroScreen.affine",
+  cases: [
+    {
+      name: "intro_pos_valid over (current[-2..8], count{0..6})",
+      export: "intro_pos_valid",
+      args: [[-2, 8], { values: [0, 1, 2, 3, 4, 5, 6] }],
+      oracle: (cur, count) => posValid(cur, count),
+    },
+    {
+      name: "intro_is_last_page over (current[-2..8], count{0..6})",
+      export: "intro_is_last_page",
+      args: [[-2, 8], { values: [0, 1, 2, 3, 4, 5, 6] }],
+      oracle: (cur, count) => isLast(cur, count),
+    },
+    {
+      name: "intro_next_page over (current[-2..8], count{0..6})",
+      export: "intro_next_page",
+      args: [[-2, 8], { values: [0, 1, 2, 3, 4, 5, 6] }],
+      oracle: (cur, count) => nextPage(cur, count),
+    },
+    {
+      // The two real page counts the feature flag toggles between (4 core + VM = 5).
+      name: "intro_next_page over real counts {4,5}",
+      export: "intro_next_page",
+      args: [{ values: [0, 1, 2, 3, 4 ] }, { values: [4, 5] }],
+      oracle: (cur, count) => nextPage(cur, count),
+    },
+    {
+      name: "intro_page_label over current[-2..10]",
+      export: "intro_page_label",
+      args: [[-2, 10]],
+      oracle: (cur) => pageLabel(cur),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/LocationData/LocationData.affine
+++ b/proposals/idaptik/migrated/LocationData/LocationData.affine
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// LocationData -- the pure-integer world-map attribute brain extracted from
+// src/app/screens/LocationData.res (the numeric core its
+// LocationDataCoprocessor.res binding routes to locationdata.wasm). The .res is
+// a 13-row table of locations; almost every column is senses: the id / name /
+// description / environment STRINGS, the per-device (IP string, x float)
+// position pairs, the worldWidth FLOAT, the backgroundColor hex. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), the host keeps every string, every
+// float, and the colour hexes, and resolves a location id to its table INDEX
+// before querying; AffineScript owns only the integer attribute lookups the
+// index keys.
+//
+// RE-DECOMPOSITION. The ReScript holds the attributes inside a record array and
+// reads them with Array.find / Array.length / field access. We re-decompose the
+// two genuinely-integer columns -- the environment KIND (an enum) and the
+// device COUNT -- as flat index-keyed lookups over the 0..12 closed band the row
+// order already fixes. The environment string column becomes its 0..3 ordinal
+// (the order the binding's ENVIRONMENT selector imposes: FIELD < CITY <
+// DATACENTER < LAB); the device-count column becomes the length of each row's
+// devicePositions array, frozen as an Int. The float worldWidth and the hex
+// backgroundColor stay host-side (they are senses); the WorldBuilder
+// buildingCount is worldWidth/200 -- a float derivation -- and also stays host-
+// side. No location strings cross; the brain sees an index, returns an Int.
+//
+//## Location index encoding (the header contract for the JS host)
+//   idx  id            env       devices      idx  id            env       devices
+//     0  field         FIELD(0)     2           7  nexus         DC(2)        3
+//     1  city          CITY(1)      8           8  devhub        DC(2)        2
+//     2  dmz           DC(2)        4           9  rural-isp     DC(2)        1
+//     3  security      DC(2)        4          10  business-isp  DC(2)        1
+//     4  scada         DC(2)        3          11  regional-isp  DC(2)        1
+//     5  lab           LAB(3)       4          12  backbone      DC(2)        1
+//     6  atlas         DC(2)        3
+//   The id->idx resolution is the host's (it owns the id strings); the brain's
+//   band is 0..12. An index outside 0..12 is not a location: location_valid
+//   reports 0, and environment_kind / device_count return the out-of-band
+//   sentinel -1 (never an in-band ordinal/count), so an off-domain index can
+//   never read a spurious attribute. -1 is a sentinel, not a clamp (assail stays
+//   clean).
+//
+//## Environment-kind encoding (mirror of the binding's ENVIRONMENT selector)
+//   0 FIELD, 1 CITY, 2 DATACENTER, 3 LAB. Only `field` and `city` are their own
+//   kind; `lab` is LAB; every other location is DATACENTER (the .res environment
+//   column verbatim).
+//
+// PURE: integers only, no floats, no strings, no arrays, no effects, no I/O.
+
+//## The number of locations in the world map (the .res allLocations length).
+pub fn location_count() -> Int { 13 }
+
+//## Whether a host integer names a defined location index. 1 = valid, 0 = out of band.
+pub fn location_valid(idx: Int) -> Int {
+  if idx < 0 { 0 } else { if idx > 12 { 0 } else { 1 } }
+}
+
+//## The environment-kind ordinal (0 FIELD, 1 CITY, 2 DATACENTER, 3 LAB) for a
+// location index, from the .res environment column. Off-domain indices return
+// the out-of-band sentinel -1. field=0, city=1, lab=5->3; all others DATACENTER.
+pub fn environment_kind(idx: Int) -> Int {
+  if location_valid(idx) == 1 {
+    if idx == 0 { 0 } else {
+      if idx == 1 { 1 } else {
+        if idx == 5 { 3 } else { 2 }
+      }
+    }
+  } else { -1 }
+}
+
+//## The number of devices a location hosts (the length of its devicePositions
+// row in the .res), keyed by location index. Off-domain indices return the
+// out-of-band sentinel -1.
+pub fn device_count(idx: Int) -> Int {
+  if location_valid(idx) == 1 {
+    if idx == 0 { 2 } else {
+      if idx == 1 { 8 } else {
+        if idx == 2 { 4 } else {
+          if idx == 3 { 4 } else {
+            if idx == 4 { 3 } else {
+              if idx == 5 { 4 } else {
+                if idx == 6 { 3 } else {
+                  if idx == 7 { 3 } else {
+                    if idx == 8 { 2 } else { 1 }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  } else { -1 }
+}

--- a/proposals/idaptik/migrated/LocationData/locationdata.config.mjs
+++ b/proposals/idaptik/migrated/LocationData/locationdata.config.mjs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for LocationData.affine (idaptik world-map attribute
+// brain; scalar i32 ABI). The oracle re-derives each function from the ORIGINAL
+// LocationData.res allLocations table (NOT from the .affine) so a codegen
+// regression surfaces as a differential mismatch.
+//
+// The oracle encodes the .res allLocations rows directly: each row's
+// `environment` string -> the binding's ENVIRONMENT ordinal (FIELD=0, CITY=1,
+// DATACENTER=2, LAB=3) and each row's `devicePositions` array -> its length.
+// id->index is the host's job (it owns the id strings), so the brain's domain
+// is the 0..12 row band.
+
+// The 13 rows of LocationData.res allLocations, in declared order:
+//   id, environment string, devicePositions length.
+const ENV = { field: 0, city: 1, datacenter: 2, lab: 3 };
+const rows = [
+  ["field", "field", 2],
+  ["city", "city", 8],
+  ["dmz", "datacenter", 4],
+  ["security", "datacenter", 4],
+  ["scada", "datacenter", 3],
+  ["lab", "lab", 4],
+  ["atlas", "datacenter", 3],
+  ["nexus", "datacenter", 3],
+  ["devhub", "datacenter", 2],
+  ["rural-isp", "datacenter", 1],
+  ["business-isp", "datacenter", 1],
+  ["regional-isp", "datacenter", 1],
+  ["backbone", "datacenter", 1],
+];
+
+const locationValid = (i) => (i >= 0 && i < rows.length ? 1 : 0);
+const environmentKind = (i) => (locationValid(i) ? ENV[rows[i][1]] : -1);
+const deviceCount = (i) => (locationValid(i) ? rows[i][2] : -1);
+
+export default {
+  affine: "LocationData.affine",
+  cases: [
+    {
+      name: "location_count()",
+      export: "location_count",
+      args: [],
+      oracle: () => rows.length,
+    },
+    {
+      name: "location_valid over idx[-3..16]",
+      export: "location_valid",
+      args: [[-3, 16]],
+      oracle: (i) => locationValid(i),
+    },
+    {
+      name: "environment_kind over idx[-3..16]",
+      export: "environment_kind",
+      args: [[-3, 16]],
+      oracle: (i) => environmentKind(i),
+    },
+    {
+      name: "device_count over idx[-3..16]",
+      export: "device_count",
+      args: [[-3, 16]],
+      oracle: (i) => deviceCount(i),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/MissionBriefing/MissionBriefing.affine
+++ b/proposals/idaptik/migrated/MissionBriefing/MissionBriefing.affine
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// MissionBriefing -- the mission-progression co-processor, the pure-integer core
+// re-decomposed from src/app/narrative/MissionBriefing.res (the completion /
+// objective-state / difficulty arithmetic) and src/app/screens/LevelConfig.res
+// (getGuardCountForDifficulty). Per the DESIGN-VISION ("AffineScript is the
+// brain, JS/Pixi the senses; only primitives cross the wasm boundary"), every
+// briefing / debrief / objective STRING, the marker glyphs, the optional/hidden
+// boolean filters, and the FOLD of the mutable objective array into integer
+// counts remain host senses on MissionBriefingCoprocessorBridge.js. What crosses
+// is exactly the deterministic arithmetic those ReScript switches and folds
+// bury: the difficulty ordinal and its derived guard count and threshold test,
+// the objective-state predicates, the completion test and progress percentage
+// over host-supplied counts, and the per-mission par time and S-grade alert
+// budget. The kernel is stateless and total: every Int the boundary admits
+// yields a defined Int, never a trap.
+//
+//## Why this split, not a port of completeObjective / formatObjectives
+// completeObjective mutates an objective record; formatObjectives builds a
+// glyph string per objective; getMission/getFile filter a record array by a
+// string id. The records, the strings, and the mutable `state` field are
+// senses. The arithmetic that remains -- "is this state Completed?", "are all
+// required objectives done given (completed,total)?", "what percent?", "what is
+// this difficulty's guard count and par/alert budget?" -- is the brain. The host
+// folds its objective array into the two counts the brain consumes; the brain
+// never sees the array.
+//
+//## Difficulty encoding (the header contract for the JS host)
+// The bridge collapses the `difficulty` variant (Tutorial..Expert) to a 1-based
+// ordinal (DIFFICULTY in the bridge):
+//   1 Tutorial   2 Easy   3 Normal   4 Hard   5 Expert
+// An ordinal outside 1..5 is not a difficulty: difficulty_value and
+// guard_count_for_difficulty return 0 (the neutral off-domain reading), never a
+// fabricated in-band figure.
+//
+//## Objective-state encoding (the header contract for the JS host)
+// The bridge collapses the `objectiveState` variant to a 0-based ordinal
+// (OBJECTIVE_STATE in the bridge), matching the ReScript constructor order:
+//   0 Pending   1 InProgress   2 Completed   3 Failed
+// The three predicates partition the band: is_completed is true only at 2,
+// is_terminal at {2,3} (settled), is_active at {0,1} (still in play). An
+// out-of-band ordinal is none of the three (all return 0).
+//
+//## Mission-index encoding (the header contract for the JS host)
+// par_time_sec / max_alert_for_s / qualifies_s_alert take a 1-based mission
+// index 1..5 over the five-mission database (the missions array order):
+//   idx  mission       par(s)  maxAlertForS
+//    1   m01_downtown    300        0
+//    2   m02_dmz         480        1
+//    3   m03_security    600        2
+//    4   m04_scada       900        1
+//    5   m05_backbone   1200        0
+// par_time_sec is a Float in the ReScript original (300.0 ..) but every value is
+// a whole second, so it crosses as raw Int -- no scaling needed. An off-domain
+// index yields par 0 and an S-budget of the out-of-band sentinel -1 (never an
+// in-band 0..2 alert level, so an unknown mission can never masquerade as a real
+// alert budget). mission_count is the constant database length.
+
+// The number of missions in the database (the missions array length).
+pub fn mission_count() -> Int { 5 }
+
+// The numeric ordinal of a difficulty: identity on a valid 1..5 ordinal, 0
+// off-domain. Mirrors the bridge's `difficultyValue` (and the variant->ordinal
+// collapse on the ReScript side).
+pub fn difficulty_value(difficulty: Int) -> Int {
+  if difficulty < 1 { return 0; }
+  if difficulty > 5 { return 0; }
+  difficulty
+}
+
+// The balanced guard count for a difficulty ordinal (LevelConfig tuning, the
+// pure-ReScript switch in getGuardCountForDifficulty updated 2026-03-16):
+//   Tutorial 1, Easy 2, Normal 2, Hard 3, Expert 2.
+// An off-domain ordinal yields 0 (no guards fabricated for a non-difficulty).
+pub fn guard_count_for_difficulty(difficulty: Int) -> Int {
+  if difficulty == 1 { return 1; }   // Tutorial
+  if difficulty == 2 { return 2; }   // Easy   (was 3 -- matches DMZ config)
+  if difficulty == 3 { return 2; }   // Normal (was 5 -- matches Security config)
+  if difficulty == 4 { return 3; }   // Hard   (was 8 -- matches SCADA config)
+  if difficulty == 5 { return 2; }   // Expert (matches Backbone config v3)
+  0
+}
+
+// Whether a mission's difficulty meets a minimum-difficulty threshold. Both are
+// 1..5 ordinals; the comparison is the natural ordinal order. 1 = meets, 0 = not.
+// Off-domain inputs simply compare as their raw integers (the host only ever
+// passes in-band ordinals); the predicate stays total.
+pub fn difficulty_meets(difficulty: Int, min_difficulty: Int) -> Int {
+  if difficulty >= min_difficulty { 1 } else { 0 }
+}
+
+// Whether an objective-state ordinal is Completed (2). 1 = yes, 0 = no.
+pub fn is_completed(state: Int) -> Int {
+  if state == 2 { 1 } else { 0 }
+}
+
+// Whether an objective-state ordinal is terminal -- Completed (2) or Failed (3).
+// 1 = settled, 0 = still in play or off-domain.
+pub fn is_terminal(state: Int) -> Int {
+  if state == 2 { return 1; }
+  if state == 3 { return 1; }
+  0
+}
+
+// Whether an objective-state ordinal is still in play -- Pending (0) or
+// InProgress (1). 1 = in play, 0 = settled or off-domain.
+pub fn is_active(state: Int) -> Int {
+  if state == 0 { return 1; }
+  if state == 1 { return 1; }
+  0
+}
+
+// Whether a mission is complete: every required objective is Completed, i.e. the
+// completed-required count has reached the total-required count, and there is at
+// least one required objective. The host folds its mutable objective array into
+// the two counts. 1 = complete, 0 = not. A non-positive total (no required
+// objectives) reads as not-complete -- the conservative reading, matching the
+// ReScript `Array.every` over an empty filter being vacuously true only when the
+// fold supplies total > 0 (the missions all carry >= 4 required objectives).
+pub fn is_complete(completed: Int, req_total: Int) -> Int {
+  if req_total <= 0 { return 0; }
+  if completed >= req_total { return 1; }
+  0
+}
+
+// The integer completion percentage 0..100 over the required objectives:
+// floor(completed * 100 / total). A non-positive total yields 0 (no progress on
+// an empty required set). The product is taken before the divide so the floor
+// matches an integer percentage rather than compounding two truncations.
+pub fn progress_percent(completed: Int, req_total: Int) -> Int {
+  if req_total <= 0 { return 0; }
+  completed * 100 / req_total
+}
+
+// The target time in whole seconds for a mission's grade calculation, by 1-based
+// mission index 1..5. The ReScript values are Float but whole seconds, so they
+// cross as raw Int. Off-domain index -> 0 (no par time).
+pub fn par_time_sec(mission_index: Int) -> Int {
+  if mission_index == 1 { return 300; }    // m01_downtown
+  if mission_index == 2 { return 480; }    // m02_dmz
+  if mission_index == 3 { return 600; }    // m03_security
+  if mission_index == 4 { return 900; }    // m04_scada
+  if mission_index == 5 { return 1200; }   // m05_backbone
+  0
+}
+
+// The maximum alert level at which a run still earns the S grade, by 1-based
+// mission index 1..5 (the maxAlertForS field of each mission). Off-domain index
+// -> the out-of-band sentinel -1, which is not an in-band 0..2 alert level, so an
+// unknown mission never masquerades as a real S-grade budget.
+pub fn max_alert_for_s(mission_index: Int) -> Int {
+  if mission_index == 1 { return 0; }      // m01_downtown
+  if mission_index == 2 { return 1; }      // m02_dmz
+  if mission_index == 3 { return 2; }      // m03_security
+  if mission_index == 4 { return 1; }      // m04_scada
+  if mission_index == 5 { return 0; }      // m05_backbone
+  -1
+}
+
+// Whether a run's observed peak alert level qualifies for the S grade on a
+// mission: the peak is within the mission's S-grade alert budget. 1 = qualifies,
+// 0 = not (including any off-domain mission, whose budget is the -1 sentinel that
+// no non-negative peak can fall within).
+pub fn qualifies_s_alert(mission_index: Int, peak_alert: Int) -> Int {
+  let budget = max_alert_for_s(mission_index);
+  if budget < 0 { return 0; }
+  if peak_alert <= budget { 1 } else { 0 }
+}

--- a/proposals/idaptik/migrated/MissionBriefing/missionbriefing.config.mjs
+++ b/proposals/idaptik/migrated/MissionBriefing/missionbriefing.config.mjs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for MissionBriefing.affine (idaptik mission-progression
+// co-processor; scalar i32 ABI). The oracles re-derive each closed band / count
+// in plain JS -- independently of the .affine source -- so a codegen regression
+// surfaces as a differential mismatch. The contract is the bridge's
+// (MissionBriefingCoprocessorBridge.js) integer surface: difficulty 1..5,
+// objective-state 0..3, 1-based mission index 1..5.
+
+// Independent re-derivations of the per-mission tables (missions array order).
+const PAR = { 1: 300, 2: 480, 3: 600, 4: 900, 5: 1200 };
+const MAXS = { 1: 0, 2: 1, 3: 2, 4: 1, 5: 0 };
+// Independent re-derivation of the LevelConfig guard-count tuning.
+const GUARDS = { 1: 1, 2: 2, 3: 2, 4: 3, 5: 2 };
+
+export default {
+  affine: "MissionBriefing.affine",
+  cases: [
+    {
+      name: "mission_count()",
+      export: "mission_count",
+      args: [],
+      oracle: () => 5,
+    },
+    {
+      name: "difficulty_value over [-2..8]",
+      export: "difficulty_value",
+      args: [[-2, 8]],
+      oracle: (d) => (d >= 1 && d <= 5 ? d : 0),
+    },
+    {
+      name: "guard_count_for_difficulty over [-2..8]",
+      export: "guard_count_for_difficulty",
+      args: [[-2, 8]],
+      oracle: (d) => GUARDS[d] ?? 0,
+    },
+    {
+      name: "difficulty_meets over [1..5] x [1..5]",
+      export: "difficulty_meets",
+      args: [[1, 5], [1, 5]],
+      oracle: (d, min) => (d >= min ? 1 : 0),
+    },
+    {
+      name: "is_completed over [-1..5]",
+      export: "is_completed",
+      args: [[-1, 5]],
+      oracle: (s) => (s === 2 ? 1 : 0),
+    },
+    {
+      name: "is_terminal over [-1..5]",
+      export: "is_terminal",
+      args: [[-1, 5]],
+      oracle: (s) => (s === 2 || s === 3 ? 1 : 0),
+    },
+    {
+      name: "is_active over [-1..5]",
+      export: "is_active",
+      args: [[-1, 5]],
+      oracle: (s) => (s === 0 || s === 1 ? 1 : 0),
+    },
+    {
+      name: "is_complete over [0..7] completed x [-1..7] total",
+      export: "is_complete",
+      args: [[0, 7], [-1, 7]],
+      oracle: (completed, total) => (total <= 0 ? 0 : completed >= total ? 1 : 0),
+    },
+    {
+      name: "progress_percent over [0..7] completed x [-1..7] total",
+      export: "progress_percent",
+      args: [[0, 7], [-1, 7]],
+      oracle: (completed, total) => (total <= 0 ? 0 : Math.floor((completed * 100) / total)),
+    },
+    {
+      name: "par_time_sec over [-1..7]",
+      export: "par_time_sec",
+      args: [[-1, 7]],
+      oracle: (i) => PAR[i] ?? 0,
+    },
+    {
+      name: "max_alert_for_s over [-1..7]",
+      export: "max_alert_for_s",
+      args: [[-1, 7]],
+      oracle: (i) => (i in MAXS ? MAXS[i] : -1),
+    },
+    {
+      name: "qualifies_s_alert over [-1..7] index x [-1..4] peak",
+      export: "qualifies_s_alert",
+      args: [[-1, 7], [-1, 4]],
+      oracle: (i, peak) => {
+        const budget = i in MAXS ? MAXS[i] : -1;
+        if (budget < 0) return 0;
+        return peak <= budget ? 1 : 0;
+      },
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/PlayTimeSplit/PlayTimeSplit.affine
+++ b/proposals/idaptik/migrated/PlayTimeSplit/PlayTimeSplit.affine
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// PlayTimeSplit -- the play-time decomposition brain, the pure-integer core
+// extracted from idaptik src/app/verisimdb/SaveGame.res `formatPlayTime`
+// (SaveGame.res:257-266). Per the DESIGN-VISION ("AffineScript is the brain,
+// JS/Pixi the senses; only primitives cross the wasm boundary") the JS host
+// keeps the elapsed-seconds Float, the localStorage save metadata, the Pixi
+// Text draw, and the "Xh Ym" / "Ym" string interpolation; AffineScript owns
+// only the integer hour/minute decomposition of a whole-minute count and the
+// caption-branch flag.
+//
+//## Why this is the separable Int sub-brain (not the whole formatPlayTime)
+// formatPlayTime first does `totalMinutes = Float.toInt(seconds /. 60.0)` -- a
+// FLOAT input that cannot cross the scalar-i32 boundary, so that truncation
+// stays host-side (it is the canonical verisimprovenrenderlogic.wasm's
+// `play_time_total_minutes`, which takes Float). What is LEFT once total
+// minutes is in hand is pure Int->Int: hours = totalMinutes / 60, minutes =
+// totalMinutes % 60, and the "show hours?" branch hours > 0. That integer core
+// is lifted here and is exactly harness-compatible (every argument an Int).
+//
+//## Re-decomposition of SaveGame.formatPlayTime
+// The ReScript original computes, in order, on a non-negative play-time:
+//   totalMinutes = Float.toInt(seconds /. 60.0)   // host-side (Float in)
+//   hours        = totalMinutes / 60               // integer division
+//   minutes      = Int.mod(totalMinutes, 60)       // JS % remainder
+//   caption       = hours > 0 ? "{h}h {m}m" : "{m}m"
+// Integer `/` and `%` here truncate toward zero, matching ReScript's int `/`
+// and Int.mod for the NON-NEGATIVE minute counts a play-time ever produces. A
+// play-time is never negative (it accumulates from zero), so a negative input
+// is not a valid play-time: it is rejected with the out-of-band sentinel -1
+// rather than silently decomposed (a guard, per rule 5; -1 is never a valid
+// hour or minute component, so the host can tell a rejection from a real
+// value). The host owns the string assembly; the caption it builds from these
+// integer components is byte-identical to the ReScript original.
+//
+//## Boundary contract (the header the JS host relies on)
+//   play_time_minutes_valid(total_minutes) -> Int   1 if total_minutes >= 0 else 0
+//   play_time_hours(total_minutes) -> Int           total_minutes / 60, or -1 if invalid
+//   play_time_minutes(total_minutes) -> Int         total_minutes % 60, or -1 if invalid
+//   play_time_has_hours(total_minutes) -> Int       1 when hours > 0 else 0 (0 if invalid)
+// Every value crosses as i32 in and i32 out; no strings, dicts or effects cross.
+// The number of minutes in one hour, the single magic constant of the split.
+pub fn minutes_per_hour() -> Int { 60 }
+
+// Whether a whole-minute count names a valid (non-negative) play-time.
+// 1 = valid, 0 = out of band. A play-time accumulates from zero, so it is never
+// negative; a negative count is host error, not a real elapsed time.
+pub fn play_time_minutes_valid(total_minutes: Int) -> Int {
+  if total_minutes < 0 { 0 } else { 1 }
+}
+
+// Hours component of a play-time: total_minutes / 60 (integer division,
+// truncating toward zero). The out-of-band sentinel -1 on a negative count,
+// which is never a valid hours component, so the host distinguishes rejection
+// from a real value (a guard, not a clamp -- assail stays clean).
+pub fn play_time_hours(total_minutes: Int) -> Int {
+  if play_time_minutes_valid(total_minutes) == 1 {
+    total_minutes / 60
+  } else {
+    0 - 1
+  }
+}
+
+// Minutes component of a play-time: total_minutes % 60 (the JS remainder; for a
+// non-negative count this is the in-hour minute in 0..59). The out-of-band
+// sentinel -1 on a negative count.
+pub fn play_time_minutes(total_minutes: Int) -> Int {
+  if play_time_minutes_valid(total_minutes) == 1 {
+    total_minutes % 60
+  } else {
+    0 - 1
+  }
+}
+
+// Caption branch: 1 when the host should render "{h}h {m}m" (hours > 0), else 0
+// ("{m}m"). On an invalid (negative) count there are no hours to show, so 0.
+pub fn play_time_has_hours(total_minutes: Int) -> Int {
+  if play_time_minutes_valid(total_minutes) == 1 {
+    let hours = total_minutes / 60;
+    if hours > 0 { 1 } else { 0 }
+  } else {
+    0
+  }
+}

--- a/proposals/idaptik/migrated/PlayTimeSplit/playtimesplit.config.mjs
+++ b/proposals/idaptik/migrated/PlayTimeSplit/playtimesplit.config.mjs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for PlayTimeSplit.affine (idaptik save-slot play-time
+// decomposition; scalar i32 ABI). The oracle re-derives the hour/minute split
+// of SaveGame.formatPlayTime in plain JS, keyed by the whole-minute count, so a
+// codegen regression in integer `/` or `%` surfaces as a differential mismatch.
+//
+// Brain contract: input is total whole minutes (the host has already done the
+// Float `trunc(seconds / 60)`); output is the integer hours/minutes components
+// and the caption-branch flag. A negative count is not a valid play-time and
+// rejects with the out-of-band sentinel -1 (components) / 0 (flags).
+
+// Independent re-implementation of the formatPlayTime integer core.
+const valid = (m) => m >= 0;
+// hours = total_minutes / 60, truncating toward zero (JS Math.trunc; for the
+// non-negative in-band domain this equals plain integer division).
+const hours = (m) => (valid(m) ? Math.trunc(m / 60) : -1);
+// minutes = total_minutes % 60 (JS remainder; 0..59 for non-negative m).
+const minutes = (m) => (valid(m) ? m % 60 : -1);
+// caption branch: show hours iff hours > 0.
+const hasHours = (m) => (valid(m) && Math.trunc(m / 60) > 0 ? 1 : 0);
+
+export default {
+  affine: "PlayTimeSplit.affine",
+  cases: [
+    {
+      name: "minutes_per_hour()",
+      export: "minutes_per_hour",
+      args: [],
+      oracle: () => 60,
+    },
+    {
+      name: "play_time_minutes_valid over [-5..200]",
+      export: "play_time_minutes_valid",
+      args: [[-5, 200]],
+      oracle: (m) => (valid(m) ? 1 : 0),
+    },
+    {
+      // Sweep across several hours plus the negative-reject band. 605 minutes
+      // exercises the 10h05m save-slot caption; -5..-1 exercises the sentinel.
+      name: "play_time_hours over [-5..605]",
+      export: "play_time_hours",
+      args: [[-5, 605]],
+      oracle: hours,
+    },
+    {
+      name: "play_time_minutes over [-5..605]",
+      export: "play_time_minutes",
+      args: [[-5, 605]],
+      oracle: minutes,
+    },
+    {
+      name: "play_time_has_hours over [-5..605]",
+      export: "play_time_has_hours",
+      args: [[-5, 605]],
+      oracle: hasHours,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/SkillTreeScreen/SkillTreeScreen.affine
+++ b/proposals/idaptik/migrated/SkillTreeScreen/SkillTreeScreen.affine
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// SkillTreeScreen -- the pure-integer XP-threshold brain extracted from
+// src/app/screens/SkillTreeScreen.res (xpForNextRank). The screen is senses:
+// the seven branching skill rows, the per-rank colour ints and rank/category
+// display STRINGS, the ability-node circles, the connector lines, the XP-bar
+// Graphics, the Storage.getString("jessica-class") read and every Pixi draw.
+// Per the DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), every string and Pixi object stays
+// host-side; AffineScript owns only the rank -> next-XP-threshold classification
+// that drives the progress bar's denominator.
+//
+// RE-DECOMPOSITION. The ReScript switches on the `skillRank` variant
+// (Novice | Trained | Proficient | Veteran | Expert) to a threshold int. We
+// re-decompose the variant as its 0..4 ascending ordinal -- the canonical
+// rank order the .res `rankOrder` array and `rankMeetsRequirement` already
+// impose (Novice < Trained < Proficient < Veteran < Expert). The variant IS
+// the ordinal; no rank strings cross. The XP-bar FILL fraction (xp/threshold)
+// is a float and stays host-side (it is a sense); the brain owns only the
+// integer threshold the fraction divides by, and the integer "is this rank
+// the maxed top" classification.
+//
+//## Rank ordinal encoding (the header contract for the JS host)
+//   ord  rank          ord  rank
+//     0  Novice          3  Veteran
+//     1  Trained         4  Expert (maxed)
+//     2  Proficient
+//   A rank ordinal outside 0..4 is not a defined rank: skill_rank_valid
+//   reports 0, and xp_for_next_rank returns the out-of-band sentinel -1 (never
+//   an in-band threshold), so an off-domain rank cannot manufacture a real
+//   threshold. -1 is a sentinel, not a clamp (assail stays clean).
+//
+//## XP-threshold contract (the second contract, for the progress bar)
+//   The next-rank XP thresholds, verbatim from the .res xpForNextRank:
+//     Novice -> 100, Trained -> 350, Proficient -> 800, Veteran -> 1500,
+//     Expert -> 1500 (already maxed: the .res returns 1500 as a no-op cap).
+//   xp_for_next_rank(ord) returns the threshold for a valid ord, else -1.
+//   These are the .res XP-threshold comment's 0 / 100 / 350 / 800 / 1500 ladder
+//   read as "threshold for the NEXT rank up from the current one".
+//
+// PURE: integers only, no floats, no strings, no arrays, no effects, no I/O.
+
+//## The number of skill ranks (Novice..Expert).
+pub fn skill_rank_count() -> Int { 5 }
+
+//## Whether a host integer names a defined skill rank. 1 = valid, 0 = out of band.
+pub fn skill_rank_valid(rank: Int) -> Int {
+  if rank < 0 { 0 } else { if rank > 4 { 0 } else { 1 } }
+}
+
+//## The XP threshold for the next rank above the given rank ordinal. Mirrors
+// xpForNextRank: Novice 100, Trained 350, Proficient 800, Veteran 1500, Expert
+// 1500 (maxed cap). An off-domain rank yields the out-of-band sentinel -1.
+pub fn xp_for_next_rank(rank: Int) -> Int {
+  if skill_rank_valid(rank) == 1 {
+    if rank == 0 { 100 } else {
+      if rank == 1 { 350 } else {
+        if rank == 2 { 800 } else {
+          if rank == 3 { 1500 } else { 1500 }
+        }
+      }
+    }
+  } else { -1 }
+}
+
+//## Whether a rank is the maxed top rank (Expert, ordinal 4): 1 if so, else 0.
+// A non-Expert valid rank still has a real next threshold; the .res shows this
+// as Expert's threshold being a no-op (its own cap). Off-domain ranks are 0.
+pub fn skill_rank_is_maxed(rank: Int) -> Int {
+  if rank == 4 { 1 } else { 0 }
+}
+
+//## The XP-bar fill, expressed as an integer permille (0..1000), so the float
+// xp/threshold of the .res crosses the boundary as a scaled Int. Mirrors
+// `fillPct = xp / threshold` then the `Math.min(.., barW)` clamp: the permille
+// is xp * 1000 / threshold, capped at 1000 (full bar). A non-positive or
+// off-domain threshold means "already full" -> 1000 (the .res `else 1.0` arm).
+// A negative xp clamps up to 0 (an empty bar can never be negative).
+pub fn xp_fill_permille(xp: Int, threshold: Int) -> Int {
+  if threshold <= 0 { 1000 } else {
+    let clamped_xp = if xp < 0 { 0 } else { xp };
+    let raw = clamped_xp * 1000 / threshold;
+    if raw > 1000 { 1000 } else { raw }
+  }
+}

--- a/proposals/idaptik/migrated/SkillTreeScreen/skilltreescreen.config.mjs
+++ b/proposals/idaptik/migrated/SkillTreeScreen/skilltreescreen.config.mjs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for SkillTreeScreen.affine (idaptik XP-threshold brain;
+// scalar i32 ABI). The oracle re-derives each function from the ORIGINAL
+// SkillTreeScreen.res semantics (NOT from the .affine) so a codegen regression
+// surfaces as a differential mismatch.
+//
+// From SkillTreeScreen.res xpForNextRank (lines 61-69):
+//   Novice => 100 | Trained => 350 | Proficient => 800
+//   Veteran => 1500 | Expert => 1500  (// Already maxed)
+// Rank variant Novice/Trained/Proficient/Veteran/Expert maps to ordinals
+// 0/1/2/3/4 (the rankOrder/rankMeetsRequirement ascending order).
+//
+// From the XP-bar fill (lines 211-218 / 309-314):
+//   let fillPct = if threshold > 0 { xp/threshold } else { 1.0 }
+//   let fillWidth = Math.min(fillPct * barW, barW)
+// Expressed here as an integer permille (fraction * 1000) so it crosses as i32:
+//   threshold <= 0  -> 1000 (the else-1.0 branch, i.e. full bar)
+//   else            -> min( trunc(max(xp,0) * 1000 / threshold), 1000 )
+// The max(xp,0) guards an empty bar from going negative; the min caps a full
+// bar at 1000, matching Math.min(.., barW).
+
+// Independent re-derivation of the rank validity from the .res ordinal domain.
+const rankValid = (r) => (r >= 0 && r <= 4 ? 1 : 0);
+
+// Independent re-derivation of xpForNextRank from the .res.
+const xpForNextRank = (r) => {
+  if (!rankValid(r)) return -1;
+  return [100, 350, 800, 1500, 1500][r];
+};
+
+// Independent re-derivation of "is the maxed top rank" (Expert == ordinal 4).
+const isMaxed = (r) => (r === 4 ? 1 : 0);
+
+// Independent re-derivation of the XP-bar fill permille from the .res.
+const fillPermille = (xp, threshold) => {
+  if (threshold <= 0) return 1000;
+  const clampedXp = xp < 0 ? 0 : xp;
+  const raw = Math.trunc((clampedXp * 1000) / threshold);
+  return raw > 1000 ? 1000 : raw;
+};
+
+export default {
+  affine: "SkillTreeScreen.affine",
+  cases: [
+    {
+      name: "skill_rank_count()",
+      export: "skill_rank_count",
+      args: [],
+      oracle: () => 5,
+    },
+    {
+      name: "skill_rank_valid over rank[-3..8]",
+      export: "skill_rank_valid",
+      args: [[-3, 8]],
+      oracle: (r) => rankValid(r),
+    },
+    {
+      name: "xp_for_next_rank over rank[-3..8]",
+      export: "xp_for_next_rank",
+      args: [[-3, 8]],
+      oracle: (r) => xpForNextRank(r),
+    },
+    {
+      name: "xp_for_next_rank exact ranks 0..4",
+      export: "xp_for_next_rank",
+      args: [{ values: [0, 1, 2, 3, 4] }],
+      oracle: (r) => xpForNextRank(r),
+    },
+    {
+      name: "skill_rank_is_maxed over rank[-3..8]",
+      export: "skill_rank_is_maxed",
+      args: [[-3, 8]],
+      oracle: (r) => isMaxed(r),
+    },
+    {
+      // xp swept against each real threshold + the maxed/zero edge cases.
+      name: "xp_fill_permille over (xp[-50..1600 sample], threshold{thresholds})",
+      export: "xp_fill_permille",
+      args: [
+        { values: [-50, 0, 1, 50, 100, 175, 350, 700, 800, 1499, 1500, 1600] },
+        { values: [0, -10, 100, 350, 800, 1500] },
+      ],
+      oracle: (xp, t) => fillPermille(xp, t),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/VeriSimError/VeriSimError.affine
+++ b/proposals/idaptik/migrated/VeriSimError/VeriSimError.affine
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// VeriSimError -- the HTTP-status error-classification brain, the pure-integer
+// core extracted from idaptik src/app/verisimdb/VeriSimError.res `fromStatus`
+// and `isRetryable`. Per the DESIGN-VISION ("AffineScript is the brain, the
+// host the senses; only primitives cross the wasm boundary") the ReScript host
+// keeps every human-readable message String, the variant payloads and the
+// `message` interpolation; AffineScript owns only the integer mapping from an
+// HTTP status code to the canonical error CATEGORY and the retry decision over
+// that category.
+//
+//## Why this is the separable Int sub-brain (not the whole VeriSimError module)
+// VeriSimError.res is a 20-constructor variant, each arm carrying a String, plus
+// three functions: `message` (variant -> String render -- pure host text, no
+// scalar maths), `fromStatus` (HTTP status Int -> variant) and `isRetryable`
+// (variant -> Bool). The String render cannot and should not cross the i32
+// boundary. What is pure-integer is the CLASSIFICATION skeleton underneath:
+// fromStatus is really `status code -> category ordinal`, and isRetryable is
+// really `category ordinal -> bool`. Those two Int->Int maps are lifted here;
+// the host re-attaches the per-category default message String (the existing
+// in-place VeriSimError.affine keeps the String arms) so the rendered error is
+// byte-identical. This integer core is exactly harness-compatible.
+//
+//## Category encoding (the header contract for the host)
+// The ordinals are the VeriSimError.res variant declaration order, so the host
+// round-trips category <-> ordinal with no collision (the same flat closed-band
+// shape DeviceType.affine and ThreatClass.affine use):
+//   ord  category                ord  category
+//     0  BadRequest (400)         10  ModalityUnavailable
+//     1  Unauthorized (401)       11  DriftComputationError
+//     2  Forbidden (403)          12  ProvenanceInvalid
+//     3  NotFound (404)           13  VclParseError
+//     4  Conflict (409)           14  VclExecutionError
+//     5  ValidationFailed (422)   15  FederationError
+//     6  RateLimited (429)        16  ConnectionError
+//     7  InternalError (500)      17  TimeoutError
+//     8  ServiceUnavailable (503) 18  SerializationError
+//     9  HexadNotFound            19  UnknownError
+// Only the nine status-reachable categories (0..8) and the catch-all 19 are
+// produced by classify_status; the domain-specific (9..15) and remaining
+// client-side (16..18) categories are constructed by the host directly, never
+// from a status code, exactly as the ReScript fromStatus switch does.
+
+// The number of canonical error categories in the taxonomy.
+pub fn error_category_count() -> Int { 20 }
+
+// Whether a host integer names a defined error category. 1 = valid, 0 = out of
+// band. Lets the host validate a category ordinal before re-attaching its
+// message String.
+pub fn is_valid_error_category(ord: Int) -> Int {
+  if ord < 0 { 0 } else { if ord > 19 { 0 } else { 1 } }
+}
+
+// Classify an HTTP status code into its error-category ordinal, reproducing
+// VeriSimError.res fromStatus exactly: the nine mapped codes go to their
+// category ordinal, and every other code (the `code => UnknownError` arm) goes
+// to UnknownError (19). This is a total map over all Int; an unmapped code is
+// not a sentinel collapse but the genuine UnknownError category the original
+// returns, so assail stays clean (flat early-return ladder, no out-of-band arm).
+pub fn classify_status(status: Int) -> Int {
+  if status == 400 { return 0; }
+  if status == 401 { return 1; }
+  if status == 403 { return 2; }
+  if status == 404 { return 3; }
+  if status == 409 { return 4; }
+  if status == 422 { return 5; }
+  if status == 429 { return 6; }
+  if status == 500 { return 7; }
+  if status == 503 { return 8; }
+  19
+}
+
+// Whether an error CATEGORY ordinal is retryable, reproducing isRetryable
+// exactly: RateLimited (6), InternalError (7), ServiceUnavailable (8),
+// ConnectionError (16) and TimeoutError (17) are retryable; every other
+// category is not. 1 = retry safe, 0 = do not retry. On an out-of-band ordinal
+// (not a real category) the conservative answer is 0 (do not retry).
+pub fn is_category_retryable(ord: Int) -> Int {
+  if is_valid_error_category(ord) == 0 { return 0; }
+  if ord == 6 { return 1; }
+  if ord == 7 { return 1; }
+  if ord == 8 { return 1; }
+  if ord == 16 { return 1; }
+  if ord == 17 { return 1; }
+  0
+}
+
+// Convenience composition: whether an HTTP status code is retryable, classifying
+// then deciding in one call (the host's common path -- it has a status code, not
+// a category, at the response boundary). 1 = retry safe, 0 = do not retry.
+pub fn is_status_retryable(status: Int) -> Int {
+  is_category_retryable(classify_status(status))
+}

--- a/proposals/idaptik/migrated/VeriSimError/verisimerror.config.mjs
+++ b/proposals/idaptik/migrated/VeriSimError/verisimerror.config.mjs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for VeriSimError.affine (idaptik VeriSimDB client error
+// classification; scalar i32 ABI). The oracle re-derives fromStatus and
+// isRetryable from VeriSimError.res semantics in plain JS, keyed by the variant
+// declaration ordinal, so a codegen regression surfaces as a differential
+// mismatch.
+//
+// Category ordinals (VeriSimError.res variant declaration order):
+//   0 BadRequest 1 Unauthorized 2 Forbidden 3 NotFound 4 Conflict
+//   5 ValidationFailed 6 RateLimited 7 InternalError 8 ServiceUnavailable
+//   9 HexadNotFound 10 ModalityUnavailable 11 DriftComputationError
+//   12 ProvenanceInvalid 13 VclParseError 14 VclExecutionError 15 FederationError
+//   16 ConnectionError 17 TimeoutError 18 SerializationError 19 UnknownError
+
+// Independent re-implementation of VeriSimError.res fromStatus, as a status->ord
+// lookup. Any status not in the table is UnknownError (19), matching the
+// `code => UnknownError(...)` catch-all arm.
+const STATUS_TO_ORD = {
+  400: 0,
+  401: 1,
+  403: 2,
+  404: 3,
+  409: 4,
+  422: 5,
+  429: 6,
+  500: 7,
+  503: 8,
+};
+const classifyStatus = (status) =>
+  Object.prototype.hasOwnProperty.call(STATUS_TO_ORD, status)
+    ? STATUS_TO_ORD[status]
+    : 19;
+
+// Independent re-implementation of VeriSimError.res isRetryable, as the set of
+// retryable category ordinals: RateLimited, InternalError, ServiceUnavailable,
+// ConnectionError, TimeoutError.
+const RETRYABLE = new Set([6, 7, 8, 16, 17]);
+const validCategory = (ord) => ord >= 0 && ord <= 19;
+const isCategoryRetryable = (ord) =>
+  validCategory(ord) && RETRYABLE.has(ord) ? 1 : 0;
+const isStatusRetryable = (status) => isCategoryRetryable(classifyStatus(status));
+
+export default {
+  affine: "VeriSimError.affine",
+  cases: [
+    {
+      name: "error_category_count()",
+      export: "error_category_count",
+      args: [],
+      oracle: () => 20,
+    },
+    {
+      name: "is_valid_error_category over [-3..25]",
+      export: "is_valid_error_category",
+      args: [[-3, 25]],
+      oracle: (ord) => (validCategory(ord) ? 1 : 0),
+    },
+    {
+      // Sweep the whole 4xx/5xx band plus unmapped codes (e.g. 200, 418, 599)
+      // so both the nine hits and the UnknownError catch-all are exercised.
+      name: "classify_status over [200..599]",
+      export: "classify_status",
+      args: [[200, 599]],
+      oracle: classifyStatus,
+    },
+    {
+      name: "is_category_retryable over categories [-3..25]",
+      export: "is_category_retryable",
+      args: [[-3, 25]],
+      oracle: isCategoryRetryable,
+    },
+    {
+      name: "is_status_retryable over [200..599]",
+      export: "is_status_retryable",
+      args: [[200, 599]],
+      oracle: isStatusRetryable,
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/VeriSimModality/VeriSimModality.affine
+++ b/proposals/idaptik/migrated/VeriSimModality/VeriSimModality.affine
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// VeriSimModality -- the VeriSimDB taxonomy brain, the pure-integer core
+// extracted from idaptik src/app/verisimdb/VeriSimTypes.res. Per the
+// DESIGN-VISION ("AffineScript is the brain, the host the senses; only
+// primitives cross the wasm boundary") the ReScript host keeps every modality
+// STRING (modalityToString / modalityFromString) and every wire record;
+// AffineScript owns only the canonical integer encodings of the two closed
+// VeriSimDB taxonomies (the eight data modalities and the five drift levels)
+// plus the ONE genuine client-side classification decision over them.
+//
+//## Why this is the separable Int sub-brain (not the whole VeriSimTypes module)
+// VeriSimTypes.res is overwhelmingly record/variant TYPE definitions plus two
+// string-conversion switches (modalityToString, modalityFromString). The string
+// conversions cannot cross the i32 boundary and stay host-side. What IS
+// pure-integer is the taxonomy skeleton underneath: `modality` is a closed
+// eight-member enum whose constructor order is its canonical 0..7 ordinal, and
+// `driftLevel` is a closed FIVE-member ORDINAL enum (Stable < Low < Moderate <
+// High < Critical) whose order carries severity meaning. Validity over those two
+// bands, and the severity comparison the client uses to decide whether a drift
+// reading is actionable, are lifted here. This integer core is exactly
+// harness-compatible.
+//
+//## Modality encoding (the header contract for the host; VeriSimTypes.res order)
+//   code  modality       code  modality
+//     0   Graph            4   Document
+//     1   Vector           5   Temporal
+//     2   Tensor           6   Provenance
+//     3   Semantic         7   Spatial
+// The encoding is LOSSLESS: eight distinct modalities map to eight distinct
+// codes, so the host round-trips modality <-> code with no collision (the same
+// flat closed-band shape DeviceType.affine uses). A code outside 0..7 is not a
+// modality: is_valid_modality reports 0 and clamp_modality returns the
+// out-of-band sentinel -1 (never an in-band code -- a sentinel, not a clamp).
+//
+//## Drift-level encoding (VeriSimTypes.res driftLevel order -- ORDINAL/ranked)
+//   code  level      meaning
+//     0   Stable     no meaningful divergence
+//     1   Low        minor drift, informational
+//     2   Moderate   drift worth surfacing -- the actionable threshold
+//     3   High       significant divergence
+//     4   Critical   re-normalisation strongly indicated
+// Unlike the modality band this band is TOTALLY ORDERED by severity, so the host
+// can ask "is this at least as severe as Moderate?" -- the single client-side
+// drift decision (everything else, the score itself and the level assignment,
+// is computed server-side and merely received).
+
+// The number of canonical data modalities in the VeriSimDB taxonomy.
+pub fn modality_count() -> Int { 8 }
+
+// Whether a host integer names a defined data modality. 1 = valid, 0 = out of band.
+pub fn is_valid_modality(code: Int) -> Int {
+  if code < 0 { 0 } else { if code > 7 { 0 } else { 1 } }
+}
+
+// Canonicalise a host integer modality: identity on a valid 0..7 code, the
+// out-of-band sentinel -1 otherwise. -1 is not an in-band code, so out-of-band
+// input can never be confused with a real modality (a sentinel, not a clamp).
+pub fn clamp_modality(code: Int) -> Int {
+  if is_valid_modality(code) == 1 { code } else { 0 - 1 }
+}
+
+// The number of drift severity levels.
+pub fn drift_level_count() -> Int { 5 }
+
+// Whether a host integer names a defined drift level. 1 = valid, 0 = out of band.
+pub fn is_valid_drift_level(code: Int) -> Int {
+  if code < 0 { 0 } else { if code > 4 { 0 } else { 1 } }
+}
+
+// Canonicalise a host integer drift level: identity on a valid 0..4 code, the
+// out-of-band sentinel -1 otherwise.
+pub fn clamp_drift_level(code: Int) -> Int {
+  if is_valid_drift_level(code) == 1 { code } else { 0 - 1 }
+}
+
+// Whether a drift level is actionable -- Moderate (2) or more severe. This is the
+// single client-side drift decision: the host uses it to decide whether to
+// surface a re-normalisation prompt. 1 = actionable, 0 = below threshold. On an
+// out-of-band level (not a real drift level) the conservative answer is 0.
+pub fn drift_is_actionable(code: Int) -> Int {
+  if is_valid_drift_level(code) == 0 { return 0; }
+  if code >= 2 { return 1; }
+  0
+}
+
+// Whether a drift level warrants the strongest warning -- Critical (4) only.
+// 1 = critical, 0 = not. Out-of-band rejects to 0.
+pub fn drift_is_critical(code: Int) -> Int {
+  if is_valid_drift_level(code) == 0 { return 0; }
+  if code == 4 { return 1; }
+  0
+}

--- a/proposals/idaptik/migrated/VeriSimModality/verisimmodality.config.mjs
+++ b/proposals/idaptik/migrated/VeriSimModality/verisimmodality.config.mjs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for VeriSimModality.affine (idaptik VeriSimDB taxonomy;
+// scalar i32 ABI). The oracle re-derives the closed modality band, the ordinal
+// drift-level band, and the actionable-drift decision from VeriSimTypes.res
+// semantics in plain JS, so a codegen regression surfaces as a differential
+// mismatch.
+//
+// Modality ordinals (VeriSimTypes.res modality declaration order):
+//   0 Graph 1 Vector 2 Tensor 3 Semantic 4 Document 5 Temporal 6 Provenance 7 Spatial
+// Drift-level ordinals (VeriSimTypes.res driftLevel order, severity-ranked):
+//   0 Stable 1 Low 2 Moderate 3 High 4 Critical
+
+const validModality = (c) => c >= 0 && c <= 7;
+const validDrift = (c) => c >= 0 && c <= 4;
+
+export default {
+  affine: "VeriSimModality.affine",
+  cases: [
+    {
+      name: "modality_count()",
+      export: "modality_count",
+      args: [],
+      oracle: () => 8,
+    },
+    {
+      name: "is_valid_modality over [-3..11]",
+      export: "is_valid_modality",
+      args: [[-3, 11]],
+      oracle: (c) => (validModality(c) ? 1 : 0),
+    },
+    {
+      name: "clamp_modality over [-3..11]",
+      export: "clamp_modality",
+      args: [[-3, 11]],
+      oracle: (c) => (validModality(c) ? c : -1),
+    },
+    {
+      name: "drift_level_count()",
+      export: "drift_level_count",
+      args: [],
+      oracle: () => 5,
+    },
+    {
+      name: "is_valid_drift_level over [-3..8]",
+      export: "is_valid_drift_level",
+      args: [[-3, 8]],
+      oracle: (c) => (validDrift(c) ? 1 : 0),
+    },
+    {
+      name: "clamp_drift_level over [-3..8]",
+      export: "clamp_drift_level",
+      args: [[-3, 8]],
+      oracle: (c) => (validDrift(c) ? c : -1),
+    },
+    {
+      // Actionable iff the level is Moderate(2) or worse, AND in band.
+      name: "drift_is_actionable over [-3..8]",
+      export: "drift_is_actionable",
+      args: [[-3, 8]],
+      oracle: (c) => (validDrift(c) && c >= 2 ? 1 : 0),
+    },
+    {
+      // Critical iff level is exactly Critical(4).
+      name: "drift_is_critical over [-3..8]",
+      export: "drift_is_critical",
+      args: [[-3, 8]],
+      oracle: (c) => (validDrift(c) && c === 4 ? 1 : 0),
+    },
+  ],
+};

--- a/proposals/idaptik/migrated/VictoryScreen/VictoryScreen.affine
+++ b/proposals/idaptik/migrated/VictoryScreen/VictoryScreen.affine
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// VictoryScreen -- the pure-integer performance-grade brain extracted from
+// src/app/screens/VictoryScreen.res (calculateGrade). The screen itself is
+// senses: the green "OPERATION COMPLETE" overlay, the per-grade colour and
+// description STRINGS, the GameI18n.t lookups, the Pixi Text/Graphics draws,
+// the escape-key wiring and the continue-button navigation. Per the
+// DESIGN-VISION ("AffineScript is the brain, JS/Pixi the senses; only
+// primitives cross the wasm boundary"), every string and every Pixi object
+// stays host-side; AffineScript owns only the integer score arithmetic and
+// its banding to a grade ordinal. This is exactly the victoryScore /
+// gradeOrdinal pair the ScreensRunLoopLogicCoprocessor binding already names.
+//
+// RE-DECOMPOSITION. The ReScript runs a `ref(100)` mutable accumulator
+// (score := score.contents - ...). We re-decompose it as a single pure
+// expression over explicit Int params -- no module state, no ref. The only
+// non-Int input in the original is `timeElapsedSec : float`, used solely in
+// two threshold tests (`> 300.0`, `> 600.0`). Seconds granularity is all the
+// thresholds need, so the host truncates the float to whole seconds and hands
+// the brain an Int; the two comparisons then live INSIDE the brain (integer-
+// exact), keeping the whole decision -- and the grade banding -- on this side
+// of the boundary. The grade variant S/A/B/C/D is re-decomposed as its
+// descending 4..0 ordinal (the order the .res switch already implies); the
+// host maps the ordinal back to its colour/description strings.
+//
+//## Score contract (the header contract for the JS host)
+//   Base score is 100. Adjustments (from VictoryScreen.res calculateGrade):
+//     - alert        : score - alert * 15
+//     - time         : score - 10 if time_sec > 300, and a further - 10 if > 600
+//     - covert        : score + covert * 5
+//     - commands     : score - 5 if commands > 100
+//     - crit success : score + crit_succ * 3
+//     - crit failure : score - crit_fail * 5
+//   The score is NOT clamped (the .res does not clamp it either); the banding
+//   below treats anything below 40 as the floor grade D, so a negative score
+//   maps to D just as the .res `else` arm does.
+//
+//## Grade contract (the second contract, for the banding)
+//   victory_grade(score) : the grade ordinal for a score.
+//     score >= 95 -> 4 (S)
+//     score >= 80 -> 3 (A)
+//     score >= 60 -> 2 (B)
+//     score >= 40 -> 1 (C)
+//     otherwise   -> 0 (D)
+//   The bands are the .res thresholds verbatim. The host owns the 0..4 ->
+//   {colour, description, "S".."D"} maps; the brain owns the cut points.
+//
+// PURE: integers only, no floats, no strings, no arrays, no effects, no I/O.
+
+//## The base performance score before any penalties or bonuses.
+pub fn victory_base_score() -> Int { 100 }
+
+//## The whole-second elapsed-time penalty: 10 once past five minutes, a
+// further 10 once past ten minutes (so 0, 10 or 20). A non-positive time is
+// below both thresholds and yields 0.
+pub fn victory_time_penalty(time_sec: Int) -> Int {
+  let first = if time_sec > 300 { 10 } else { 0 };
+  let second = if time_sec > 600 { 10 } else { 0 };
+  first + second
+}
+
+//## The command-spam penalty: 5 once more than a hundred commands were run,
+// else 0. The .res tests `commandsExecuted > 100`.
+pub fn victory_command_penalty(commands: Int) -> Int {
+  if commands > 100 { 5 } else { 0 }
+}
+
+//## The full performance score from 100. Mirrors calculateGrade's accumulator
+// as one expression: base, minus alert and time and command penalties, plus
+// covert-link and critical-success bonuses, minus the critical-failure
+// penalty. Not clamped (the banding's floor grade absorbs a negative score).
+pub fn victory_score(alert: Int, time_sec: Int, commands: Int, covert: Int, crit_succ: Int, crit_fail: Int) -> Int {
+  let base = 100;
+  let after_alert = base - alert * 15;
+  let after_time = after_alert - victory_time_penalty(time_sec);
+  let after_covert = after_time + covert * 5;
+  let after_commands = after_covert - victory_command_penalty(commands);
+  let after_crit_succ = after_commands + crit_succ * 3;
+  after_crit_succ - crit_fail * 5
+}
+
+//## The grade ordinal (4 S, 3 A, 2 B, 1 C, 0 D) for a performance score,
+// using the .res thresholds 95 / 80 / 60 / 40 with D as the floor.
+pub fn victory_grade(score: Int) -> Int {
+  if score >= 95 { 4 } else {
+    if score >= 80 { 3 } else {
+      if score >= 60 { 2 } else {
+        if score >= 40 { 1 } else { 0 }
+      }
+    }
+  }
+}
+
+//## The grade ordinal computed directly from the raw run stats, composing
+// victory_score with victory_grade so the host can ask for the final grade in
+// one call (the gradeOrdinal kernel of the binding).
+pub fn victory_grade_of_stats(alert: Int, time_sec: Int, commands: Int, covert: Int, crit_succ: Int, crit_fail: Int) -> Int {
+  victory_grade(victory_score(alert, time_sec, commands, covert, crit_succ, crit_fail))
+}

--- a/proposals/idaptik/migrated/VictoryScreen/victoryscreen.config.mjs
+++ b/proposals/idaptik/migrated/VictoryScreen/victoryscreen.config.mjs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MPL-2.0
+// hypatia: allow cicd_rules/javascript_detected -- Deno trial component for nextgen-evangelist; production target is Rust/AffineScript (see proposals/nextgen-evangelist/README.adoc)
+//
+// affine-parity config for VictoryScreen.affine (idaptik performance-grade
+// brain; scalar i32 ABI). The oracle re-derives each function from the ORIGINAL
+// VictoryScreen.res calculateGrade semantics (NOT from the .affine) so a codegen
+// regression surfaces as a differential mismatch.
+//
+// From VictoryScreen.res calculateGrade (lines 70-107):
+//   let score = ref(100)
+//   score := score.contents - stats.alertLevelReached * 15
+//   if stats.timeElapsedSec > 300.0 { score := score.contents - 10 }
+//   if stats.timeElapsedSec > 600.0 { score := score.contents - 10 }
+//   score := score.contents + stats.covertLinksDiscovered * 5
+//   if stats.commandsExecuted > 100 { score := score.contents - 5 }
+//   score := score.contents + stats.critSuccessCount * 3
+//   score := score.contents - stats.critFailureCount * 5
+//   if score >= 95 { S } else if >= 80 { A } else if >= 60 { B }
+//   else if >= 40 { C } else { D }
+// timeElapsedSec is a float in the .res; the host truncates to whole seconds
+// before crossing, so the oracle takes an integer second count and the two
+// threshold tests (> 300, > 600) coincide with the float ones on whole seconds.
+// Grade variant S/A/B/C/D maps to ordinals 4/3/2/1/0 (descending switch order).
+
+// Independent re-derivation of the score accumulator from the .res.
+const timePenalty = (t) => (t > 300 ? 10 : 0) + (t > 600 ? 10 : 0);
+const commandPenalty = (c) => (c > 100 ? 5 : 0);
+const score = (alert, t, commands, covert, critSucc, critFail) =>
+  100 - alert * 15 - timePenalty(t) + covert * 5 - commandPenalty(commands) +
+  critSucc * 3 - critFail * 5;
+
+// Independent re-derivation of the grade banding from the .res.
+const grade = (s) => {
+  if (s >= 95) return 4;
+  if (s >= 80) return 3;
+  if (s >= 60) return 2;
+  if (s >= 40) return 1;
+  return 0;
+};
+const gradeOfStats = (alert, t, commands, covert, critSucc, critFail) =>
+  grade(score(alert, t, commands, covert, critSucc, critFail));
+
+export default {
+  affine: "VictoryScreen.affine",
+  cases: [
+    {
+      name: "victory_base_score()",
+      export: "victory_base_score",
+      args: [],
+      oracle: () => 100,
+    },
+    {
+      name: "victory_time_penalty over t[0..900] step-swept",
+      export: "victory_time_penalty",
+      args: [[0, 900]],
+      oracle: (t) => timePenalty(t),
+    },
+    {
+      name: "victory_time_penalty boundary 299/300/301/600/601 + negative",
+      export: "victory_time_penalty",
+      args: [{ values: [-10, 0, 299, 300, 301, 599, 600, 601, 5000] }],
+      oracle: (t) => timePenalty(t),
+    },
+    {
+      name: "victory_command_penalty over c[0..200]",
+      export: "victory_command_penalty",
+      args: [[0, 200]],
+      oracle: (c) => commandPenalty(c),
+    },
+    {
+      name: "victory_command_penalty boundary 99/100/101 + negative",
+      export: "victory_command_penalty",
+      args: [{ values: [-5, 0, 99, 100, 101, 1000] }],
+      oracle: (c) => commandPenalty(c),
+    },
+    {
+      name: "victory_grade over score[-30..120]",
+      export: "victory_grade",
+      args: [[-30, 120]],
+      oracle: (s) => grade(s),
+    },
+    {
+      name: "victory_grade band edges 39/40/59/60/79/80/94/95",
+      export: "victory_grade",
+      args: [{ values: [39, 40, 59, 60, 79, 80, 94, 95, 96] }],
+      oracle: (s) => grade(s),
+    },
+    {
+      // Full score over a representative cross-product of the six stat axes.
+      name: "victory_score over (alert,t,commands,covert,critSucc,critFail)",
+      export: "victory_score",
+      args: [
+        { values: [0, 1, 2, 5] }, // alert level reached (0..5/5 in HUD, wider for safety)
+        { values: [0, 250, 400, 700] }, // elapsed whole seconds straddling both thresholds
+        { values: [0, 100, 150] }, // commands executed straddling the > 100 cut
+        { values: [0, 3, 8] }, // covert links discovered
+        { values: [0, 4 ] }, // critical successes
+        { values: [0, 3 ] }, // critical failures
+      ],
+      oracle: (a, t, c, cv, cs, cf) => score(a, t, c, cv, cs, cf),
+    },
+    {
+      // The composed grade-of-stats over the same axes.
+      name: "victory_grade_of_stats over the six stat axes",
+      export: "victory_grade_of_stats",
+      args: [
+        { values: [0, 1, 2, 5] },
+        { values: [0, 250, 400, 700] },
+        { values: [0, 100, 150] },
+        { values: [0, 3, 8] },
+        { values: [0, 4 ] },
+        { values: [0, 3 ] },
+      ],
+      oracle: (a, t, c, cv, cs, cf) => gradeOfStats(a, t, c, cv, cs, cf),
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Completes the exhaustive idaptik corpus sweep (C13 + C14). This cluster covers the **sense-heavy** directory groups — `screens` (+ `training`/`locations`), `vm/lib/ocaml`, `engine` + `shared/src`, `verisimdb` + `proven`, and the long-tail grab-bag — **148 `.res` files** — extracting **12 new `Int->Int` brains**. Brain count **79 → 91**.

## New brains (12) — verified G1/G2/G4 green

`VictoryScreen` (2430) · `PlayTimeSplit` (2040) · `VeriSimError` (859) · `MissionBriefing` (285) · `IntroScreen` (254) · `InstructionCoprocessor` (175) · `SkillTreeScreen` (114) · `VeriSimModality` (80) · `BalanceAnalyser` (68) · `LocationData` (61) · `AmbushObjective` (31) · `HighwayHits` (28)

(`N` = parity cases, all passing.) **~6,425 cases**, every brain assail-clean. Independently re-verified, not just agent-reported.

## Disposition (148 files)

| | count |
|---|---|
| New brains | 12 |
| Already migrated | 45 |
| `NO_NEW_BRAINS` | 91 |

The 23 individual `vm/lib` instruction files are confirmed covered by the migrated `Vm*` category brains; `shared/src` is a duplicate tree of `src/shared` (already migrated). Several new brains are **residual sub-brains earlier clusters scoped out** (screen score/grade kernels, the opcode taxonomy, the VeriSim classifications). Full per-file ledger in `EVIDENCE-C14-sense-sweep.adoc`.

## Corpus status

With **C13 (17) + C14 (12) = 29 new brains across 307 files**, the idaptik logic corpus is exhaustively classified. A handful of straggler leaves (`screens/main`, `screens/hub`, `vm/wasm`, two `devices/` subdirs — ~8 files) are swept in a follow-up.

## Notes

- Brains stay `Int->Int` (the parity harness passes integer args only); floats are carried as ×1000 milli-units / permille where integer-exact, else host-side.
- Recurring authoring landmines re-confirmed: `total` is a reserved word; the flat early-`return N;` idiom is the reliable many-branch style that stays assail-clean.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_