### PR TITLE
feat(ci): package-registry provenance

### DIFF
--- a/.github/workflows/affine-vscode-publish.yml
+++ b/.github/workflows/affine-vscode-publish.yml
@@ -23,6 +23,7 @@ on:
       - 'affine-vscode-v*'
 permissions:
   contents: read
+  id-token: write # npm provenance via GitHub OIDC
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -54,7 +55,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${HOME}/.npmrc"
       - name: Publish to npm
         working-directory: packages/affine-vscode
-        run: npm publish --access public
+        run: npm publish --provenance --access public
       - name: Clean up npm auth
         if: always()
         run: rm -f "${HOME}/.npmrc"


### PR DESCRIPTION
Adds native package-registry provenance to the publish workflows (additive, no behavioural change to a successful publish).

## npm — `.github/workflows/affine-vscode-publish.yml`
Publishes `@hyperpolymath/affine-vscode` to **public npmjs** (`registry.npmjs.org`) via `npm publish`.
- Added `id-token: write` to the workflow-level `permissions:` (kept `contents: read`). The workflow has a single `publish` job, so top-level permissions cover it.
- Added `--provenance` to the publish command (kept existing `--access public`).
- npm will now attach a signed provenance attestation (built via GitHub OIDC).
- `package.json` already has a correct `repository` field (`https://github.com/hyperpolymath/affinescript.git`, directory `packages/affine-vscode`) — required for provenance, so nothing to fix.

## JSR — `.github/workflows/publish-jsr.yml`
JSR records provenance automatically when run in GitHub Actions with `id-token: write`.
- **No change needed**: the `publish` job already has `permissions: contents: read` + `id-token: write` (it relies on JSR OIDC and commits no token). `deno publish` needs no extra flag.

## Notes / skips
- No `vsce`/VS Code Marketplace publish exists in these workflows; the affine-vscode artefact is a genuine npm package consumed via `require(...)`, so the npm-provenance pattern applies cleanly.
- No GitHub Packages (`npm.pkg.github.com`) publish present — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)