### PR TITLE
feat(ci): attest build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ jobs:
           fi
   build:
     needs: prepare
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -98,6 +102,10 @@ jobs:
         run: |
           install -m 0755 _build/default/bin/main.exe \
             "affinescript-${{ matrix.target }}"
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: 'affinescript-${{ matrix.target }}'
       - name: Upload the binary to the release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Estate build-provenance attestation rollout.

Adds `actions/attest-build-provenance@v2` (SHA-pinned, per the repo's full-SHA `uses:` policy) to the `build` matrix job of `release.yml`.

**Attested:** each per-target compiler binary (`affinescript-<target>` for linux-x64 / macos-x64 / macos-arm64) right after it is staged, before the `gh release upload`.

**Changes (additive only):**
- Added a job-level `permissions` block to `build`: `contents: write` (preserves the existing `gh release upload`) + `id-token: write` + `attestations: write`.
- Added an "Attest build provenance" step after "Stage the binary", with `subject-path: 'affinescript-${{ matrix.target }}'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)