### PR TITLE
fix(docs): repoint README soundness-ledger refs to docs/SOUNDNESS.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ Early and experimental. This is *v0.2*: the architecture is settled, the
 implementation and the metatheory are partial and still moving. It is suitable
 for experimentation, teaching, and small sound components -- not yet for
 production. What is proven, what is implemented, and what is still prose are
-stated plainly below and tracked in `SOUNDNESS-LEDGER.adoc`.
+stated plainly below and tracked in `docs/SOUNDNESS.adoc`.
 
 == What you get
 
@@ -142,7 +142,7 @@ risk here, and it is not yet solved.
 Soundness is *partially mechanised, and honestly tracked.* An initial,
 axiom-free, machine-checked result for code-generation preservation exists
 (Coq/Rocq). A number of residuals remain open; they are recorded -- not hidden
--- in `SOUNDNESS-LEDGER.adoc`, which states for each claim whether it is
+-- in `docs/SOUNDNESS.adoc`, which states for each claim whether it is
 mechanised or still argued in prose.
 
 The ledger is the source of truth for what currently holds. This README
@@ -192,7 +192,7 @@ totality cut, and a WebAssembly target -- rather than any one ingredient.
 == Documentation
 
 // TODO: link the design notes and the examples directory once locations are stable.
-* Soundness status: `SOUNDNESS-LEDGER.adoc`
+* Soundness status: `docs/SOUNDNESS.adoc`
 
 == License
 


### PR DESCRIPTION
## What

README referenced `SOUNDNESS-LEDGER.adoc` — a filename that **does not exist** — in three places (lines 30, 145, 195). The soundness single-source-of-truth is `docs/SOUNDNESS.adoc`. Repointed all three.

## Why it's not cosmetic

`tools/check-soundness-ledger.sh` **Property 2 (back-links)** does `grep -q "SOUNDNESS.adoc"` over the pointer docs (README.adoc, CAPABILITY-MATRIX, PROOF-NEEDS, NAVIGATION, .claude/CLAUDE.md). `SOUNDNESS-LEDGER.adoc` does not contain the substring `SOUNDNESS.adoc`, so the gate — wired into `just check` + CI — was **RED**:

```
ERROR (property 2): README.adoc no longer links to docs/SOUNDNESS.adoc
Soundness-ledger gate FAILED.
```

The other four pointer docs already referenced `docs/SOUNDNESS.adoc` correctly; README was the sole offender.

## Verification

Built off system OCaml 4.14.1 + opam (dune 3.24.0) and ran the full gate after the fix:

```
BUILD_EXIT=0
OK: soundness ledger — all 5 properties hold
  (anchors exist + back-links + content-bound + stamp-fresh + pins live).
GATE_EXIT=0
```

Docs-only; no build or behaviour change (`README.adoc | 6 +++---`).

## Out of scope (flagged, not bundled)
- README TODOs "add a LICENSE file" (×2) are stale — `LICENSE` (MPL-2.0, 16 KB) exists. Separate follow-up.
- `6a2` → `descriptiles` estate-mandate migration (`.machine_readable/6a2/` + 32 refs) — deserves its own scoped PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)