### PR TITLE
fix(ci): soundness gate must not assume bare `dune` on PATH (greens main)

### DIFF
--- a/tools/check-soundness-ledger.sh
+++ b/tools/check-soundness-ledger.sh
@@ -253,8 +253,21 @@ check_pins() {
   local pins; pins="$(pinned_row_pins)"
   [ -n "$pins" ] || { note "ERROR (property 5): no 'residual (pinned)'/'open (tracked)' rows found (fail closed)"; return 1; }
   printf '%s\n' "$pins" | grep -q '^NOPIN$' && { note "ERROR (property 5): a pinned/open row names no test_* pin (fail closed)"; return 1; }
-  dune build "$XFAIL_EXE" >/dev/null 2>&1 || { note "ERROR (property 5): cannot build ${XFAIL_EXE}"; return 1; }
-  local report; report="$(AFFINE_FIXTURES="$PWD/test/e2e/fixtures" "_build/default/${XFAIL_EXE}" 2>&1 || true)"
+  # Run the pin harness. CI builds it in the `dune build` / `dune runtest` steps
+  # before this gate, so prefer the pre-built binary and do NOT assume a bare
+  # `dune` is on PATH (in CI dune is reached via `opam exec --`, not bare). Only
+  # build if the exe is missing (e.g. a standalone local run), with whatever dune
+  # is available. Fail closed if it still isn't there.
+  local exe="_build/default/${XFAIL_EXE}"
+  if [ ! -x "$exe" ]; then
+    if command -v dune >/dev/null 2>&1; then
+      dune build "$XFAIL_EXE" >/dev/null 2>&1 || true
+    elif command -v opam >/dev/null 2>&1; then
+      opam exec -- dune build "$XFAIL_EXE" >/dev/null 2>&1 || true
+    fi
+  fi
+  [ -x "$exe" ] || { note "ERROR (property 5): pin harness ${exe} not built (run dune build first)"; return 1; }
+  local report; report="$(AFFINE_FIXTURES="$PWD/test/e2e/fixtures" "$exe" 2>&1 || true)"
   local pin r=0
   while IFS= read -r pin; do
     [ -z "$pin" ] && continue


### PR DESCRIPTION
Greens `main`, which #633 left red.

## Root cause
The soundness gate's property 5 ran `dune build test/xfail/test_xfail_pins.exe`. CI reaches dune only via `opam exec -- dune`, not bare `dune` on `PATH`, so this failed with *"ERROR (property 5): cannot build test/xfail/test_xfail_pins.exe"* — and the `build` job exited there (before `@fmt`). It greened locally because my dev box has `dune` at `/usr/bin/dune`; that environment difference is exactly what a local-only run can't catch.

## Fix
The harness exe is already built by the `dune build` / `dune runtest` steps that run *before* the gate, so the gate now prefers the **pre-built binary** (`_build/default/...`) and only builds — with whatever dune is available (`dune`, else `opam exec -- dune`) — if it's missing. Fail-closed if it still isn't there.

## Verified (the actual CI condition, not just locally)
Built the exe, then ran the gate with `dune`/`opam` removed from `PATH`:
```
dune on restricted PATH? NO
OK: soundness ledger — all 5 properties hold (...)
rc=0
```

## Note
#633's `build` died at this gate, so `@fmt` never ran on its `lib/*.ml` edits (the `return`-fence). With the gate fixed, CI here will reach `@fmt`; if it flags those lib edits I'll follow up (I can't run `ocamlformat` in my environment, so I'd apply the diff from the CI log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbxKhXQwTvVgkYDgBMLJoa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbxKhXQwTvVgkYDgBMLJoa)_