### PR TITLE
fix(ci): close the governance gate — SPDX, permissions, SHA pins, reusable bump

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -25,5 +25,5 @@ permissions:
   pull-requests: write
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@5fa7a834e015f22c14d2de592ccc369caefa318a
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@81dbf2dd854b1444fd6236fa2352474383b2c2b9
     secrets: inherit

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,9 +19,9 @@ jobs:
       image: ghcr.io/stefan-hoeck/idris2-pack@sha256:f0758996a931fb35d9ecb1de273c4d59dabe2a09b433afc7e357f65a08b7e1ff
     steps:
       - name: Checkout Site
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Checkout Ddraig SSG
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: hyperpolymath/ddraig-ssg
           path: .ddraig-ssg
@@ -38,7 +38,7 @@ jobs:
           fi
           ./.ddraig-ssg/build/exec/ddraig build src _site https://hyperpolymath.github.io/${GITHUB_REPOSITORY#*/}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: '_site'
   deploy:
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
The governance gate is all-jobs-must-pass, so these ship as one commit;
individually none of them turns the repo green.

* SPDX line-1 header and a top-level `permissions:` block on every
  workflow file (the two `Workflow security linter` checks).
* Every `uses:` tag reference resolved to a full 40-hex commit SHA. This
  satisfies the linter and also the repository's own
  `sha_pinning_required` Actions policy, which refuses `@v4` at parse
  time — a refusal that produces no check run at all.
* `hypatia-scan.yml` now grants `security-events: write`. This is not
  cosmetic and is not separable from the pin bump below: at HEAD the
  reusable declares `security-events: write` where the old pin declared
  `read`, and a called workflow cannot escalate beyond its caller's
  grant. Bumping the pin without this would fail at parse time.
* The three reusables watched by the staleness gate (governance,
  hypatia-scan, scorecard) advanced to standards HEAD, which is 62
  commits ahead of the false-green cache fix and includes the
  deny-list-negative fix from standards#524.

`mirror-reusable` and `secret-scanner-reusable` are deliberately left on
their current pins: the staleness gate does not watch them, so they are
not holding anything red, and bumping them carries unrelated risk.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

