### PR TITLE
fix(ci): add missing SPDX headers to workflow files

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 name: GitHub Pages (Ddraig SSG)
 on:
   push:


### PR DESCRIPTION
The `Governance` workflow fails on every push here. Its **Workflow security linter** job requires every `.github/workflows/*.yml` to carry an `SPDX-License-Identifier` comment on **line 1**:

```
ERROR: .github/workflows/<file> missing SPDX header
Add SPDX header + permissions:
```

This is a real gate catching a real gap — the files below never had the header. Each failure is another red workflow feeding the `ci_activity` notification flood.

### Licence identifier

`MPL-2.0` — taken from **this repo's own existing workflow headers**, which agree unanimously. It is *not* assumed or copied from a template. Repos with mixed or absent identifiers were deliberately skipped for a manual decision rather than guessed, because an earlier estate sweep flattened co-developed AGPL repos to MPL-2.0.

### Files

`pages.yml`

Pure one-line prepend — no other content is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)