### PR TITLE
fix(ci): format lib/borrow_polonius/dune to satisfy dune fmt

### DIFF
--- a/lib/borrow_polonius/dune
+++ b/lib/borrow_polonius/dune
@@ -1,6 +1,7 @@
 ; ADR-022 M1: the Polonius-style loan solver lives in its own library, created
 ; but NOT yet wired into `affinescript` (nothing depends on it). M3 wires it in
 ; behind a parallel-run diff against the lexical checker; M4 cuts over.
+
 (library
  (name borrow_polonius)
  (public_name affinescript.borrow_polonius)


### PR DESCRIPTION
## What

Greens `main`'s `build` job. After #617 fixed the doc-truthing guard, the next `build` step — `dune build @fmt` — fails because **#614 added `lib/borrow_polonius/dune` without the blank line** `dune fmt` requires between the comment block and the `(library …)` stanza.

## Fix

Add the single blank line (canonical `dune format-dune-file` output). Nothing else changes.

> Note: root `dune-project` / `.build/dune-project` show "drift" only under newer **local** dune (3.14.0) and drift identically on `2aa00ff` where CI's `@fmt` was green — i.e. CI's dune does **not** flag them, so they're deliberately left untouched.

## Why this is a separate PR

#614 was merged (bypass) while its CI was incomplete — the `build` job died at doc-truthing *before* reaching `@fmt`, so its `@fmt` compliance was never checked. #617 fixed the first failure; this fixes the one it unmasked. After this, the `build` job should be green.

Verified: `dune format-dune-file lib/borrow_polonius/dune` is now a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lz7pRcec2Z3tVtaAhvB3M8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lz7pRcec2Z3tVtaAhvB3M8)_