### PR TITLE
chore(guix): substitute leftover template placeholders; fix licence comment

### DIFF
--- a/affinescript-vite/.guix-channel
+++ b/affinescript-vite/.guix-channel
@@ -1,5 +1,5 @@
 ;; SPDX-License-Identifier: MPL-2.0
-;; Copyright (c) {{CURRENT_YEAR}} hyperpolymath (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+;; Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 ;;
 ;; Guix channel definition for AffineScript-Vite
 ;;

--- a/affinescript-vite/guix.scm
+++ b/affinescript-vite/guix.scm
@@ -1,5 +1,5 @@
 ;; SPDX-License-Identifier: MPL-2.0
-;; Copyright (c) {{CURRENT_YEAR}} hyperpolymath (hyperpolymath) <j.d.a.jewell@open.ac.uk>
+;; Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 ;;
 ;; Guix package definition for AffineScript-Vite
 ;;
@@ -64,8 +64,6 @@
     ;; TODO: Add runtime dependencies
     ))
   (home-page "https://github.com/hyperpolymath/AffineScript-Vite")
-  (synopsis "{{PROJECT_PURPOSE}}")
+  (synopsis "Official Vite plugin for AffineScript — compiles .as/.affine to WASM + JS with HMR")
   (description "RSR-compliant project. See README.adoc for details.")
-  (license (list
-            ;; MPL-2.0 extends MPL-2.0
-            mpl2.0)))
+  (license mpl2.0))

--- a/affinescriptiser/.guix-channel
+++ b/affinescriptiser/.guix-channel
@@ -1,20 +1,20 @@
 ;; SPDX-License-Identifier: MPL-2.0
-;; Copyright (c) {{CURRENT_YEAR}} {{AUTHOR}} ({{OWNER}}) <{{AUTHOR_EMAIL}}>
+;; Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 ;;
-;; Guix channel definition for {{PROJECT_NAME}}
+;; Guix channel definition for affinescriptiser
 ;;
 ;; To use this channel, add to ~/.config/guix/channels.scm:
 ;;
 ;;   (channel
-;;     (name '{{PROJECT_NAME}})
-;;     (url "https://github.com/{{OWNER}}/{{PROJECT_NAME}}")
+;;     (name 'affinescriptiser)
+;;     (url "https://github.com/hyperpolymath/affinescriptiser")
 ;;     (branch "main"))
 ;;
 ;; Then: guix pull
 
 (channel
   (version 0)
-  (url "https://github.com/{{OWNER}}/{{PROJECT_NAME}}")
+  (url "https://github.com/hyperpolymath/affinescriptiser")
   (dependencies
    (channel
      (name 'guix)

--- a/affinescriptiser/guix.scm
+++ b/affinescriptiser/guix.scm
@@ -1,13 +1,15 @@
 ;; SPDX-License-Identifier: MPL-2.0
 ;; Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 ;;
-;; Guix package definition for {{PROJECT_NAME}}
+;; Guix package definition for affinescriptiser
 ;;
 ;; Usage:
 ;;   guix shell -D -f guix.scm    # Enter development shell
 ;;   guix build -f guix.scm       # Build package
 ;;
-;; TODO: Replace {{PROJECT_NAME}} and customize inputs for your language/stack.
+;; affinescriptiser is a Rust CLI (cargo build --release). The build phases
+;; below are the RSR scaffold default (install README only); wiring the real
+;; cargo build is tracked separately.
 ;; See: https://guix.gnu.org/manual/en/html_node/Defining-Packages.html
 
 (use-modules (guix packages)
@@ -18,7 +20,7 @@
              (gnu packages base))
 
 (package
-  (name "{{PROJECT_NAME}}")
+  (name "affinescriptiser")
   (version "0.1.0")
   (source (local-file "." "source"
                        #:recursive? #t
@@ -28,20 +30,9 @@
   (arguments
    '(#:phases
      (modify-phases %standard-phases
-       ;; TODO: Customize build phases for your project
-       ;; Examples for common stacks:
-       ;;
-       ;; Rust:
+       ;; TODO: wire the real Rust build, e.g.
        ;;   (replace 'build (lambda _ (invoke "cargo" "build" "--release")))
        ;;   (replace 'check (lambda _ (invoke "cargo" "test")))
-       ;;
-       ;; Elixir:
-       ;;   (replace 'build (lambda _ (invoke "mix" "compile")))
-       ;;   (replace 'check (lambda _ (invoke "mix" "test")))
-       ;;
-       ;; Zig:
-       ;;   (replace 'build (lambda _ (invoke "zig" "build")))
-       ;;   (replace 'check (lambda _ (invoke "zig" "build" "test")))
        (delete 'configure)
        (delete 'build)
        (delete 'check)
@@ -53,19 +44,14 @@
                         (string-append out "/share/doc/README.adoc"))))))))
   (native-inputs
    (list
-    ;; TODO: Add build-time dependencies
-    ;; Examples:
-    ;;   rust (gnu packages rust)
-    ;;   elixir (gnu packages elixir)
-    ;;   zig (gnu packages zig)
+    ;; TODO: add build-time dependencies (Rust toolchain) once the cargo
+    ;; build phase above is wired.
     ))
   (inputs
    (list
-    ;; TODO: Add runtime dependencies
+    ;; TODO: add runtime dependencies
     ))
-  (home-page "https://github.com/hyperpolymath/{{PROJECT_NAME}}")
-  (synopsis "{{PROJECT_PURPOSE}}")
+  (home-page "https://github.com/hyperpolymath/affinescriptiser")
+  (synopsis "Wrap code in affine + dependent types targeting WASM")
   (description "RSR-compliant project. See README.adoc for details.")
-  (license (list
-            ;; MPL-2.0 extends MPL-2.0
-            mpl2.0)))
+  (license mpl2.0))


### PR DESCRIPTION
Fixes guix drift in two RSR-scaffolded sub-projects whose guix files still carried unsubstituted `{{...}}` template tokens and a nonsense licence comment.

- **`affinescriptiser/guix.scm`** + **`affinescriptiser/.guix-channel`** — substituted every leftover placeholder: `{{PROJECT_NAME}}` → `affinescriptiser`, `{{OWNER}}` → `hyperpolymath`, `{{AUTHOR}}`/`{{AUTHOR_EMAIL}}`/`{{CURRENT_YEAR}}` → the canonical author / 2026. Real `synopsis` ("Wrap code in affine + dependent types targeting WASM", from its CLAUDE.md); added a note that it's a Rust CLI and that wiring the real `cargo` build is follow-up.
- **`affinescript-vite/guix.scm`** + **`affinescript-vite/.guix-channel`** — substituted `{{CURRENT_YEAR}}` → 2026 and the canonical author; real `synopsis` (Vite plugin for AffineScript).
- Both `guix.scm` — replaced the nonsensical `(license (list ;; MPL-2.0 extends MPL-2.0 \n mpl2.0))` with the idiomatic single `(license mpl2.0)`.

## Notes / out of scope
- The build phases remain the RSR scaffold default (install `README.adoc` only); wiring the real `cargo`/Vite builds is a separate enhancement and is left as a TODO comment.
- **Flag (not guix, not changed here):** `affinescript-vite/README.adoc` carries a `License: AGPL-3.0` badge, which conflicts with the MPL-2.0 SPDX header + the estate MPL-2.0 policy. Worth reconciling separately.

## Verification
- ✅ All four files paren-balanced; no `{{...}}` placeholders remain.
- ⚠️ **No guix toolchain in this environment**, so `guix build` could not be run — changes are by inspection + paren-balance only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wqBHniW8sHDCqCoEvBe9n

---
_Generated by [Claude Code](https://claude.ai/code/session_015wqBHniW8sHDCqCoEvBe9n)_