### PR TITLE
compiler: implement the float wall — Float binops + typed locals lower to f64

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -175,6 +175,18 @@ type expr =
           signed-integer compare on the two `[len][utf8]` pointers (which is
           meaningless). The interpreter and non-wasm backends treat it as an
           ordinary string comparison. String-wall slice 10 (#458). *)
+  | ExprFloatBinary of expr * binary_op * expr
+      (** Float binary operation, `a <op> b` where both sides are `Float`:
+          arithmetic ([OpAdd] / [OpSub] / [OpMul] / [OpDiv], yielding `Float`)
+          or comparison ([OpLt] / [OpLe] / [OpGt] / [OpGe] / [OpEq] / [OpNe],
+          yielding `Bool`). Like {!ExprStringEq}, this is not produced by the
+          parser: it is introduced by the post-typecheck elaboration
+          (see {!Typecheck.elaborate_string_concat}) that rewrites the Float
+          case of these operators, so the wasm backend lowers them to the f64
+          instruction family (`F64Add`, `F64Lt`, …) instead of the i32 family
+          `gen_binop` returns — which would emit `i32.lt_s` on f64 operands and
+          fail wasm validation. The interpreter and non-wasm backends treat it
+          as the ordinary `Float` operation. The "float wall". *)
   | ExprUnary of unary_op * expr
   | ExprBlock of block
   | ExprReturn of expr option

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -27,6 +27,14 @@ type context = {
   globals : global list;             (** global variables *)
   locals : (string * int) list;      (** local variable name to index map *)
   next_local : int;                  (** next available local index *)
+  local_types : (int * value_type) list;
+  (** Float wall: local index -> wasm value type, for indices whose value is
+      f64 (Float params and Float-bound `let`s). Indices absent here default to
+      i32. Drives the typed [f_locals] emission so a float bound to a local is
+      declared f64 rather than failing wasm validation. *)
+  fn_ret_types : (string * value_type) list;
+  (** Float wall: function name -> wasm result value type, so a call site
+      `let x = f(...)` can infer whether x is f64. *)
   loop_depth : int;                  (** current loop nesting depth *)
   func_indices : (string * int) list;
   (** Top-level name environment shared by functions and constants.
@@ -95,6 +103,8 @@ let create_context () : context = {
   globals = [];
   locals = [];
   next_local = 0;
+  local_types = [];
+  fn_ret_types = [];
   loop_depth = 0;
   func_indices = [];
   lambda_funcs = [];
@@ -418,6 +428,41 @@ let gen_literal (ctx : context) (lit : literal) : (context * instr) result =
         Ok (ctx', I32Const (Int32.of_int offset))
     end
 
+(** Float wall: structurally infer the wasm value type an expression yields,
+    AFTER elaboration (Float ops are [ExprFloatBinary]). Used to decide whether
+    a `let`-bound local must be declared f64. Conservative — anything not seen
+    to be f64 defaults to i32, matching the pre-float-wall world. *)
+let rec expr_val_type (ctx : context) (e : expr) : value_type =
+  match e with
+  | ExprLit (LitFloat _) -> F64
+  | ExprFloatBinary (_, (OpAdd | OpSub | OpMul | OpDiv), _) -> F64
+  | ExprFloatBinary (_, _, _) -> I32          (* comparisons yield Bool/i32 *)
+  | ExprUnary (OpNeg, e1) -> expr_val_type ctx e1
+  | ExprSpan (e1, _) -> expr_val_type ctx e1
+  | ExprVar id ->
+    (match lookup_local ctx id.name with
+     | Ok idx ->
+       (match List.assoc_opt idx ctx.local_types with Some t -> t | None -> I32)
+     | Error _ -> I32)
+  | ExprApp (ExprVar id, _) ->
+    (match List.assoc_opt id.name ctx.fn_ret_types with Some t -> t | None -> I32)
+  | ExprIf r -> expr_val_type ctx r.ei_then
+  | ExprBlock blk ->
+    (match blk.blk_expr with Some e1 -> expr_val_type ctx e1 | None -> I32)
+  | ExprLet lb ->
+    (match lb.el_body with Some e1 -> expr_val_type ctx e1 | None -> I32)
+  | _ -> I32
+
+(** Float wall: run-length-encode local value types (in index order) into the
+    wasm [local] group list (default i32). *)
+let rle_locals (vts : value_type list) : local list =
+  List.fold_right (fun vt acc ->
+    match acc with
+    | { l_count; l_type } :: rest when l_type = vt ->
+      { l_count = l_count + 1; l_type = vt } :: rest
+    | _ -> { l_count = 1; l_type = vt } :: acc)
+    vts []
+
 (** Generate code for binary operation *)
 let gen_binop (op : binary_op) : instr =
   match op with
@@ -731,6 +776,25 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
     in
     Ok (ctxB, code)
 
+  | ExprFloatBinary (left, op, right) ->
+    (* Float wall: lower a Float binop to the f64 instruction family. Arith
+       (+,-,*,/) yields an f64 value; the six comparisons yield an i32 bool.
+       Operands are f64 (float literals -> F64Const, Float params -> f64 param
+       slots, nested ExprFloatBinary arith -> f64), so this validates. *)
+    let* (ctx1, left_code)  = gen_expr ctx  left  in
+    let* (ctx2, right_code) = gen_expr ctx1 right in
+    let* f64_op = match op with
+      | OpAdd -> Ok F64Add | OpSub -> Ok F64Sub
+      | OpMul -> Ok F64Mul | OpDiv -> Ok F64Div
+      | OpLt  -> Ok F64Lt  | OpLe  -> Ok F64Le
+      | OpGt  -> Ok F64Gt  | OpGe  -> Ok F64Ge
+      | OpEq  -> Ok F64Eq  | OpNe  -> Ok F64Ne
+      | _ -> Error (UnsupportedFeature
+               "Float wall: only + - * / and the six comparisons lower to f64; \
+                Float OpMod / bitwise are unsupported")
+    in
+    Ok (ctx2, left_code @ right_code @ [f64_op])
+
   | ExprBinary (left, op, right) ->
     let* (ctx', left_code) = gen_expr ctx left in
     let* (ctx'', right_code) = gen_expr ctx' right in
@@ -805,6 +869,15 @@ let rec gen_expr (ctx : context) (expr : expr) : (context * instr list) result =
   | ExprLet lb ->
     let* (ctx', rhs_code) = gen_expr ctx lb.el_value in
     let* (ctx'', pat_code) = gen_pattern_bind ctx' lb.el_pat in
+    (* Float wall: record a float-bound local's f64 type (see StmtLet). *)
+    let ctx'' = match lb.el_pat with
+      | PatVar id ->
+        (match lookup_local ctx'' id.name with
+         | Ok idx when expr_val_type ctx'' lb.el_value = F64 ->
+           { ctx'' with local_types = (idx, F64) :: ctx''.local_types }
+         | _ -> ctx'')
+      | _ -> ctx''
+    in
     begin match lb.el_body with
       | Some body ->
         let* (ctx_final, body_code) = gen_expr ctx'' body in
@@ -2362,6 +2435,12 @@ and gen_stmt (ctx : context) (stmt : stmt) : (context * instr list) result =
           | None -> layout_from_rhs ()
         in
         let (ctx'', idx) = alloc_local ctx' id.name in
+        (* Float wall: a float-bound local must be declared f64 (else a LocalSet
+           of an f64 into an i32 slot fails wasm validation). *)
+        let ctx'' = match expr_val_type ctx'' sl.sl_value with
+          | F64 -> { ctx'' with local_types = (idx, F64) :: ctx''.local_types }
+          | _ -> ctx''
+        in
         let ctx_with_layout = match layout_opt with
           | Some layout ->
             { ctx'' with field_layouts = (id.name, layout) :: ctx''.field_layouts }
@@ -2871,7 +2950,12 @@ let () =
 
 let gen_function (ctx : context) (fd : fn_decl) : (context * func) result =
   (* Create fresh context for function scope, but preserve lambda_funcs and next_lambda_id *)
-  let fn_ctx = { ctx with locals = []; next_local = 0; loop_depth = 0 } in
+  (* Float wall: reset [local_types] too — local indices restart at 0 per
+     function, so a previous function's f64-local entries must not leak (else a
+     later function's i32 local at the same index is mis-declared f64). Keep
+     [fn_ret_types]: it is module-level (cross-function call inference). *)
+  let fn_ctx = { ctx with locals = []; next_local = 0; loop_depth = 0;
+                          local_types = [] } in
 
   (* Parameters become locals 0..n-1. When a parameter's declared type
      names a known struct, register its field layout under the parameter
@@ -2879,6 +2963,11 @@ let gen_function (ctx : context) (fd : fn_decl) : (context * func) result =
      rather than defaulting to 0. *)
   let (ctx_with_params, _) = List.fold_left (fun (c, _) param ->
     let (c', idx) = alloc_local c param.p_name.name in
+    (* Float wall: record the param's wasm value type (Float -> F64) so body
+       val-type inference and the f_locals emission see f64 params. *)
+    let c' = { c' with local_types =
+      (idx, (match type_to_wasm param.p_ty with Ok t -> t | Error _ -> I32))
+      :: c'.local_types } in
     let c'' =
       match struct_name_of_ty param.p_ty with
       | Some sname ->
@@ -2929,11 +3018,13 @@ let gen_function (ctx : context) (fd : fn_decl) : (context * func) result =
 
   (* Compute additional locals (beyond parameters) *)
   let local_count = ctx_final.next_local - param_count in
-  let locals = if local_count > 0 then
-    [{ l_count = local_count; l_type = I32 }]
-  else
-    []
+  (* Float wall: declare each non-param local with its tracked value type
+     (default i32), so a float-bound local is f64; RLE into local groups. *)
+  let local_vts = List.init (max 0 local_count) (fun i ->
+    let idx = param_count + i in
+    match List.assoc_opt idx ctx_final.local_types with Some t -> t | None -> I32)
   in
+  let locals = rle_locals local_vts in
 
   (* Create function (type index will be set by gen_decl) *)
   let func = {
@@ -2955,13 +3046,14 @@ let intern_func_type (types : func_type list) (ft : func_type) : int * func_type
   in
   find_idx 0 types
 
-(** Build a WASM-side [func_type] for a top-level function declaration, mirroring
-    the convention used by [gen_decl TopFn]: every param is i32, the result is
-    [i32]. Used both for local fn types and for imported fn types so that calls
-    through either path agree on signature. *)
+(** Build a WASM-side [func_type] for a top-level function declaration. Params
+    and result follow the AffineScript type via [type_to_wasm] (Float wall:
+    `Float` -> F64, everything else -> i32). Used by [gen_decl TopFn] AND by
+    call/import sites so every path agrees on the signature. *)
 let func_type_of_fn_decl (fd : fn_decl) : func_type =
-  let params = List.map (fun _ -> I32) fd.fd_params in
-  let results = [I32] in
+  let vt ty = match type_to_wasm ty with Ok t -> t | Error _ -> I32 in
+  let params = List.map (fun p -> vt p.p_ty) fd.fd_params in
+  let results = match fd.fd_ret_ty with Some ty -> [vt ty] | None -> [I32] in
   { ft_params = params; ft_results = results }
 
 let gen_decl (ctx : context) (decl : top_level) : context result =
@@ -2992,9 +3084,9 @@ let gen_decl (ctx : context) (decl : top_level) : context result =
 
   | TopFn fd ->
     (* Create function type *)
-    let param_types = List.map (fun _ -> I32) fd.fd_params in
-    let result_type = [I32] in
-    let func_type = { ft_params = param_types; ft_results = result_type } in
+    (* Float wall: params/results follow the AS type (Float -> F64) via the
+       shared builder, so the definition signature matches call/import sites. *)
+    let func_type = func_type_of_fn_decl fd in
 
     (* Add type to types list *)
     let type_idx = List.length ctx.types in
@@ -3022,6 +3114,10 @@ let gen_decl (ctx : context) (decl : top_level) : context result =
       func_indices = ctx_with_type.func_indices @ [(fd.fd_name.name, func_idx)];
       ownership_annots = ctx_with_type.ownership_annots @ [(func_idx, param_kinds, ret_kind)];
       fn_ret_structs = fn_ret_structs';
+      (* Float wall: record this fn's result value type for call-site inference. *)
+      fn_ret_types = (fd.fd_name.name,
+        (match func_type.ft_results with t :: _ -> t | [] -> I32))
+        :: ctx_with_type.fn_ret_types;
     } in
 
     (* Generate function with correct type index *)

--- a/lib/effect_sites.ml
+++ b/lib/effect_sites.ml
@@ -74,7 +74,7 @@ let rec visit_expr (visit : expr -> unit) (e : expr) : unit =
   | ExprSpan (e, _) | ExprUnary (_, e) ->
     go_expr e
   | ExprIndex (a, b) | ExprBinary (a, _, b) | ExprStringConcat (a, b)
-  | ExprStringEq (a, b, _) | ExprStringRel (a, b, _) ->
+  | ExprStringEq (a, b, _) | ExprStringRel (a, b, _) | ExprFloatBinary (a, _, b) ->
     (* ExprStringConcat (slice 8b) recurses like ExprBinary and is NOT a call
        site: string `++` is not an effect operation, so keeping it out of the
        ExprApp census preserves effect-ordinal parity between the interpreter

--- a/lib/interp.ml
+++ b/lib/interp.ml
@@ -150,6 +150,12 @@ let rec eval (env : env) (expr : expr) : value result =
        never sees this wasm-only elaboration. *)
     eval env (ExprBinary (left, op, right))
 
+  | ExprFloatBinary (left, op, right) ->
+    (* Float wall: re-dispatch to the original Float `ExprBinary` — the
+       interpreter evaluates float ops directly and never sees this wasm-only
+       elaboration. *)
+    eval env (ExprBinary (left, op, right))
+
   | ExprBinary (left, op, right) ->
     let* left_val = eval env left in
     let* right_val = eval env right in

--- a/lib/opt.ml
+++ b/lib/opt.ml
@@ -90,6 +90,15 @@ let rec fold_constants_expr (expr : expr) : expr =
     else
       ExprStringRel (left', right', op)
 
+  (* Float wall: fold sub-expressions of a Float binop. *)
+  | ExprFloatBinary (left, op, right) ->
+    let left' = fold_constants_expr left in
+    let right' = fold_constants_expr right in
+    if left == left' && right == right' then
+      expr
+    else
+      ExprFloatBinary (left', op, right')
+
   | ExprUnary (op, operand) ->
     let operand' = fold_constants_expr operand in
     if operand == operand' then

--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -785,6 +785,20 @@ let string_rel_sites : expr list ref = ref []
 (** Discard any recorded String-relational sites (e.g. before re-checking). *)
 let reset_string_rel_sites () : unit = string_rel_sites := []
 
+(** Float wall. Physical-identity record of the `Float`-typed binary-op nodes
+    (`+`/`-`/`*`/`/`, `<`/`<=`/`>`/`>=`, `==`/`!=`). They type-check (synth
+    dispatches `Float`) but codegen's [gen_binop] returns only the i32
+    instruction family, so an f64 operand reaches `i32.lt_s`/`i32.add`/… and
+    fails wasm validation. Populated by {!synth} (three sites: the arith
+    branch's `Float` case, the `comparison` branch's `Float` case, and the
+    `==`/`!=` else branch when the operands are `Float`); consumed by
+    {!elaborate_string_concat} (which clears it) to rewrite them into
+    {!Ast.ExprFloatBinary} for the f64 lowering. *)
+let float_binop_sites : expr list ref = ref []
+
+(** Discard any recorded Float-binop sites (e.g. before re-checking). *)
+let reset_float_binop_sites () : unit = float_binop_sites := []
+
 (** {1 Expression synthesis (mode ⇒)} *)
 
 (** Synthesize a type for an expression. *)
@@ -1079,6 +1093,9 @@ let rec synth (ctx : context) (expr : expr) : ty result =
       match repr lhs_ty with
       | TCon "Float" ->
         let* () = check ctx rhs ty_float in
+        (* Float wall: record this arith node so elaboration rewrites it to
+           ExprFloatBinary (codegen must emit f64 ops, not the i32 family). *)
+        float_binop_sites := concat_node :: !float_binop_sites;
         Ok ty_float
       | _ ->
         let (lhs_ty', rhs_ty, result_ty) = type_of_binop op in
@@ -1090,6 +1107,8 @@ let rec synth (ctx : context) (expr : expr) : ty result =
       match repr lhs_ty with
       | TCon "Float" ->
         let* () = check ctx rhs ty_float in
+        (* Float wall: relational Float comparison -> ExprFloatBinary (f64 cmp). *)
+        float_binop_sites := concat_node :: !float_binop_sites;
         Ok ty_bool
       | TCon "String" ->
         (* String relational ops are byte-wise lexicographic, matching
@@ -1152,6 +1171,7 @@ let rec synth (ctx : context) (expr : expr) : ty result =
        | OpEq | OpNe ->
          (match repr lhs_ty with
           | TCon "String" -> string_eq_sites := concat_node :: !string_eq_sites
+          | TCon "Float" -> float_binop_sites := concat_node :: !float_binop_sites
           | _ -> ())
        | _ -> ());
       Ok result_ty
@@ -1512,10 +1532,13 @@ let rec elab_expr (e : expr) : expr =
     then ExprStringEq (l', r', (match op with OpNe -> true | _ -> false))
     else if List.memq e !string_rel_sites
     then ExprStringRel (l', r', op)
+    else if List.memq e !float_binop_sites
+    then ExprFloatBinary (l', op, r')
     else ExprBinary (l', op, r')
   | ExprStringConcat (l, r) -> ExprStringConcat (elab_expr l, elab_expr r)
   | ExprStringEq (l, r, neg) -> ExprStringEq (elab_expr l, elab_expr r, neg)
   | ExprStringRel (l, r, op) -> ExprStringRel (elab_expr l, elab_expr r, op)
+  | ExprFloatBinary (l, op, r) -> ExprFloatBinary (elab_expr l, op, elab_expr r)
   | ExprSpan (e', sp) -> ExprSpan (elab_expr e', sp)
   | ExprLit _ | ExprVar _ | ExprVariant _ -> e
   | ExprField (base, fld) -> ExprField (elab_expr base, fld)
@@ -1610,13 +1633,15 @@ let elaborate_string_concat (program : program) : program =
      `==`/`!=` rewrite — [elab_expr] consults both site lists, so one walk
      (and the existing single wasm-path call site) covers both. *)
   let result =
-    match !string_concat_sites, !string_eq_sites, !string_rel_sites with
-    | [], [], [] -> program
+    match !string_concat_sites, !string_eq_sites, !string_rel_sites,
+          !float_binop_sites with
+    | [], [], [], [] -> program
     | _ -> { program with prog_decls = List.map elab_top program.prog_decls }
   in
   reset_string_concat_sites ();
   reset_string_eq_sites ();
   reset_string_rel_sites ();
+  reset_float_binop_sites ();
   result
 
 (** {1 Declaration checking} *)

--- a/proposals/EVIDENCE-float-wall-finding.adoc
+++ b/proposals/EVIDENCE-float-wall-finding.adoc
@@ -3,6 +3,14 @@
 = Finding: the "float wall" — Float arith/compare codegen emits i32 ops (2026-06-14)
 :toc: macro
 
+[IMPORTANT]
+====
+*RESOLVED (2026-06-14).* The float wall is implemented — Float binops lower to
+the f64 family, and Float values flow through params/results/typed locals. See
+`EVIDENCE-float-wall-implementation.adoc`. This document is retained as the
+original finding + fix-shape analysis.
+====
+
 == Summary
 
 `Float`-typed binary operations (`+`, `-`, `*`, `/`, `<`, `<=`, `>`, `>=`, `==`)

--- a/proposals/EVIDENCE-float-wall-implementation.adoc
+++ b/proposals/EVIDENCE-float-wall-implementation.adoc
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+= Float wall — implementation (2026-06-14)
+:toc: macro
+
+toc::[]
+
+== Summary
+
+The "float wall" (see `EVIDENCE-float-wall-finding.adoc`) is closed. `Float`
+binary operations now lower to the f64 instruction family, and `Float` values
+flow correctly through function parameters, results, and locals. Built in two
+verified stages, mirroring the string-wall type-channel pattern.
+
+== Stage 1 — params, results, and binop dispatch
+
+* *`ExprFloatBinary of expr * binary_op * expr`* (`ast.ml`): a dedicated node for
+  a `Float`-typed binop, introduced by the post-typecheck elaboration like
+  `ExprStringEq`/`ExprStringRel`.
+* *typecheck* records `Float`-typed binop nodes into `float_binop_sites` at the
+  three synth sites (arith branch's `Float` case, `comparison` branch's `Float`
+  case, and the `==`/`!=` else branch when operands are `Float`);
+  `elaborate_string_concat` rewrites them to `ExprFloatBinary`.
+* *codegen* lowers `ExprFloatBinary` to the f64 family: arithmetic
+  (`+ - * /`) → `F64Add`/`F64Sub`/`F64Mul`/`F64Div` (an f64 value); the six
+  comparisons (`< <= > >= == !=`) → `F64Lt`/`…`/`F64Ne` (an i32 bool).
+* *params/results* (`func_type_of_fn_decl`, used by both definitions and call
+  sites) now follow the AS type via `type_to_wasm` (`Float` → F64), so a `Float`
+  param is an f64 slot and a `Float`-returning fn declares an f64 result.
+
+Stage 1 makes `Float`-param classifiers, stack-flowing float arithmetic, and
+`Float`-returning functions compile — anything that does not bind a float to a
+named local.
+
+== Stage 2 — typed locals
+
+* *context* gains `local_types : (int * value_type) list` (local index → wasm
+  type, default i32) and `fn_ret_types : (string * value_type) list`.
+* *`expr_val_type`* structurally infers whether an expression yields f64 (float
+  literal, `ExprFloatBinary` arith, a tracked f64 local/param, an f64-returning
+  call, and the obvious congruences), defaulting to i32.
+* *`let` bindings* (`StmtLet`, `ExprLet`) record a float-bound local's index as
+  F64; *params* are recorded from their declared type.
+* *`gen_function`* emits `f_locals` by mapping each non-param local index to its
+  tracked type and run-length-encoding (`rle_locals`), instead of one i32 group.
+  Critically it resets `local_types` per function (indices restart at 0), so a
+  prior function's f64-local does not mis-type a later function's i32 local.
+
+== Verification
+
+* New e2e fixture `test/e2e/fixtures/float_wall.affine` + `test_e2e.ml`
+  (`test_floatwall_lowers_to_f64`). Executed value 11210 (out-of-band).
+* Behavioural (out-of-band, Deno): params, comparisons, stack arith, `Float`
+  returns, float locals, float-local chains, float-fn-call bindings, and mixed
+  int/float locals — all correct.
+* `proposals/nextgen-evangelist/affine-parity/examples/string_float_demo`
+  exercises the harness f64 arg pass-through with a real `band_of(Float)` brain
+  (8/8, alongside the String cases — 30/30 total).
+* *No regression*: 48,000+ int-brain parity cases across the idaptik corpus pass
+  unchanged (typed locals are inert for all-i32 functions — they RLE to a single
+  i32 group, identical to the previous emission).
+
+== Not in scope (follow-ons)
+
+* *Float unary negation* (`-x` on `Float`) still routes through `ExprUnary`/
+  `gen_unop` (i32 `0 - x`); a small parallel fix.
+* *Internal calls passing Float arguments*: the call-instruction type builders
+  (distinct from `func_type_of_fn_decl`) still assume i32 args, so an internal
+  `g(floatExpr)` call would mis-type. External entry points (the harness / JS)
+  are unaffected. `OpMod`/bitwise on `Float` are rejected loudly.

--- a/proposals/nextgen-evangelist/affine-parity/examples/string_float_demo.affine
+++ b/proposals/nextgen-evangelist/affine-parity/examples/string_float_demo.affine
@@ -15,3 +15,9 @@ pub fn classify(s: String) -> Int {
 pub fn str_cmp(a: String, b: String) -> Int {
   if a < b { -1 } else { if a == b { 0 } else { 1 } }
 }
+
+// Float wall: a Float-argument classifier — exercises the harness's f64 arg
+// pass-through (now that Float binop codegen lands).
+pub fn band_of(x: Float) -> Int {
+  if x < 10.0 { 0 } else { if x < 100.0 { 1 } else { 2 } }
+}

--- a/proposals/nextgen-evangelist/affine-parity/examples/string_float_demo.config.mjs
+++ b/proposals/nextgen-evangelist/affine-parity/examples/string_float_demo.config.mjs
@@ -6,5 +6,7 @@ export default {
       oracle: (s) => (s === "scan" ? 1 : s === "exit" ? 2 : 0) },
     { export: "str_cmp", args: [{ strings: ["a", "ab", "b", ""] }, { strings: ["a", "ab", "b", ""] }],
       oracle: (a, b) => (a < b ? -1 : a === b ? 0 : 1) },
+    { export: "band_of", args: [{ values: [0.0, 5.5, 9.999, 10.0, 50.0, 99.9, 100.0, 250.0] }],
+      oracle: (x) => (x < 10 ? 0 : x < 100 ? 1 : 2) },
   ],
 };

--- a/test/e2e/fixtures/float_wall.affine
+++ b/test/e2e/fixtures/float_wall.affine
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025-2026 hyperpolymath
+//
+// Float-wall e2e fixture: Float params/returns/locals + arithmetic + the six
+// comparisons all lower to the f64 instruction family (ExprFloatBinary) instead
+// of the i32 family gen_binop returns. Exercises a float local (`s`), a
+// float-returning fn (favg), a float-fn-call binding (avg), and mixed bands.
+// Executed value (verified out-of-band): 11210.
+
+fn band(x: Float) -> Int {
+  if x < 10.0 { 0 } else { if x < 100.0 { 1 } else { 2 } }
+}
+fn favg(a: Float, b: Float) -> Float {
+  let s = a + b;
+  s / 2.0
+}
+fn main() -> Int {
+  let avg = favg(3.0, 5.0);
+  band(5.0)
+  + band(50.0) * 10
+  + band(500.0) * 100
+  + (if avg < 5.0 { 1 } else { 0 }) * 1000
+  + (if avg > 3.0 { 1 } else { 0 }) * 10000
+}

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -4117,6 +4117,22 @@ let test_stringwall_rel_lowers_after_elaboration () =
          "slice 10: string `<`/`<=`/`>`/`>=` should lower to wasm after elaboration, got: %s"
          msg)
 
+(* Float wall: Float binops (+ - * / and the six comparisons) type-check but
+   gen_binop returns only the i32 family. The float fixture exercises Float
+   params/returns/locals/arith/comparisons, which must compile after the
+   ExprFloatBinary elaboration rather than emitting i32 ops on f64 operands. *)
+let test_floatwall_lowers_to_f64 () =
+  match run_frontend (fixture "float_wall.affine") with
+  | Error e -> Alcotest.failf "frontend failed on float_wall.affine: %s" e
+  | Ok (prog, _resolve_ctx) ->
+    let elaborated = Affinescript.Typecheck.elaborate_string_concat prog in
+    (match wasm_codegen elaborated with
+     | Ok _ -> ()
+     | Error msg ->
+       Alcotest.failf
+         "float wall: Float binops should lower to the f64 family after elaboration, got: %s"
+         msg)
+
 let stringwall_concat_guard_tests = [
   Alcotest.test_case "string `++` is rejected (not silently miscompiled)"
     `Quick test_stringwall_concat_guard_rejects_string;
@@ -4128,6 +4144,8 @@ let stringwall_concat_guard_tests = [
     `Quick test_stringwall_eq_lowers_after_elaboration;
   Alcotest.test_case "string `<`/`<=`/`>`/`>=` lowers to wasm after elaboration (slice 10)"
     `Quick test_stringwall_rel_lowers_after_elaboration;
+  Alcotest.test_case "Float binops lower to the f64 family after elaboration (float wall)"
+    `Quick test_floatwall_lowers_to_f64;
 ]
 
 (* ---- STDLIB-04b: Throws extern `error<T>` (Refs #329) ----


### PR DESCRIPTION
## Summary

Implements the **float wall** — the float counterpart to the string wall. `Float` binary ops (`+ - * /` and the six comparisons) type-checked but the wasm backend lowered them with the **i32** instruction family on f64 operands (failing validation: `i32.lt_s ... found f64`), and `Float` params/results/locals were hard-coded `i32`, so float values couldn't flow at all.

## Two stages (mirroring the string-wall type-channel)

**Stage 1 — params / results / binop dispatch:** new `ExprFloatBinary` AST node; typecheck records `Float`-typed binops (`float_binop_sites`, three synth sites) and `elaborate_string_concat` rewrites them; codegen lowers to the f64 family (`F64Add`…, `F64Lt`… — arith → f64 value, comparison → i32 bool); `func_type_of_fn_decl` (shared by definitions **and** call sites, so signatures agree) lowers params/results via `type_to_wasm` (`Float → F64`).

**Stage 2 — typed locals:** `context` gains `local_types` + `fn_ret_types`; `expr_val_type` structurally infers f64-yielding expressions; `let` bindings record float-bound locals as f64; `gen_function` RLE-emits typed `f_locals` and **resets `local_types` per function** — the one real bug found in testing: local indices restart at 0, so a prior function's f64 local was mis-typing a later function's i32 local.

## Verification

- params, comparisons, stack arith, **`Float` returns**, float locals + chains, float-fn-call bindings, **mixed int/float locals** — all correct (`test/e2e/fixtures/float_wall.affine` → 11210; e2e test added)
- harness demo exercises the f64 arg pass-through via a real `band_of(Float)` brain — **30/30** across String + Float args
- **no regression**: **48,000+** int-brain parity cases pass unchanged (typed locals are inert for all-i32 functions — they RLE to a single i32 group, identical to before)

## Effect

The float-domain idaptik modules previously marked `NO_NEW_BRAINS` *only* because of the integer-only parity ABI are now compilable and parity-testable.

## Follow-ons (noted in `EVIDENCE-float-wall-implementation.adoc`)

Float unary negation (`-x`) still routes through `gen_unop`; internal calls passing `Float` args (call-instruction type builders still assume i32 args — external entry points unaffected). `OpMod`/bitwise on `Float` are rejected loudly.

https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKhFQePiRsAj7aqnxbG8s)_