### PR TITLE
fix(ci): group Dependabot updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    # Batch this ecosystem into a single PR. Ungrouped, Dependabot
+    # opens one PR per dependency, and each PR re-fires every
+    # workflow in the repo.
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This repo's `dependabot.yml` has no `groups:` block, so **Dependabot opens one PR per dependency**.

Each of those PRs re-fires *every* workflow in the repo. So one estate-wide bump — say `actions/checkout` 7.0.0 → 7.0.1 — fans out into N PRs × M workflow runs worth of notifications. Combined with workflows that fail, that is a large amplifier of the notification flood.

### Fix

Add `groups:` with `patterns: ["*"]`, so the same bump arrives as a **single** PR:

```yaml
    groups:
      github-actions:
        patterns:
          - "*"
```

This matches the **223 estate repos that already group** (exemplar: `aerie`). 50 did not — this is one of them.

Update frequency and ecosystems are unchanged; only the PR batching changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)