### PR TITLE
fix(ci): repair the two standing red checks (codeql version split + stale hypatia pin)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.28.1
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3.28.1
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -25,5 +25,5 @@ permissions:
   pull-requests: write
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@5fa7a834e015f22c14d2de592ccc369caefa318a
     secrets: inherit


### PR DESCRIPTION
## Problem — every PR carries two red checks

1. **`analyze (actions, none)`** — CodeQL, and per the workflow's own comment a **required** check:
   ```
   ##[error]Loaded a configuration file for version '4.36.2', but running version '4.36.3'
   ```
   Root cause: dependabot #670/#673 bumped `analyze`/`upload-sarif` to v4.36.3 (`54f647b7`) but left **`init`** at v4.36.2 (`8aad20d1`) — a partial bump (dependabot treats init/analyze as separate actions). init writes a config the newer analyze rejects. The stale `# v3.28.1` comments hid the split.

2. **`hypatia / Hypatia Neurosymbolic Analysis`** — `Cache not found for input keys: hypatia-scanner-v2-… → exit 1`.
   Root cause: the wrapper pinned the standards reusable at `d135b05` — the known estate CI-red master-cause pin. Fixed upstream in standards **#428** (GITHUB_TOKEN), **#441** (un-stale scanner cache — our exact symptom), #445, #453.

## Fix (2 files, 3 lines)
- `codeql.yml`: `init` → `54f647b7 # v4.36.3` (same SHA as analyze); comments corrected to the SHAs' real version.
- `hypatia-scan.yml`: reusable pin `d135b05` → `5fa7a834e` (#453, latest commit touching the reusable).

YAML validated. This PR's own check run is the live test — `analyze (actions, none)` and `hypatia` should both go green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)