### PR TITLE
fix(release): restore release binaries — immutable-release draft flow + portable BSD sed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Create the release (idempotent)
+      - name: Create the release as a draft (idempotent)
+        # Immutable releases (enabled on this repo) forbid adding assets to a
+        # *published* release — the v0.2.0 build legs hit "HTTP 422: Cannot
+        # upload assets to an immutable release", so it shipped source-only.
+        # Fix: create the release as a DRAFT (still mutable); the build legs
+        # upload binaries into the draft and the checksums job publishes it
+        # last, sealing it atomically with all assets attached.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -42,7 +48,7 @@ jobs:
           if gh release view "$tag" >/dev/null 2>&1; then
             echo "release $tag already exists; reusing"
           else
-            gh release create "$tag" --generate-notes --verify-tag --title "$tag"
+            gh release create "$tag" --draft --generate-notes --verify-tag --title "$tag"
           fi
   build:
     needs: prepare
@@ -75,8 +81,14 @@ jobs:
         # LSP serverInfo, ONNX producer_version).
         run: |
           v="${GITHUB_REF_NAME#v}"
-          sed -i "s/^let value = .*/let value = \"$v\"/" lib/version.ml
-          sed -i "s/^(version .*)/(version $v)/" .build/dune-project
+          # Use `sed -i.bak` (backup-suffix attached): both GNU sed (Linux) and
+          # BSD sed (macOS) accept it. Bare `sed -i "s/..."` makes BSD sed treat
+          # the script as the backup suffix and the filename as a command, dying
+          # with "extra characters at the end of l command" — which is exactly
+          # why the v0.2.0 macOS legs failed before building anything.
+          sed -i.bak "s/^let value = .*/let value = \"$v\"/" lib/version.ml
+          sed -i.bak "s/^(version .*)/(version $v)/" .build/dune-project
+          rm -f lib/version.ml.bak .build/dune-project.bak
           echo "Baked version: $v"
           grep '^let value' lib/version.ml
           grep '^(version' .build/dune-project
@@ -107,3 +119,7 @@ jobs:
           ( cd dl && sha256sum affinescript-* | sort -k2 > SHA256SUMS )
           cat dl/SHA256SUMS
           gh release upload "$tag" --repo "$GITHUB_REPOSITORY" dl/SHA256SUMS --clobber
+          # Seal the release last. Under immutable releases assets can only be
+          # added while the release is a draft, so publish only once all four
+          # assets (three binaries + SHA256SUMS) are attached.
+          gh release edit "$tag" --repo "$GITHUB_REPOSITORY" --draft=false --latest


### PR DESCRIPTION
## Problem

`v0.2.0` shipped **source-only** (regression from `v0.1.1`, which had `affinescript-linux-x64`, `affinescript-macos-x64`, `affinescript-macos-arm64`, `SHA256SUMS`). Downstream consumers on locked-down networks rely on the prebuilt binary (building from source needs opam + ~15 packages, blocked when `opam.ocaml.org` 403s), and the `v0.1.1` binary can't parse `v0.2.0`-only syntax — e.g. quandledb's `quandle_gui.affine` → `Parse error` (quandledb PR #60 had to pin `v0.1.1`).

## Root cause — two bugs, both confirmed from the failed v0.2.0 run ([26694097435](https://github.com/hyperpolymath/affinescript/actions/runs/26694097435))

1. **Immutable releases.** `prepare` created a *published* release, then the build matrix uploaded assets to it. The repo enabled immutable releases between `v0.1.1` (`immutable:false`) and `v0.2.0` (`immutable:true`); immutable *published* releases reject asset uploads — the linux leg died with:
   ```
   HTTP 422: Cannot upload assets to an immutable release.
   ```
2. **BSD sed.** The version-bake step (added in v0.2.0) used `sed -i "s/…"`, which **BSD sed on the macOS runners** rejects (`sed: 1: "lib/version.ml": extra characters at the end of l command`) — so `macos-x64` and `macos-arm64` failed *before building anything*.

## Fix (`.github/workflows/release.yml` only)

- **Draft → upload → publish:** create the release as a `--draft` (mutable), let the build legs upload binaries into it, and `gh release edit --draft=false --latest` **last** in the checksums job — so it seals atomically with all four assets attached, compatible with immutable releases.
- **Portable in-place sed:** `sed -i.bak …` (accepted by both GNU and BSD sed) + remove the backups.

## Verification

- Compiler builds in release mode locally (`dune build --release` → ELF x86-64); `--version` and `check <file>` work.
- Bake substitutions match `lib/version.ml` (`let value = "0.2.1"`) and `.build/dune-project` (`(version 0.2.1)`).
- YAML validated.

## Publishing

`v0.2.0` is immutable and cannot be amended, so binaries are published via a fresh **`v0.2.1`** tag built with this fixed workflow (per the task: "otherwise cut v0.2.1"). This PR lands the same fix on `main` for all future releases.

Refs ADR-019, #260 S2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lz7pRcec2Z3tVtaAhvB3M8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lz7pRcec2Z3tVtaAhvB3M8)_