### PR TITLE
compiler+harness: string-wall cleanup + affine-parity String-arg support (+ float-wall finding)

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -439,7 +439,15 @@ let gen_binop (op : binary_op) : instr =
   | OpBitXor -> I32Xor
   | OpShl -> I32Shl
   | OpShr -> I32ShrS
-  | OpConcat -> I32Add (* Placeholder *)
+  | OpConcat ->
+    (* Unreachable: `++` never reaches [gen_binop]. String `++` is lowered by
+       the [ExprStringConcat] arm (slice 8b) or rejected by the slice-8a guard;
+       list `++` is lowered by its own [ExprBinary (_, OpConcat, _)] arm; and
+       compound-assign only maps `+= -= *= /=`. The former placeholder returned
+       [I32Add], which would have *silently* summed two pointers if ever
+       reached — fail loudly instead so a regression surfaces immediately. *)
+    failwith "gen_binop: OpConcat must be lowered via ExprStringConcat or the \
+              list-concat arm, never through gen_binop"
 
 (** Generate code for unary operation *)
 let gen_unop (op : unary_op) : instr result =

--- a/proposals/EVIDENCE-float-wall-finding.adoc
+++ b/proposals/EVIDENCE-float-wall-finding.adoc
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Finding: the "float wall" — Float arith/compare codegen emits i32 ops (2026-06-14)
+:toc: macro
+
+== Summary
+
+`Float`-typed binary operations (`+`, `-`, `*`, `/`, `<`, `<=`, `>`, `>=`, `==`)
+*type-check* but the wasm backend lowers them with **integer** instructions on
+f64 operands, producing a module that fails WebAssembly validation. This is the
+float analogue of the string wall (slices 8b/9/10): the type checker dispatches
+`Float` correctly, but `gen_binop` returns only the i32 instruction family.
+
+== Reproduction
+
+[source]
+----
+pub fn band_of(x: Float) -> Int {
+  if x < 10.0 { 0 } else { if x < 100.0 { 1 } else { 2 } }
+}
+----
+
+[source]
+----
+$ main.exe compile band_of.affine -o band_of.wasm      # compiles
+$ # instantiation fails:
+WebAssembly.instantiate(): Compiling function failed:
+  i32.lt_s[1] expected type i32, found f64.const of type f64
+----
+
+`codegen.ml gen_binop` maps `OpLt -> I32LtS`, `OpAdd -> I32Add`, etc., with no
+`Float` path; the `ExprBinary` lowering applies it to f64 operands.
+
+== Why it has never surfaced
+
+The entire idaptik migration corpus (94 brains) is `Int(...)->Int`: every float
+quantity is carried as a x1000 milli-unit / permille integer, precisely because
+float codegen does not work and the parity harness passes integer args. So no
+shipped artefact exercises float binops, and the gap stayed latent.
+
+== Shape of the fix (the float wall)
+
+The same type-channel pattern that closed the string wall applies. Either:
+
+* *Type-directed elaboration* (mirrors slices 8b/9/10): `synth` records
+  `Float`-typed binop nodes; an elaboration rewrites them to dedicated
+  `ExprFloatBinary` / `ExprFloatRel` nodes; codegen lowers those to the f64
+  instruction family (`F64Add`, `F64Lt`, …). Most faithful to the established
+  pattern.
+* *Operand-type threading at codegen*: give the `ExprBinary` lowering the
+  synthesised operand type so it can pick the i32 vs f64 instruction directly.
+  Smaller surface but introduces a type channel into codegen that does not yet
+  exist there.
+
+The f64 instructions already exist in `lib/wasm.ml` (`F64Const` is emitted for
+float literals today); only the binop dispatch is missing.
+
+== Harness readiness
+
+`proposals/nextgen-evangelist/affine-parity` already accepts Float arguments
+(non-integer values in a `{ values: [...] }` spec pass through as wasm f64; the
+result is read as i32). The moment float binop codegen lands, float-input brains
+(physics thresholds, geometry classifications, the ~12 float-domain modules
+marked `NO_NEW_BRAINS` in cluster C13/C14 purely for the integer-only ABI)
+become compilable and parity-testable with no further harness work.

--- a/proposals/EVIDENCE-float-wall-finding.adoc
+++ b/proposals/EVIDENCE-float-wall-finding.adoc
@@ -52,8 +52,32 @@ The same type-channel pattern that closed the string wall applies. Either:
   Smaller surface but introduces a type channel into codegen that does not yet
   exist there.
 
-The f64 instructions already exist in `lib/wasm.ml` (`F64Const` is emitted for
-float literals today); only the binop dispatch is missing.
+*Scope correction (2026-06-14, after investigation).* This is bigger than "add
+a binop arm". The f64 *instructions* all exist in `lib/wasm.ml` (`F64Add`,
+`F64Lt`, …; `F64Const` is already emitted for float literals), but the codegen's
+*value model is i32-only*, so the fix needs f64 value-type tracking end to end:
+
+. *Params* — `codegen.ml` `TopFn` lowers `ft_params = List.map (fun _ -> I32)
+  fd.fd_params` (line ~2995). A `Float` param is declared `i32`, so an f64 arg
+  cannot even arrive. Lower each param from its annotation via the existing
+  `TyCon "Float" -> F64` mapping (line ~170).
+. *Results* — `ft_results = [I32]` (line ~2996). Lower from `fd.fd_ret_ty` so a
+  `Float`-returning fn declares an `f64` result.
+. *Locals* — `alloc_local` (line ~181) tracks only `(name, idx)`; the function's
+  locals are emitted all-`i32`. Binding a float value (`let y = x + 1.0`) would
+  `LocalSet` an f64 into an i32 slot → validation failure. Locals must carry a
+  `val_type`, threaded through `alloc_local` and the locals-emission.
+. *Binop dispatch* — the `ExprFloatBinary` elaboration (mirrors slices 8b/9/10):
+  `synth` records `Float`-typed binop nodes (three sites: the arith branch's
+  `Float` case, the `comparison` branch's `Float` case, and the `==`/`!=` else
+  branch when operands are `Float`); elaboration rewrites to `ExprFloatBinary`;
+  codegen lowers to the f64 family (arith → f64 value; comparison → i32 bool).
+
+Items 1–2 are small; item 3 (typed locals) is the load-bearing change and the
+main validation-risk surface; item 4 is the string-wall pattern again. A
+*narrow first slice* (params + returns + comparisons + stack-flowing arith,
+erroring on float `let`-bindings until typed locals land) makes `Float -> Int`
+classifiers like `band_of` compile without item 3, but is partial.
 
 == Harness readiness
 

--- a/proposals/EVIDENCE-stringwall-slices9-10.adoc
+++ b/proposals/EVIDENCE-stringwall-slices9-10.adoc
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= String-wall slices 9–10 + completion capstone (2026-06-14)
+:toc: macro
+
+toc::[]
+
+== Context
+
+The "string wall" is the family of `String`-typed operations that the wasm
+backend lowered to integer ops on the underlying `[len: i32][utf8 bytes]`
+*pointer* rather than on the string's bytes. A `String` value is an i32 pointer
+into linear memory, so any pointer-level integer op gives a wrong answer for two
+equal-valued strings that live at distinct heap addresses (e.g. a literal vs a
+string built at runtime).
+
+Slices 1–7 established the byte-level string primitives (length, indexing,
+byte-scan helpers, `startsWith`/`contains`, the WASI `env_at`/`arg_at` string
+builders). Slice 8 split into 8a (a *sound-rejection guard* that loudly refused
+the syntactically-obvious string `++` cases codegen could not yet lower) and 8b
+(the type-directed `ExprStringConcat` lowering). This document records slices
+9 (equality) and 10 (relational) — which complete the wall — and the final
+hardening.
+
+== The type-channel pattern (shared by 8b / 9 / 10)
+
+Codegen is type-blind; it cannot tell from `a == b` whether `a` is `Int` or
+`String`. The fix routes the decision through the type checker, which *does*
+know:
+
+1. *`Typecheck.synth`* records the physical AST node (`List.memq` identity) of
+   every `String`-typed operator occurrence into a site list
+   (`string_concat_sites` / `string_eq_sites` / `string_rel_sites`).
+2. *`Typecheck.elaborate_string_concat`* (run on the wasm-codegen path only)
+   walks the program once and rewrites each recorded `ExprBinary` node into a
+   dedicated AST node.
+3. *Codegen* lowers the dedicated node with a real byte-level routine.
+
+This keeps the interpreter and non-wasm backends untouched (they never run the
+elaboration and handle the original `ExprBinary` directly), and it is
+*complete* — variable-to-variable cases are covered because the recording is
+type-directed, not syntactic.
+
+== Slice 9 — `==` / `!=` (`ExprStringEq`)
+
+* Equality is polymorphic (`type_of_binop` gives `'a -> 'a -> Bool`), so a
+  `String` `==` lands in `synth`'s general `else` branch; recorded there when
+  `repr lhs_ty = TCon "String"`.
+* `ExprStringEq (expr, expr, bool)` — the `bool` is `true` for `!=`.
+* Lowering: length guard, then a byte loop bounded by the (equal) length; `!=`
+  negates with `I32Eqz`. The loop runs only after lengths match, so it never
+  reads past either string.
+
+== Slice 10 — `<` / `<=` / `>` / `>=` (`ExprStringRel`)
+
+* Relational ops land in `synth`'s `comparison` branch (which already returns
+  `Bool` for `String` per #458); recorded there.
+* `ExprStringRel (expr, expr, binary_op)` carries the operator (always one of
+  `OpLt`/`OpLe`/`OpGt`/`OpGe`).
+* Lowering: byte-wise *lexicographic* compare — compare the common prefix
+  unsigned (`I32LtU`/`I32GtU`), and on a tie the shorter string is smaller; the
+  result `cmp ∈ {-1,0,1}` maps onto `cmp <signed-op> 0`. The loop is bounded at
+  `min(len_a, len_b)` (via `Select`), so it never reads out of bounds.
+
+== Final hardening
+
+`gen_binop`'s `| OpConcat -> I32Add (* Placeholder *)` arm — a latent landmine
+that would have silently summed two pointers — is now a `failwith` guard. It is
+provably unreachable (string `++` → `ExprStringConcat`/8a-guard; list `++` →
+its own arm; compound-assign maps only `+= -= *= /=`), so the change is pure
+defensive hardening: a regression that ever routed `++` through `gen_binop`
+surfaces as a loud failure instead of a wrong answer.
+
+== Verification
+
+* `test/e2e/fixtures/string_eq.affine`, `string_rel.affine` + the slice-9 /
+  slice-10 cases in `test/test_e2e.ml` (compile-after-elaboration).
+* Value checks (out-of-band, via Deno): equality and lexicographic ordering
+  verified across decisive-byte, prefix-ordering, empty-string, equality, and
+  built-vs-literal cases.
+* No regression: tens of thousands of `Int`-`==`/relational parity cases across
+  the idaptik migration corpus pass unchanged (only `String` operands are
+  recorded for elaboration; `Int`/`Bool`/`Float` are untouched).
+
+== Status
+
+*The string wall is complete.* `++`, `==`/`!=`, and `<`/`<=`/`>`/`>=` all lower
+correctly on the wasm target. The remaining string surface (interpolation,
+`format`, richer stdlib string functions) is additive, not a correctness wall.
+
+NOTE: the parity harness passes integer arguments only, so brains compiled for
+it remain `Int(...)->Int`; exercising these string ops with real `String`-input
+consumers needs the string/float test-harness extension (separate work item).

--- a/proposals/nextgen-evangelist/affine-parity/examples/string_float_demo.affine
+++ b/proposals/nextgen-evangelist/affine-parity/examples/string_float_demo.affine
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Demo for affine-parity String argument support. `classify` exercises slice-9
+// String `==` against a literal; `str_cmp` exercises slice-9 + slice-10
+// comparing two RUNTIME-PROVIDED strings (pointer vs pointer) — the strongest
+// check that value (not pointer) comparison holds for JS-supplied strings.
+// (A Float case is omitted: float `<`/arithmetic codegen still emits i32 ops —
+// a separate "float wall" the harness is ready for once codegen is fixed.)
+
+pub fn classify(s: String) -> Int {
+  if s == "scan" { 1 } else { if s == "exit" { 2 } else { 0 } }
+}
+
+pub fn str_cmp(a: String, b: String) -> Int {
+  if a < b { -1 } else { if a == b { 0 } else { 1 } }
+}

--- a/proposals/nextgen-evangelist/affine-parity/examples/string_float_demo.config.mjs
+++ b/proposals/nextgen-evangelist/affine-parity/examples/string_float_demo.config.mjs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MPL-2.0
+export default {
+  affine: "string_float_demo.affine",
+  cases: [
+    { export: "classify", args: [{ strings: ["scan", "exit", "foo", "sca", "scann", ""] }],
+      oracle: (s) => (s === "scan" ? 1 : s === "exit" ? 2 : 0) },
+    { export: "str_cmp", args: [{ strings: ["a", "ab", "b", ""] }, { strings: ["a", "ab", "b", ""] }],
+      oracle: (a, b) => (a < b ? -1 : a === b ? 0 : 1) },
+  ],
+};

--- a/proposals/nextgen-evangelist/affine-parity/parity.mjs
+++ b/proposals/nextgen-evangelist/affine-parity/parity.mjs
@@ -17,15 +17,24 @@
 // which oracle.
 //
 //## ABI SCOPE (read this)
-// This runner handles the **scalar i32 ABI** only: every argument is an i32 and
-// every result is an i32. That is exactly the boundary the DESIGN-VISION
-// prescribes ("they pass primitives across the wasm boundary") and it covers
-// pure-integer co-processors such as SecurityRank. Array/string parameters use
-// a different convention -- `[len:i32 LE][utf8 bytes]` written into linear
-// memory plus an exported `__affine_alloc` -- and are a deliberate follow-on,
-// NOT implemented here. Exports taking [Int]/String params therefore can only be
-// invoked here in their nullary form (e.g. Kernel_IO's `main`, whose array
-// arguments are inlined inside the .affine source).
+// This runner handles i32 results over i32 / f64 / String arguments:
+//   * i32 args   -- swept as integer ranges/values (the original scalar ABI),
+//   * f64 args   -- any non-integer values in a `{ values: [...] }` spec are
+//                   passed through verbatim as wasm f64 (args are not coerced),
+//   * String args -- written into linear memory as `[len:i32 LE][utf8 bytes]`
+//                   and passed BY POINTER (an i32). The string layout matches
+//                   the compiler's (codegen `gen_literal`). The oracle still
+//                   receives the original JS string, not the pointer.
+// Every result is read back as an i32 (`| 0`).
+//
+// String scratch memory: after instantiation the runner grows the module's
+// linear memory by one page (64 KiB) and writes string args into that fresh
+// page (reset before each call). Because the page sits above all of the
+// module's data and bump-heap base, a read-only string consumer (the common
+// case -- a classifier that reads its String arg and returns an Int) never
+// collides with it. A module that *allocates heavily during the call* before
+// reading its String arg could in principle reach the scratch page; such cases
+// should size their sweeps modestly or write a bespoke driver.
 //
 //## CONFIG SHAPE
 // A config is a `.mjs` module with a default export:
@@ -126,9 +135,42 @@ function expandArgSpec(spec, paramIndex) {
     return out;
   }
   if (spec && Array.isArray(spec.values)) return spec.values.slice();
+  if (spec && Array.isArray(spec.strings)) return spec.strings.slice();
   throw new Error(
-    `arg spec #${paramIndex} must be a number, a [lo,hi] range, or { values: [...] }`,
+    `arg spec #${paramIndex} must be a number, a [lo,hi] range, { values: [...] }, or { strings: [...] }`,
   );
+}
+
+// Build a writer for String args. Grows the module's linear memory by one page
+// and bump-allocates `[len:i32 LE][utf8]` strings into it, 4-byte aligned, so
+// each is a valid AffineScript string the wasm can read by pointer. Returns
+// null when the module exports no memory (then String args are a usage error).
+function makeStringWriter(memory) {
+  if (!(memory instanceof WebAssembly.Memory)) return null;
+  const oldPages = memory.grow(1); // fresh page above all module data + heap
+  const base = oldPages * 65536;
+  const enc = new TextEncoder();
+  let bump = base;
+  return {
+    reset() {
+      bump = base;
+    },
+    write(s) {
+      const u = enc.encode(s);
+      const need = 4 + u.length;
+      // Grow if a long string would overrun the scratch page.
+      if (bump + need > memory.buffer.byteLength) {
+        memory.grow(Math.ceil(need / 65536) + 1);
+      }
+      const ptr = bump;
+      const dv = new DataView(memory.buffer); // re-read: grow detaches the buffer
+      dv.setInt32(ptr, u.length, true);
+      new Uint8Array(memory.buffer, ptr + 4, u.length).set(u);
+      bump = ptr + need;
+      bump += (4 - (bump & 3)) & 3; // 4-byte align the next string
+      return ptr;
+    },
+  };
 }
 
 // Cartesian product of a list of value-lists. [] -> [[]] (the single empty tuple).
@@ -141,7 +183,7 @@ function cartesian(lists) {
 
 // Run a single case (one export + its arg sweep + its oracle). Returns
 // { name, total, pass, failures: [{args, got, want}] }.
-function runCase(exports, kase, idx) {
+function runCase(exports, kase, idx, stringWriter) {
   const name = kase.name || kase.export || `case#${idx}`;
   const fn = exports[kase.export];
   if (typeof fn !== "function") {
@@ -159,7 +201,22 @@ function runCase(exports, kase, idx) {
   let pass = 0;
   const failures = [];
   for (const tuple of tuples) {
-    const got = fn(...tuple) | 0; // normalise to i32
+    // String args are written into scratch linear memory as [len][utf8] and
+    // passed by pointer; the oracle still sees the original JS string. i32 /
+    // f64 args pass through unchanged.
+    let wasmArgs = tuple;
+    if (tuple.some((v) => typeof v === "string")) {
+      if (!stringWriter) {
+        throw new Error(
+          `case "${name}" passes a String arg but the module exports no "memory"`,
+        );
+      }
+      stringWriter.reset();
+      wasmArgs = tuple.map((v) =>
+        typeof v === "string" ? stringWriter.write(v) : v
+      );
+    }
+    const got = fn(...wasmArgs) | 0; // normalise result to i32
     const want = kase.oracle(...tuple) | 0;
     if (got === want) {
       pass++;
@@ -206,12 +263,13 @@ export async function runParity(configPath, { verbose = false } = {}) {
   }
 
   const exports = await instantiate(outPath);
+  const stringWriter = makeStringWriter(exports.memory);
 
   let grandTotal = 0;
   let grandPass = 0;
   const results = [];
   cfg.cases.forEach((kase, i) => {
-    const r = runCase(exports, kase, i);
+    const r = runCase(exports, kase, i, stringWriter);
     results.push(r);
     grandTotal += r.total;
     grandPass += r.pass;


### PR DESCRIPTION
Two related "finish & connect the string wall" changes on one branch.

## 1. String-wall cleanup (compiler)

`gen_binop`'s `OpConcat -> I32Add (* Placeholder *)` was a latent landmine — it would *silently sum two string pointers* if ever reached. It is provably unreachable (string `++` → `ExprStringConcat` / the 8a guard; list `++` → its own arm; compound-assign maps only `+= -= *= /=`), so it is now a loud `failwith` guard. `proposals/EVIDENCE-stringwall-slices9-10.adoc` consolidates the eq (slice 9) + relational (slice 10) lowerings and records the wall complete.

## 2. affine-parity String-argument support (harness)

Extends the differential-parity harness to pass **String** args: after instantiation it grows linear memory by one page and writes args as `[len:i32 LE][utf8]` (matching the compiler's string layout), passing them by pointer; the oracle still receives the JS string. Adds a `{ strings: [...] }` arg-spec form. Float args already pass through as wasm f64 via `{ values: [...] }`.

This **connects the string-wall compiler fixes to the migration harness**. The demo (`examples/string_float_demo`) proves slice-9 `==` against a literal **and** slice-9 + slice-10 comparing two *runtime-provided* strings pointer-vs-pointer — **22/22**. No regression on int-only configs (DeviceType / VmState / Maths / NetworkZones unchanged).

## Finding: the "float wall"

`Float` binops type-check but codegen emits **i32** instructions on f64 operands (`band_of` fails wasm validation: `i32.lt_s ... found f64`). Never surfaced because the 94-brain corpus is all-Int (×1000 milli-units). The harness is already ready for float-input brains; the float-codegen fix is the unblocker. See `proposals/EVIDENCE-float-wall-finding.adoc`.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s