### PR TITLE
fix(ci): use the canonical Scorecard wrapper instead of a local copy

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,42 +1,20 @@
 # SPDX-License-Identifier: MPL-2.0
-#
-# Standalone OpenSSF Scorecard. Previously a thin caller of
-# `hyperpolymath/standards/.github/workflows/scorecard-reusable.yml`; that
-# cross-repo dependency had a persistent startup_failure history (see the
-# prior note in this file's git history). This self-contained version calls
-# `ossf/scorecard-action` directly — mirroring the already-direct sibling
-# `scorecard-enforcer.yml` — so there is no external-repo workflow dependency.
-# `ossf/scorecard-action` / `github/codeql-action` stay SHA-pinned (third-party
-# actions); they match the pins used in scorecard-enforcer.yml.
 name: Scorecards supply-chain security
+
 on:
   branch_protection_rule:
   schedule:
     - cron: '23 4 * * 1'
   push:
     branches: [main]
-permissions:
-  contents: read
+
+permissions: read-all
+
 jobs:
   analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@81dbf2dd854b1444fd6236fa2352474383b2c2b9
     permissions:
+      contents: read
       security-events: write
       id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-      - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v3
-        with:
-          sarif_file: results.sarif
+    secrets: inherit


### PR DESCRIPTION
The staleness gate rejects ANY workflow containing both
`ossf/scorecard-action@` and `github/codeql-action/upload-sarif@`, whatever
its triggers. 273 of 302 estate repos already call standards'
`scorecard-reusable.yml`, which reports with `results_format: json` +
`publish_results: true` and never uploads SARIF to Code Scanning.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>