### PR TITLE
docs: reconcile stale "#255 blocker" refs — loop-codegen defect is fixed

### DIFF
--- a/docs/ECOSYSTEM.adoc
+++ b/docs/ECOSYSTEM.adoc
@@ -148,8 +148,10 @@ The contract is *narrower than older prose claimed* and is exactly this:
 |`affinescript-dom` |reconciler (compiles) |INT-08 (#183): `src/dom.as`
 (non-parsing 39-line stub) renamed to canonical `src/dom.affine` and
 replaced with a real VDOM + render + mount + minimal-mutation
-reconciler that compiles end-to-end. Runtime gated on #255 (pre-existing
-wasm loop-codegen defect).
+reconciler that compiles end-to-end. The #255 wasm loop-codegen defect that
+gated its runtime is *FIXED* (PR #257; issue closed 2026-05-19), so the
+runtime is no longer blocked by it; end-to-end DOM runtime remains to be
+re-verified.
 
 |`affinescript-pixijs` |skeleton |Migration-prerequisite scaffold (#56).
 
@@ -168,8 +170,8 @@ canonical `affinescript tea-bridge` + a re-entrancy fixture.
 shipped + closed 2026-05-31 as `packages/affine-js/loader.js` — already
 host-agnostic (Deno/Node/browser parity). Whether the satellite repo
 still earns its keep (vs. folding into `affine-js`) is the open question
-in #489; revisit when INT-08 reconciler runtime (#183) unblocks (#255)
-and dictates any DOM-specific loader surface.
+in #489; revisit when INT-08 reconciler runtime (#183) is re-verified (#255
+loop-codegen fixed via #257) and dictates any DOM-specific loader surface.
 
 |`affinescript-cadre` |scaffold |Was imaginary until #175. Router/navigation
 satellite (internal `lib/tea_router.ml` contract exists).
@@ -268,16 +270,18 @@ shipped (`TeaApp`/`parseTeaLayout`, Linear-msg enforced); INT-01 dep
 cleared (#253). Router/nav = separate INT-09
 |INT-08 |DOM reconciler in `affinescript-dom` |#183 |reconciler
 implemented + compiles (resolve→typecheck→codegen→wasm); `.as`→`.affine`
-corrected. INT-02 dep cleared. Runtime BLOCKED by #255 (wasm
-loop-codegen defect, pre-existing)
+corrected. INT-02 dep cleared. #255 (wasm loop-codegen defect) that gated
+the runtime is FIXED (PR #257, closed 2026-05-19); runtime to be re-verified
+end-to-end
 |INT-09 |`affinescript-cadre` router/navigation runtime |ledger-only
 |planned (blocked by INT-07)
 |INT-10 |LSP distribution (`affinescript-lsp`) |#282 |unblocked —
 distribution decided (ADR-019: Releases + thin Deno/JSR shim, #260).
 Consumes the shim once #260 S2/S3 land
 |INT-11 |Browser host parity (DOM loader + reconciler end-to-end) |
-ledger-only |planned (INT-02 dep cleared 2026-05-31 via #179; still
-blocked by INT-08 runtime via #255). Satellite-repo question = #489.
+ledger-only |planned (INT-02 dep cleared 2026-05-31 via #179; #255 that
+gated INT-08 runtime is fixed via #257 — pending INT-08 runtime
+re-verification). Satellite-repo question = #489.
 |INT-12 |typed-wasm convergence: AffineScript-emitted fixtures into the
 typed-wasm cross-compat suite (closes the Stage-E runway) |ledger-only |
 planned (Stage E; coordinates with `hyperpolymath/typed-wasm` C5.1)

--- a/docs/TECH-DEBT.adoc
+++ b/docs/TECH-DEBT.adoc
@@ -423,7 +423,8 @@ licence in root `LICENSE`).
 |INT-07 |`affinescript-tea` runtime |S2 |#182 runtime + run loop shipped
 (TeaApp/parseTeaLayout, Linear-msg enforced); INT-01 cleared (#253)
 |INT-08 |DOM reconciler |S2 |#183 implemented + compiles; `.as`→`.affine`
-fixed; runtime blocked by #255 (wasm loop-codegen defect)
+fixed; #255 (wasm loop-codegen defect) that gated the runtime is fixed
+(PR #257, closed 2026-05-19) — runtime to be re-verified end-to-end
 |INT-10 |`affinescript-lsp` distribution |S2 |**DONE end-to-end live**
 (#282, ADR-019 S4): LSP resolves the compiler via `AFFINESCRIPT_COMPILER`
 → `affinescript` on `PATH` → the `@hyperpolymath/affinescript` shim

--- a/docs/bindings-roadmap.adoc
+++ b/docs/bindings-roadmap.adoc
@@ -84,10 +84,10 @@ no further significant ReScript → AffineScript work is tractable.
 |idaptik `src/app/multiplayer/PhoenixSocket.res` + LobbyManager; needed for any multiplayer / sync-server feature.
 
 |7
-|*DOM* — fill the `for-in` / `while` codegen gap (issue #255) so the existing reconciler runs
-|`●` / `◯` blocked-by-#255
+|*DOM* — re-verify the reconciler runs end-to-end (the `for-in` / `while` codegen gap, issue #255, is fixed)
+|`●` / `◯` #255-fixed; re-verify runtime
 |`affinescript-dom`
-|187-line virtual-DOM + reconciler exists; blocked on a wasm-codegen defect. Unblocking #255 turns this from compile-only to runtime-usable. *Not a binding gap — a codegen bug.*
+|187-line virtual-DOM + reconciler exists and compiles. The wasm loop-codegen defect (#255) that blocked its runtime is *fixed* (PR #257, issue closed 2026-05-19); end-to-end runtime remains to be re-verified. *Was not a binding gap — a codegen bug, now resolved.*
 
 |8
 |*WebGL / Canvas2D context* (HTMLCanvasElement, getContext, drawImage, fillRect, transform stack)


### PR DESCRIPTION
## What

Issue **#255** (`for-in`/`while` loop bodies never execute in compiled wasm) was fixed in **PR #257** (commit `85488d74`, an ~8-line array-offset correction) and **closed 2026-05-19**. Verified on current `main`: freshly compiled loops execute their bodies (`while`→55, `for`→15, the exact #255 combo fixture→34).

But several roadmap docs still advertised #255 as a **live runtime blocker**, falsely gating **INT-08** (DOM reconciler #183), **INT-11** (browser parity), and the DOM bindings row on a resolved bug.

## Fix — 7 references reconciled (docs-only)
- `docs/ECOSYSTEM.adoc` — satellite registry + INT-08/INT-11 rows
- `docs/bindings-roadmap.adoc` — DOM row #7
- `docs/TECH-DEBT.adoc` — INT-08 row

Honest reconciliation: states #255 is fixed (PR #257, closed 2026-05-19) and marks the DOM/INT-08 **end-to-end runtime as "to be re-verified"** rather than asserting it runs (not driven end-to-end in this change).

## Why it matters
A false "blocked" on the roadmap misdirects effort — it implies INT-08/INT-11/DOM need a codegen fix that already shipped. Removing it clarifies that the next step there is *runtime re-verification*, not a bug fix.

## Verification (real toolchain — dune 3.24.0)
```
BUILD_EXIT=0
OK: doc-truthing intact — presence invariants + over-claim ratchet (DOC-04/05/08/09).
OK: soundness ledger — all 5 properties hold.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)