### PR TITLE
fix(parser): #558 — honest-reject removed assume(...); fix misnamed fixture

### DIFF
--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -1107,6 +1107,23 @@ expr_primary:
   | UNSAFE LBRACE ops = list(unsafe_op) RBRACE
     { ExprUnsafe ops }
 
+  /* #558: `assume(predicate)` is the removed refinement-assertion form
+     (spec.md §830; refinement / dependent types were removed 2026-04-10,
+     CORE-05 deferred post-v1). The `ASSUME` keyword token had no production,
+     so it surfaced a cryptic generic parse error. Reject it honestly and
+     deliberately instead — the predicate is parsed only so the error can
+     point at it, never enforced (there is no silent-accept path). The
+     refinement TYPE form `T where (P)` cannot be given the same fence without
+     regressing trait where-clauses (the shared `WHERE` token forces a
+     shift/reduce decision before the predicate is visible), so it still
+     surfaces a generic parse error. */
+  | ASSUME LPAREN expr RPAREN
+    { raise (Parser_errors.Parse_action_error
+        ("refinement assertion `assume(...)` is not supported in v1: \
+          refinement and dependent types were removed 2026-04-10 (CORE-05 \
+          is deferred post-v1); the predicate is parsed but never enforced. \
+          Refs #558.", $startpos, $endpos)) }
+
 /* expr_record_body / expr_record_rest: recursive parse of `{ f:v, ..spread }`
    record expressions.  Spread is lexed as ROW_VAR when it is a bare
    identifier (e.g. `..record`), or starts with DOTDOT when it is an

--- a/test/e2e/fixtures/assume_rejected.affine
+++ b/test/e2e/fixtures/assume_rejected.affine
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 hyperpolymath
+//
+// Issue #558 (honest-rejection). `assume(predicate)` is the removed
+// refinement-assertion form (CORE-05 deferred post-v1). The parser must reject
+// it with a deliberate, named error — not a cryptic generic parse error — and
+// must never silently accept it.
+fn f(x: Int) -> Int {
+  assume(x > 0);
+  x
+}

--- a/test/e2e/fixtures/generic_functions.affine
+++ b/test/e2e/fixtures/generic_functions.affine
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+// End-to-end test: generic function parsing (type parameters).
+// Renamed from refinement_types.affine (#558): the fixture exercises generic
+// functions, not refinement types — refinement/dependent types were removed
+// 2026-04-10. It contains no `where` clause and no refinement predicate.
+
+fn identity[T](x: T) -> T = x;
+
+fn apply[T, U](f: (T) -> U, x: T) -> U = f(x);

--- a/test/e2e/fixtures/refinement_types.affine
+++ b/test/e2e/fixtures/refinement_types.affine
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: MPL-2.0
-// End-to-end test: type constraints via where clauses
-// Tests: parsing of where-clause constraints on generic functions
-
-fn identity[T](x: T) -> T = x;
-
-fn apply[T, U](f: (T) -> U, x: T) -> U = f(x);

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -173,12 +173,31 @@ let test_parse_dependent_types () =
     (* 1 type decl + 3 functions *)
     Alcotest.(check int) "declaration count" 4 (List.length prog.prog_decls)
 
-let test_parse_refinement_types () =
-  match parse_fixture (fixture "refinement_types.affine") with
+let test_parse_generic_functions () =
+  (* Renamed from test_parse_refinement_types (#558): the fixture exercises
+     generic functions, not refinement types (which were removed 2026-04-10
+     and never parsed silently). *)
+  match parse_fixture (fixture "generic_functions.affine") with
   | Error msg -> Alcotest.fail msg
   | Ok prog ->
     Alcotest.(check bool) "has declarations" true
       (List.length prog.prog_decls > 0)
+
+let test_parse_assume_rejected () =
+  (* #558 honest-rejection: `assume(predicate)` (the removed refinement-assert)
+     must fail with a deliberate, named parse error, never be silently
+     accepted. *)
+  match parse_fixture (fixture "assume_rejected.affine") with
+  | Ok _ ->
+      Alcotest.fail
+        "expected `assume(...)` to be rejected (Refs #558); got Ok — the \
+         removed refinement-assertion form is being silently accepted"
+  | Error msg ->
+      let mentions s =
+        try ignore (Str.search_forward (Str.regexp_string s) msg 0); true
+        with Not_found -> false in
+      Alcotest.(check bool) "error names the assume/refinement rejection" true
+        (mentions "assume" || mentions "refinement")
 
 let test_parse_traits () =
   match parse_fixture (fixture "traits.affine") with
@@ -251,7 +270,8 @@ let parse_tests = [
   Alcotest.test_case "arithmetic" `Quick test_parse_arithmetic;
   Alcotest.test_case "affine_basic" `Quick test_parse_affine_basic;
   Alcotest.test_case "dependent_types" `Quick test_parse_dependent_types;
-  Alcotest.test_case "refinement_types" `Quick test_parse_refinement_types;
+  Alcotest.test_case "generic_functions" `Quick test_parse_generic_functions;
+  Alcotest.test_case "assume() honest-rejection (#558)" `Quick test_parse_assume_rejected;
   Alcotest.test_case "traits" `Quick test_parse_traits;
   Alcotest.test_case "effects" `Quick test_parse_effects;
   Alcotest.test_case "ownership" `Quick test_parse_ownership;


### PR DESCRIPTION
## Context — the premise is stale

#558 reports refinement-type predicates that "parse but are silently not enforced (`TRefined`)". Investigation shows this is **no longer accurate**: `TRefined` does not exist in the AST, and refinement/dependent types (including `T where (P)` and `assume(predicate)`) were **removed 2026-04-10** (`spec.md` §711–713, §1849). Refinement syntax **parse-errors** today — there is **no silent-accept / accepts-wrong-program path**, so this is not the live soundness hole the issue describes. The genuine residual defects are *honesty* ones, addressed here where viable.

## Changes

1. **`assume(...)` honest-rejection** (`lib/parser.mly`). The `ASSUME` keyword token was left dangling (no production) by the 2026-04-10 grammar removal, so `assume(...)` surfaced a cryptic generic parse error. Add a **conflict-free** production (ASSUME is a fresh token — **zero** new LR conflicts; verified 68 s/r + 7 r/r unchanged) that raises a deliberate, named error pointing at the removed feature.
2. **Fix the misnamed fixture.** `refinement_types.affine` contained only generic functions (no refinement, no `where`) yet produced a green `refinement_types` test — false coverage. Renamed to `generic_functions.affine` + `test_parse_generic_functions`, comment corrected.

## Deliberately out of scope

- **`T where (P)` honest-rejection is non-viable.** It cannot be fenced without **regressing trait where-clauses**: the shared `WHERE` token forces a shift/reduce decision *before* the predicate is visible, and menhir resolves it by shifting into the refinement — breaking `fn f() -> T where C`. It still surfaces a generic parse error.
- **The doc-lies** (`CAPABILITY-MATRIX.adoc` "TRefined parses", `STATE`/`TECH-DEBT` CORE-05 rows) are **owner-only** edits — the strict SPDX-header pre-commit gate on `.adoc`/`.md` blocks them. Flagged for manual reconciliation.
- Dead error codes `E0305`/`W0701` left in place (harmless; removal is churn).

## Tests

New `E2E Parse` cases — `generic_functions` (parses, honest coverage) and `assume() honest-rejection (#558)` (deliberate parse error). Full suite **452/452 green**.

Refs #558 — recommend reframing the issue from "soundness" to "doc-truthing + hygiene"; the doc reconciliation is the remaining owner-gated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)