### PR TITLE
chore(governance): land missing docs/packaging before the standards#505 gates bite

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell
+#
+# Development environment for affinescript.
+#
+# Estate policy is Guix primary / Nix fallback (hyperpolymath/standards).
+# This is the Nix fallback tier. It is a dev shell, not a package build:
+# it declares the toolchain needed to work on this repo, pinned to an
+# exact nixpkgs revision per the estate SHA-pinning rule.
+#
+# Packages mirror the build tooling actually present in this repo
+# (just ocaml) — not a generic estate default.
+#
+#   nix develop      # enter the shell
+#   nix flake check  # verify this file evaluates (run before committing)
+{
+  description = "affinescript development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/b134951a4c9f3c995fd7be05f3243f8ecd65d798";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [ just ocaml dune_3 ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
Remediates this repo against the two governance gates promoted from advisory to blocking in [hyperpolymath/standards#513](https://github.com/hyperpolymath/standards/pull/513) (closing standards#505).

Those gates previously **could not fail**: the docs check only emitted `::warning::`, and the package-policy job ended in an unconditional `✅ Package policy check passed`. They are now real, with a grace window — they begin **blocking on 2026-08-21**. This repo was measured as non-compliant, so this PR lands the missing files ahead of that date.

**Added here:** `packaging`

### `flake.nix`
A **dev shell**, not a package build. Estate policy is Guix primary / Nix fallback; this is the fallback tier, and a `guix.scm` is welcome later to move to the primary.

- Packages mirror the tooling **actually present in this repo** (`just ocaml`), not a generic default.
- `nixpkgs` is pinned to an exact revision per the estate SHA-pinning rule.
- **Verified**: `nix flake check` passes (nix 2.35.1). Every package name was confirmed to exist in the pinned revision before generation — nothing here is guessed.

---
Part of an estate-wide sweep; 63 repos were identified as non-compliant. Third-party/forked repos (`HOL`, `awesome-*`, `lua-filters`) were **excluded** per the licence policy's do-not-touch rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)