### PR TITLE
test(faces): prove a Python-face program runs end-to-end (face → wasm → result)

### DIFF
--- a/test/e2e/fixtures/python_face_runnable.pyaff
+++ b/test/e2e/fixtures/python_face_runnable.pyaff
@@ -1,0 +1,30 @@
+# face: python
+# SPDX-License-Identifier: MPL-2.0
+#
+# End-to-end proof (2026-07-07) that a *face-authored* program compiles
+# through the Python face → canonical → typecheck → wasm and RUNS with the
+# right answer. This is the README's headline claim ("faces are the product")
+# exercised for real, not just parsed.
+#
+# Recursion, not a loop: the Python face currently drops the trailing `;` on
+# the last statement of a while/for body (issue #683), so face-authored loops
+# don't yet compile. Recursion's tail line is a value expression, which the
+# face handles correctly — so this proves the face→wasm path without waiting
+# on #683. (Variable names also avoid the `total` soft-keyword collision,
+# issue #682.)
+
+def fac(n: Int) -> Int:
+    if n == 0:
+        1
+    else:
+        n * fac(n - 1)
+
+def sum_to(n: Int) -> Int:
+    if n == 0:
+        0
+    else:
+        n + sum_to(n - 1)
+
+def main() -> Int:
+    # fac(5)=120, sum_to(100)=5050  ->  120 + 5050 = 5170
+    fac(5) + sum_to(100)

--- a/test/e2e/python_face_e2e.sh
+++ b/test/e2e/python_face_e2e.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+#
+# End-to-end proof that a Python-face-authored program runs: compile
+# fixtures/python_face_runnable.pyaff *through the Python face* to core-WASM
+# and assert main() === 5170 (fac(5)=120 + sum_to(100)=5050). Exercises the
+# README's "faces are the product" claim as running code, not just a parse.
+#
+# Requires the compiler built (dune build → _build/default/bin/main.exe;
+# override with AFFINESCRIPT_BIN) and node on PATH. Skips loudly (exit 0)
+# if either is absent.
+set -uo pipefail
+cd "$(dirname "$0")"
+REPO="$(cd ../.. && pwd)"
+BIN="${AFFINESCRIPT_BIN:-$REPO/_build/default/bin/main.exe}"
+SRC="fixtures/python_face_runnable.pyaff"
+EXPECT=5170
+
+[ -x "$BIN" ] || { echo "SKIP: compiler not built ($BIN) — run dune build"; exit 0; }
+command -v node >/dev/null 2>&1 || { echo "SKIP: node not on PATH"; exit 0; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+WASM="$TMP/pf.wasm"
+
+# The `# face: python` pragma on line 1 selects the face; no --face needed.
+"$BIN" compile "$SRC" -o "$WASM" || { echo "FAIL: compile through Python face"; exit 1; }
+
+node - "$WASM" "$EXPECT" <<'JS'
+import { readFile } from "node:fs/promises";
+const [wasm, expect] = [process.argv[2], Number(process.argv[3])];
+const { instance } = await WebAssembly.instantiate(
+  await readFile(wasm), { wasi_snapshot_preview1: { fd_write: () => 0 } });
+const got = instance.exports.main();
+console.log(`main() = ${got} (expected ${expect})`);
+if (got !== expect) { console.error("FAIL: wrong result"); process.exit(1); }
+console.log("PASS: Python-face program ran end-to-end (face → wasm → correct result)");
+JS


### PR DESCRIPTION
## What

The README's headline is *"faces are the product"* — write a familiar surface, get the affine core underneath, compiled to wasm. That path had **never been exercised as running code**, only parsed (the scan flagged "faces exist but no face-authored program is proven end-to-end to wasm"). This closes that.

- `test/e2e/fixtures/python_face_runnable.pyaff` — Python-shaped source (`def`, `if/else`, recursion) with a `# face: python` pragma.
- `test/e2e/python_face_e2e.sh` — compiles it **through the Python face** to core-WASM and asserts `main() === 5170` (`fac(5)=120 + sum_to(100)=5050`). Skips loudly without the compiler/node; `AFFINESCRIPT_BIN` overrides the path.

```
Compiled fixtures/python_face_runnable.pyaff -> pf.wasm (WASM)
main() = 5170 (expected 5170)
PASS: Python-face program ran end-to-end (face → wasm → correct result)
```

## Two real bugs the faces path surfaced (filed)

Recursion is used deliberately, because proving this found:
- **#683** — the Python face drops the trailing `;` on the last statement of a `while`/`for` body (tail-position detection doesn't distinguish loop bodies from value bodies), so face-authored **loops** don't yet compile. Recursion's tail line is a value expression, which the face handles correctly.
- **#682** — `total` is rejected as a variable name in `let`-binding / assignment position (the `TOTAL` soft-keyword's ident-recovery is incomplete).

An honest end-to-end proof of the face→wasm path *today*, a regression lock, with the loop gap tracked in #683.

## Gates
`dune build` 0 · face e2e PASS · doc-truthing OK · soundness ledger all-5 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)