### PR TITLE
docs: resolve the SystemET/Anytype design-notes TODO (README.adoc)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,7 +112,14 @@ AffineScript is one setting of a more general machine.
   the thing this design is built to avoid.)
 * *Faces to core.* Many surfaces, one core AST, one proof.
 
-// TODO: link the SystemET / Anytype design notes once they have stable locations.
+The design notes now have stable homes:
+link:https://github.com/hyperpolymath/systemet[systemet] (the theory: layer
+meanings, gates, proof obligations) and
+link:https://github.com/hyperpolymath/anytype[anytype] (the kernel: a
+parameterised graded checker). AffineScript's `{0,1,ω}` quantity semiring
+(`lib/quantity.ml`) is one instantiation of anytype's L2 grade-algebra
+interface — the same checking rules under a different algebra give a
+different discipline.
 
 == Where this fits
 


### PR DESCRIPTION
Resolves the long-standing `// TODO: link the SystemET / Anytype design notes once they have stable locations.` at README.adoc:115.

Both locations are now stable — and as of hyperpolymath/anytype#12 the kernel is real code, not prose: AffineScript's `{0,1,ω}` quantity semiring (`lib/quantity.ml`) is one instantiation of anytype's L2 grade-algebra interface (its affine instance mirrors `q_add`/`q_mul`/`q_le` cell-for-cell, verified by anytype's golden matrix).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)